### PR TITLE
Fix branch creation error handling and credential prompt

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -179,7 +179,13 @@ export default function Home() {
 
   // Auto-open settings if Anthropic credentials not configured
   useEffect(() => {
-    if (loaded && credentials && !credentials.hasAnthropicApiKey && !credentials.hasAnthropicAuthToken) {
+    if (
+      loaded &&
+      (
+        !credentials ||
+        (!credentials.hasAnthropicApiKey && !credentials.hasAnthropicAuthToken)
+      )
+    ) {
       setSettingsOpen(true)
     }
   }, [loaded, credentials])

--- a/components/branch-list.tsx
+++ b/components/branch-list.tsx
@@ -307,9 +307,25 @@ export function BranchList({
         }),
       })
 
-      const reader = res.body!.getReader()
+      if (!res.ok) {
+        let message = `Failed to create branch (${res.status})`
+        try {
+          const data = await res.json()
+          message = data.error || data.message || message
+        } catch {
+          // Ignore parse errors and use fallback message
+        }
+        throw new Error(message)
+      }
+
+      if (!res.body) {
+        throw new Error("Failed to create branch: empty server response")
+      }
+
+      const reader = res.body.getReader()
       const decoder = new TextDecoder()
       let buffer = ""
+      let hasTerminalEvent = false
 
       while (true) {
         const { done, value } = await reader.read()
@@ -325,6 +341,7 @@ export function BranchList({
             try {
               const data = JSON.parse(line.slice(6))
               if (data.type === "done") {
+                hasTerminalEvent = true
                 // Use server-side branchId to replace the temporary client-side ID
                 onUpdateBranch(branchId, {
                   id: data.branchId, // Replace client ID with server ID
@@ -334,6 +351,7 @@ export function BranchList({
                   previewUrlPattern: data.previewUrlPattern,
                 })
               } else if (data.type === "error") {
+                hasTerminalEvent = true
                 onUpdateBranch(branchId, {
                   status: "error",
                 })
@@ -342,6 +360,10 @@ export function BranchList({
             } catch {}
           }
         }
+      }
+
+      if (!hasTerminalEvent) {
+        throw new Error("Branch creation did not complete. Please try again.")
       }
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : "Failed to create branch"


### PR DESCRIPTION
## Summary
Fixes a branch-creation UX issue where users without Claude credentials could get stuck in a perpetual loading state, and ensures first-time users are prompted to configure credentials immediately after login by opening the settings page immediately after the user logs in.

## Problem
When creating a branch from the UI:
- `/api/sandbox/create` can return a non-SSE error response (e.g., missing Anthropic credentials).
- The frontend assumed a streaming body and didn’t fail fast on non-OK responses.
- Result: branch stayed in `creating` with no clear frontend failure state.

Also, users with no `UserCredentials` row were not auto-prompted to set credentials.

## Changes
- `components/branch-list.tsx`
  - Added early handling for `!res.ok` responses from `/api/sandbox/create`.
  - Normalizes error message from `error || message || status`.
  - Guards missing response body.
  - Tracks whether stream reaches a terminal event (`done`/`error`).
  - Fails safely if stream ends without terminal event, routing to existing error path.
- `app/page.tsx`
  - Updated settings auto-open condition to also trigger when `credentials === null` (new users), not only when credentials exist but are empty.

## Expected Behavior
- Missing credentials during branch create now transitions branch to `error` instead of infinite loading.
- New users are immediately prompted to configure Claude credentials after login.
- Existing successful branch creation flow remains unchanged.

## Validation
- Type-check passes: `npx tsc --noEmit`