### PR TITLE
Feat/Mobile Ui 2

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,7 +11,8 @@ import { ChatPanel, EmptyChatPanel } from "@/components/chat-panel"
 import { GitHistoryPanel } from "@/components/git-history-panel"
 import { SettingsModal } from "@/components/settings-modal"
 import { AddRepoModal } from "@/components/add-repo-modal"
-import { Loader2 } from "lucide-react"
+import { Loader2, ChevronLeft, GitBranch } from "lucide-react"
+import { useIsMobile } from "@/hooks/use-mobile"
 
 // Types for database models
 interface DbSandbox {
@@ -106,6 +107,7 @@ function transformRepo(dbRepo: DbRepo) {
 export default function Home() {
   const { data: session, status } = useSession()
   const router = useRouter()
+  const isMobile = useIsMobile()
 
   const [repos, setRepos] = useState<ReturnType<typeof transformRepo>[]>([])
   const [quota, setQuota] = useState<Quota | null>(null)
@@ -515,6 +517,7 @@ export default function Home() {
   return (
     <>
       <main className="flex h-dvh overflow-hidden">
+        {/* Repo Sidebar - always visible */}
         <RepoSidebar
           repos={repos}
           activeRepoId={activeRepoId}
@@ -537,6 +540,7 @@ export default function Home() {
           quota={quota}
         />
 
+        {/* Desktop: Branch List (always visible) */}
         <div className="hidden sm:flex">
           {activeRepo ? (
             <BranchList
@@ -563,7 +567,93 @@ export default function Home() {
           )}
         </div>
 
-        <div className="flex min-w-0 flex-1">
+        {/* Mobile: Branch List (fullscreen, shown when mobileView === "branches") */}
+        {isMobile && mobileView === "branches" && (
+          <div className="flex flex-1 flex-col sm:hidden">
+            {activeRepo ? (
+              <BranchList
+                repo={activeRepo}
+                activeBranchId={activeBranchId}
+                onSelectBranch={handleSelectBranch}
+                onAddBranch={handleAddBranch}
+                onRemoveBranch={handleRemoveBranch}
+                onUpdateBranch={handleUpdateBranch}
+                onQuotaRefresh={handleQuotaRefresh}
+                width="100%"
+                onWidthChange={() => {}}
+                pendingStartCommit={pendingStartCommit}
+                onClearPendingCommit={() => setPendingStartCommit(null)}
+                quota={quota}
+                isMobile={true}
+              />
+            ) : (
+              <div className="flex h-full flex-col items-center justify-center bg-card text-muted-foreground px-4">
+                <GitBranch className="h-8 w-8 mb-3 text-muted-foreground/50" />
+                <p className="text-sm text-center">Add a repository to get started</p>
+                <p className="text-xs text-muted-foreground/60 mt-1 text-center">
+                  Tap the + button in the sidebar
+                </p>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Mobile: Chat Panel (fullscreen, shown when mobileView === "chat") */}
+        {isMobile && mobileView === "chat" && (
+          <div className="flex min-w-0 flex-1 flex-col sm:hidden">
+            {/* Mobile header with back button */}
+            <div className="flex items-center gap-2 border-b border-border bg-card px-3 py-2">
+              <button
+                onClick={() => setMobileView("branches")}
+                className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+              >
+                <ChevronLeft className="h-5 w-5" />
+              </button>
+              {activeRepo && (
+                <div className="flex items-center gap-2 min-w-0">
+                  <span className="text-xs text-muted-foreground truncate">
+                    {activeRepo.owner}/{activeRepo.name}
+                  </span>
+                  {activeBranch && (
+                    <>
+                      <span className="text-muted-foreground/30">/</span>
+                      <span className="text-xs font-medium text-foreground truncate">
+                        {activeBranch.name}
+                      </span>
+                    </>
+                  )}
+                </div>
+              )}
+            </div>
+            {activeBranch && activeRepo ? (
+              <ChatPanel
+                branch={activeBranch}
+                repoFullName={`${activeRepo.owner}/${activeRepo.name}`}
+                repoName={activeRepo.name}
+                repoOwner={activeRepo.owner}
+                gitHistoryOpen={gitHistoryOpen}
+                onToggleGitHistory={() => setGitHistoryOpen((v) => !v)}
+                onAddMessage={(msg) => handleAddMessage(activeBranch.id, msg)}
+                onUpdateMessage={(messageId, updates) =>
+                  handleUpdateMessage(activeBranch.id, messageId, updates)
+                }
+                onUpdateBranch={(updates) =>
+                  handleUpdateBranch(activeBranch.id, updates)
+                }
+                onSaveDraftForBranch={handleSaveDraftForBranch}
+                onForceSave={() => {}}
+                onCommitsDetected={() => setGitHistoryRefreshTrigger((n) => n + 1)}
+                onBranchFromCommit={(hash) => setPendingStartCommit(hash)}
+                isMobile={true}
+              />
+            ) : (
+              <EmptyChatPanel hasRepos={repos.length > 0} />
+            )}
+          </div>
+        )}
+
+        {/* Desktop: Main content area */}
+        <div className="hidden sm:flex min-w-0 flex-1">
           {activeBranch && activeRepo ? (
             <ChatPanel
               branch={activeBranch}

--- a/components/add-repo-modal.tsx
+++ b/components/add-repo-modal.tsx
@@ -206,9 +206,9 @@ export function AddRepoModal({ open, onClose, githubUser, existingRepos, onAddRe
   // Fork confirmation view
   if (forkPrompt) {
     return (
-      <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
         <div className="absolute inset-0 bg-background/80 backdrop-blur-sm" onClick={onClose} />
-        <div className="relative z-10 flex w-full max-w-md flex-col rounded-xl border border-border bg-card shadow-2xl overflow-hidden">
+        <div className="relative z-10 flex w-full max-w-md flex-col rounded-xl border border-border bg-card shadow-2xl overflow-hidden max-h-[90vh]">
           <div className="flex items-center justify-between border-b border-border px-5 py-4">
             <div className="flex items-center gap-2">
               <GitFork className="h-4 w-4 text-muted-foreground" />
@@ -247,10 +247,10 @@ export function AddRepoModal({ open, onClose, githubUser, existingRepos, onAddRe
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
       <div className="absolute inset-0 bg-background/80 backdrop-blur-sm" onClick={onClose} />
-      <div className="relative z-10 flex w-full max-w-md flex-col rounded-xl border border-border bg-card shadow-2xl overflow-hidden">
-        <div className="flex items-center justify-between border-b border-border px-5 py-4">
+      <div className="relative z-10 flex w-full max-w-md flex-col rounded-xl border border-border bg-card shadow-2xl overflow-hidden max-h-[90vh]">
+        <div className="flex items-center justify-between border-b border-border px-4 sm:px-5 py-4">
           <div className="flex items-center gap-2">
             <Github className="h-4 w-4 text-muted-foreground" />
             <h2 className="text-sm font-semibold text-foreground">Add Repository</h2>

--- a/components/branch-list.tsx
+++ b/components/branch-list.tsx
@@ -35,10 +35,11 @@ interface BranchListProps {
   onUpdateBranch: (branchId: string, updates: Partial<Branch>) => void
   onQuotaRefresh?: () => void
   quota?: { current: number; max: number; remaining: number } | null
-  width: number
+  width: number | string
   onWidthChange: (w: number) => void
   pendingStartCommit?: string | null
   onClearPendingCommit?: () => void
+  isMobile?: boolean
 }
 
 function StatusDot({ branch, isActive }: { branch: Branch; isActive: boolean }) {
@@ -90,6 +91,7 @@ export function BranchList({
   onWidthChange,
   pendingStartCommit,
   onClearPendingCommit,
+  isMobile = false,
 }: BranchListProps) {
   const [search, setSearch] = useState("")
   const [branchFromOpen, setBranchFromOpen] = useState(false)
@@ -356,8 +358,14 @@ export function BranchList({
     }
   }, [newBranchName, newBranchBase, creating, repo, onAddBranch, onUpdateBranch, onQuotaRefresh, branchPlaceholder, startCommit, githubBranches])
 
+  // Compute width style for desktop vs mobile
+  const widthStyle = isMobile ? { width: "100%" } : { width: typeof width === "number" ? width : width }
+
   return (
-    <div className="relative flex h-full shrink-0 flex-col border-r border-border bg-card" style={{ width }}>
+    <div className={cn(
+      "relative flex h-full flex-col bg-card",
+      isMobile ? "flex-1" : "shrink-0 border-r border-border"
+    )} style={widthStyle}>
       <a
         href={`https://github.com/${repo.owner}/${repo.name}`}
         target="_blank"
@@ -400,7 +408,9 @@ export function BranchList({
                   <button
                     onClick={() => onSelectBranch(branch.id)}
                     className={cn(
-                      "flex w-full cursor-pointer items-center gap-2.5 rounded-md px-3 py-2.5 text-left transition-colors",
+                      "flex w-full cursor-pointer items-center gap-2.5 rounded-md px-3 text-left transition-colors",
+                      // Larger touch targets on mobile
+                      isMobile ? "py-3.5 min-h-[56px]" : "py-2.5",
                       isActive
                         ? "bg-accent text-foreground"
                         : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
@@ -620,11 +630,13 @@ export function BranchList({
         </DialogContent>
       </Dialog>
 
-      {/* Resize handle */}
-      <div
-        onMouseDown={startResize}
-        className="absolute right-0 top-0 h-full w-1 cursor-col-resize hover:bg-primary/30 transition-colors z-10"
-      />
+      {/* Resize handle (desktop only) */}
+      {!isMobile && (
+        <div
+          onMouseDown={startResize}
+          className="absolute right-0 top-0 h-full w-1 cursor-col-resize hover:bg-primary/30 transition-colors z-10"
+        />
+      )}
     </div>
   )
 }

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -252,6 +252,7 @@ interface ChatPanelProps {
   onForceSave: () => void
   onCommitsDetected?: () => void
   onBranchFromCommit?: (commitHash: string) => void
+  isMobile?: boolean
 }
 
 export function ChatPanel({
@@ -268,6 +269,7 @@ export function ChatPanel({
   onForceSave,
   onCommitsDetected,
   onBranchFromCommit,
+  isMobile = false,
 }: ChatPanelProps) {
   const [input, setInput] = useState(branch.draftPrompt ?? "")
   const [renaming, setRenaming] = useState(false)
@@ -973,44 +975,55 @@ export function ChatPanel({
     <TooltipProvider delayDuration={0}>
       <div className="flex min-w-0 flex-1 flex-col bg-background">
         {/* Header */}
-        <header className="flex items-center gap-2 border-b border-border px-3 py-2.5 sm:px-4">
-          {renaming ? (
-            <div className="flex items-center gap-1.5 min-w-0 ml-2.5">
-              <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor" className="shrink-0 text-muted-foreground">
-                <path fillRule="evenodd" d="M11.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5zm-2.25.75a2.25 2.25 0 1 1 3 2.122V6A2.5 2.5 0 0 1 10 8.5H6a1 1 0 0 0-1 1v1.128a2.251 2.251 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.5 0v1.836A2.493 2.493 0 0 1 6 7h4a1 1 0 0 0 1-1v-.628A2.25 2.25 0 0 1 9.5 3.25zM4.25 12a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5zM3.5 3.25a.75.75 0 1 1 1.5 0 .75.75 0 0 1-1.5 0z" />
-              </svg>
-              <div className="inline-grid min-w-0 [&>*]:[grid-area:1/1]">
-                <span className="invisible whitespace-pre px-1.5 text-xs font-mono">{renameValue || " "}</span>
-                <input
-                  ref={renameInputRef}
-                  value={renameValue}
-                  onChange={(e) => setRenameValue(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") handleRename()
-                    if (e.key === "Escape") setRenaming(false)
-                  }}
-                  onBlur={() => { if (!renameLoading) setRenaming(false) }}
-                  disabled={renameLoading}
-                  className="h-6 bg-transparent border border-border/30 rounded px-1.5 text-xs font-mono text-foreground focus:outline-none focus:border-border/60 min-w-[3ch]"
-                  autoFocus
-                />
-              </div>
-              {renameLoading && <Loader2 className="h-3 w-3 animate-spin text-muted-foreground shrink-0" />}
-            </div>
-          ) : (
-            <button
-              onClick={() => { setRenaming(true); setRenameValue(branch.name) }}
-              className="flex items-center gap-1.5 min-w-0 ml-2.5 py-1 cursor-pointer group/branch"
-            >
-              <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor" className="shrink-0 text-muted-foreground">
-                <path fillRule="evenodd" d="M11.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5zm-2.25.75a2.25 2.25 0 1 1 3 2.122V6A2.5 2.5 0 0 1 10 8.5H6a1 1 0 0 0-1 1v1.128a2.251 2.251 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.5 0v1.836A2.493 2.493 0 0 1 6 7h4a1 1 0 0 0 1-1v-.628A2.25 2.25 0 0 1 9.5 3.25zM4.25 12a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5zM3.5 3.25a.75.75 0 1 1 1.5 0 .75.75 0 0 1-1.5 0z" />
-              </svg>
-              <span className="truncate text-xs font-mono text-muted-foreground">{branch.name}</span>
-              <Pencil className="h-2.5 w-2.5 shrink-0 text-muted-foreground/0 group-hover/branch:text-muted-foreground transition-colors" />
-            </button>
+        <header className={cn(
+          "flex items-center gap-2 border-b border-border",
+          isMobile ? "px-2 py-2" : "px-3 py-2.5 sm:px-4"
+        )}>
+          {/* Branch name section - hidden on mobile since it's in the parent header */}
+          {!isMobile && (
+            <>
+              {renaming ? (
+                <div className="flex items-center gap-1.5 min-w-0 ml-2.5">
+                  <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor" className="shrink-0 text-muted-foreground">
+                    <path fillRule="evenodd" d="M11.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5zm-2.25.75a2.25 2.25 0 1 1 3 2.122V6A2.5 2.5 0 0 1 10 8.5H6a1 1 0 0 0-1 1v1.128a2.251 2.251 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.5 0v1.836A2.493 2.493 0 0 1 6 7h4a1 1 0 0 0 1-1v-.628A2.25 2.25 0 0 1 9.5 3.25zM4.25 12a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5zM3.5 3.25a.75.75 0 1 1 1.5 0 .75.75 0 0 1-1.5 0z" />
+                  </svg>
+                  <div className="inline-grid min-w-0 [&>*]:[grid-area:1/1]">
+                    <span className="invisible whitespace-pre px-1.5 text-xs font-mono">{renameValue || " "}</span>
+                    <input
+                      ref={renameInputRef}
+                      value={renameValue}
+                      onChange={(e) => setRenameValue(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") handleRename()
+                        if (e.key === "Escape") setRenaming(false)
+                      }}
+                      onBlur={() => { if (!renameLoading) setRenaming(false) }}
+                      disabled={renameLoading}
+                      className="h-6 bg-transparent border border-border/30 rounded px-1.5 text-xs font-mono text-foreground focus:outline-none focus:border-border/60 min-w-[3ch]"
+                      autoFocus
+                    />
+                  </div>
+                  {renameLoading && <Loader2 className="h-3 w-3 animate-spin text-muted-foreground shrink-0" />}
+                </div>
+              ) : (
+                <button
+                  onClick={() => { setRenaming(true); setRenameValue(branch.name) }}
+                  className="flex items-center gap-1.5 min-w-0 ml-2.5 py-1 cursor-pointer group/branch"
+                >
+                  <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor" className="shrink-0 text-muted-foreground">
+                    <path fillRule="evenodd" d="M11.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5zm-2.25.75a2.25 2.25 0 1 1 3 2.122V6A2.5 2.5 0 0 1 10 8.5H6a1 1 0 0 0-1 1v1.128a2.251 2.251 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.5 0v1.836A2.493 2.493 0 0 1 6 7h4a1 1 0 0 0 1-1v-.628A2.25 2.25 0 0 1 9.5 3.25zM4.25 12a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5zM3.5 3.25a.75.75 0 1 1 1.5 0 .75.75 0 0 1-1.5 0z" />
+                  </svg>
+                  <span className="truncate text-xs font-mono text-muted-foreground">{branch.name}</span>
+                  <Pencil className="h-2.5 w-2.5 shrink-0 text-muted-foreground/0 group-hover/branch:text-muted-foreground transition-colors" />
+                </button>
+              )}
+            </>
           )}
 
-          <div className="ml-auto flex items-center gap-0.5 shrink-0 overflow-x-auto">
+          <div className={cn(
+            "flex items-center gap-0.5 shrink-0 overflow-x-auto",
+            isMobile ? "flex-1 justify-end" : "ml-auto"
+          )}>
             {branch.sandboxId && (<>
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -1158,7 +1171,10 @@ export function ChatPanel({
         </header>
 
         {/* Messages */}
-        <div ref={scrollRef} onScroll={handleScroll} className="flex-1 overflow-y-auto px-3 py-6 sm:px-6">
+        <div ref={scrollRef} onScroll={handleScroll} className={cn(
+          "flex-1 overflow-y-auto py-4",
+          isMobile ? "px-3" : "px-3 py-6 sm:px-6"
+        )}>
           {branch.status === "creating" ? (
             <div className="flex h-full flex-col items-center justify-center gap-3 text-muted-foreground">
               <Loader2 className="h-8 w-8 animate-spin text-primary" />
@@ -1201,7 +1217,10 @@ export function ChatPanel({
         </div>
 
         {/* Input */}
-        <div className="border-t border-border px-3 py-3 sm:px-6">
+        <div className={cn(
+          "border-t border-border py-3",
+          isMobile ? "px-3" : "px-3 sm:px-6"
+        )}>
           <div className="flex items-end gap-2 rounded-lg border border-border bg-card px-3 py-2 focus-within:border-primary/50 focus-within:ring-1 focus-within:ring-primary/20">
             <textarea
               ref={textareaRef}

--- a/components/diff-modal.tsx
+++ b/components/diff-modal.tsx
@@ -210,14 +210,14 @@ export function DiffModal({ open, onClose, repoOwner, repoName, branchName, base
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
-      <DialogContent className="sm:max-w-3xl max-h-[80vh] flex flex-col">
+      <DialogContent className="sm:max-w-3xl max-h-[85vh] flex flex-col overflow-hidden">
         <DialogHeader>
-          <div className="flex items-center gap-3">
+          <div className="flex flex-wrap items-center gap-2 sm:gap-3">
             <DialogTitle className="text-sm">Diff</DialogTitle>
             {isCommitMode ? (
               <>
                 <code className="rounded bg-accent px-1.5 py-0.5 text-xs font-mono text-primary/70">{commitHash}</code>
-                {commitMessage && <span className="text-xs text-muted-foreground truncate max-w-[300px]">{commitMessage}</span>}
+                {commitMessage && <span className="text-xs text-muted-foreground truncate max-w-[200px] sm:max-w-[300px]">{commitMessage}</span>}
               </>
             ) : (
               <>
@@ -225,7 +225,7 @@ export function DiffModal({ open, onClose, repoOwner, repoName, branchName, base
                   <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
                 ) : (
                   <Select value={compareBranch} onValueChange={setCompareBranch}>
-                    <SelectTrigger className="w-48 h-7 text-xs">
+                    <SelectTrigger className="w-36 sm:w-48 h-7 text-xs">
                       <SelectValue placeholder="Compare to..." />
                     </SelectTrigger>
                     <SelectContent>
@@ -235,7 +235,7 @@ export function DiffModal({ open, onClose, repoOwner, repoName, branchName, base
                     </SelectContent>
                   </Select>
                 )}
-                <span className="text-xs text-muted-foreground">...{branchName}</span>
+                <span className="text-xs text-muted-foreground truncate">...{branchName}</span>
               </>
             )}
           </div>

--- a/components/repo-sidebar.tsx
+++ b/components/repo-sidebar.tsx
@@ -66,7 +66,7 @@ export function RepoSidebar({
 
   return (
     <TooltipProvider delayDuration={0}>
-      <aside className="flex h-full w-[60px] shrink-0 flex-col items-center gap-2 border-r border-border bg-sidebar py-3">
+      <aside className="flex h-full w-[60px] sm:w-[60px] shrink-0 flex-col items-center gap-2 border-r border-border bg-sidebar py-3">
         {repos.map((repo, index) => {
           const isActive = repo.id === activeRepoId
           const hasRunning = repo.branches.some((b) => b.status === "running" || b.status === "creating")
@@ -124,7 +124,7 @@ export function RepoSidebar({
                   <button
                     onClick={() => onSelectRepo(repo.id)}
                     className={cn(
-                      "relative flex cursor-pointer h-10 w-10 items-center justify-center rounded-lg font-mono text-xs font-semibold transition-all overflow-hidden",
+                      "relative flex cursor-pointer h-11 w-11 sm:h-10 sm:w-10 items-center justify-center rounded-lg font-mono text-xs font-semibold transition-all overflow-hidden",
                       isActive
                         ? "ring-2 ring-primary"
                         : "hover:bg-accent hover:text-foreground"
@@ -167,9 +167,9 @@ export function RepoSidebar({
           <TooltipTrigger asChild>
             <button
               onClick={onOpenAddRepo}
-              className="flex cursor-pointer h-10 w-10 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              className="flex cursor-pointer h-11 w-11 sm:h-10 sm:w-10 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
             >
-              <Plus className="h-4 w-4" />
+              <Plus className="h-5 w-5 sm:h-4 sm:w-4" />
             </button>
           </TooltipTrigger>
           <TooltipContent side="right">Add repository</TooltipContent>
@@ -179,7 +179,7 @@ export function RepoSidebar({
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <button
-                className="flex cursor-pointer h-10 w-10 items-center justify-center rounded-lg overflow-hidden transition-colors hover:ring-2 hover:ring-primary/50"
+                className="flex cursor-pointer h-11 w-11 sm:h-10 sm:w-10 items-center justify-center rounded-lg overflow-hidden transition-colors hover:ring-2 hover:ring-primary/50"
               >
                 {userAvatar ? (
                   <img src={userAvatar} alt="User menu" className="h-full w-full rounded-lg object-cover" />

--- a/components/settings-modal.tsx
+++ b/components/settings-modal.tsx
@@ -125,9 +125,9 @@ export function SettingsModal({ open, onClose, credentials, onCredentialsUpdate 
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
       <div className="absolute inset-0 bg-background/80 backdrop-blur-sm" onClick={onClose} />
-      <div className="relative z-10 flex w-full max-w-lg flex-col rounded-xl border border-border bg-card shadow-2xl overflow-hidden">
+      <div className="relative z-10 flex w-full max-w-lg flex-col rounded-xl border border-border bg-card shadow-2xl overflow-hidden max-h-[90vh]">
         {/* Header */}
         <div className="flex items-center justify-between border-b border-border px-5 py-4">
           <h2 className="text-sm font-semibold text-foreground">Settings</h2>
@@ -140,7 +140,7 @@ export function SettingsModal({ open, onClose, credentials, onCredentialsUpdate 
         </div>
 
         {/* Anthropic Credentials */}
-        <div className="flex flex-col gap-4 px-5 py-4">
+        <div className="flex flex-col gap-4 px-4 sm:px-5 py-4 overflow-y-auto">
           {/* Anthropic Auth */}
           <div className="flex flex-col gap-1.5">
             <div className="flex items-center gap-2">


### PR DESCRIPTION
- Add mobile-responsive UI support

Implement proper mobile support for the application:

- Add mobile view switching using existing mobileView state in page.tsx
- Show fullscreen branch list on mobile with back navigation to chat
- Add mobile header with back button showing repo/branch context
- Update BranchList to support mobile mode with larger touch targets
- Update ChatPanel to hide duplicate header info on mobile
- Make RepoSidebar buttons larger on mobile (44px touch targets)
- Update modals (Settings, AddRepo, Diff) with proper mobile constraints
- Add max-height and overflow handling for modals on small screens

The mobile UI now properly toggles between branch list and chat views,
with intuitive navigation and properly sized touch targets throughout.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>