### PR TITLE
Feat/Sync Windows

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,19 @@ import { useSession, signOut } from "next-auth/react"
 import { useRouter } from "next/navigation"
 import { generateId } from "@/lib/store"
 import type { Branch, Message } from "@/lib/types"
+import {
+  useBroadcastSync,
+  type BranchAddedPayload,
+  type BranchRemovedPayload,
+  type BranchUpdatedPayload,
+  type MessageAddedPayload,
+  type MessageUpdatedPayload,
+  type RepoAddedPayload,
+  type RepoRemovedPayload,
+  type ExecutionStartedPayload,
+  type ExecutionCompletedPayload,
+  type QuotaUpdatedPayload,
+} from "@/lib/use-broadcast-sync"
 import { RepoSidebar } from "@/components/repo-sidebar"
 import { BranchList } from "@/components/branch-list"
 import { ChatPanel, EmptyChatPanel } from "@/components/chat-panel"
@@ -125,6 +138,187 @@ export default function Home() {
   const [gitHistoryRefreshTrigger, setGitHistoryRefreshTrigger] = useState(0)
   const [pendingStartCommit, setPendingStartCommit] = useState<string | null>(null)
 
+  // Keep refs for repos state to use in sync handlers (avoid stale closures)
+  const reposRef = useRef(repos)
+  reposRef.current = repos
+
+  // Cross-window sync handlers
+  const handleSyncBranchAdded = useCallback((payload: BranchAddedPayload) => {
+    setRepos((prev) => {
+      const repo = prev.find((r) => r.id === payload.repoId)
+      if (!repo) return prev
+      // Check if branch already exists
+      if (repo.branches.some((b) => b.id === payload.branch.id)) return prev
+      return prev.map((r) => {
+        if (r.id !== payload.repoId) return r
+        return { ...r, branches: [...r.branches, payload.branch] }
+      })
+    })
+  }, [])
+
+  const handleSyncBranchRemoved = useCallback((payload: BranchRemovedPayload) => {
+    setRepos((prev) =>
+      prev.map((r) => {
+        if (r.id !== payload.repoId) return r
+        return {
+          ...r,
+          branches: r.branches.filter((b) => b.id !== payload.branchId),
+        }
+      })
+    )
+    // If the removed branch was active, clear selection
+    if (activeBranchIdRef.current === payload.branchId) {
+      setActiveBranchId(null)
+    }
+  }, [])
+
+  const handleSyncBranchUpdated = useCallback((payload: BranchUpdatedPayload) => {
+    setRepos((prev) =>
+      prev.map((r) => {
+        if (r.id !== payload.repoId) return r
+        return {
+          ...r,
+          branches: r.branches.map((b) => {
+            if (b.id !== payload.branchId) return b
+            const updated = { ...b, ...payload.updates }
+            // Handle ID replacement if provided
+            if (payload.newBranchId) {
+              updated.id = payload.newBranchId
+            }
+            return updated
+          }),
+        }
+      })
+    )
+    // Update active branch ID if it changed
+    if (payload.newBranchId && activeBranchIdRef.current === payload.branchId) {
+      setActiveBranchId(payload.newBranchId)
+    }
+  }, [])
+
+  const handleSyncMessageAdded = useCallback((payload: MessageAddedPayload) => {
+    setRepos((prev) =>
+      prev.map((r) => {
+        if (r.id !== payload.repoId) return r
+        return {
+          ...r,
+          branches: r.branches.map((b) => {
+            if (b.id !== payload.branchId) return b
+            // Check if message already exists
+            if (b.messages.some((m) => m.id === payload.message.id)) return b
+            return {
+              ...b,
+              messages: [...b.messages, payload.message],
+            }
+          }),
+        }
+      })
+    )
+  }, [])
+
+  const handleSyncMessageUpdated = useCallback((payload: MessageUpdatedPayload) => {
+    setRepos((prev) =>
+      prev.map((r) => {
+        if (r.id !== payload.repoId) return r
+        return {
+          ...r,
+          branches: r.branches.map((b) => {
+            if (b.id !== payload.branchId) return b
+            return {
+              ...b,
+              messages: b.messages.map((m) =>
+                m.id === payload.messageId ? { ...m, ...payload.updates } : m
+              ),
+            }
+          }),
+        }
+      })
+    )
+  }, [])
+
+  const handleSyncRepoAdded = useCallback((payload: RepoAddedPayload) => {
+    setRepos((prev) => {
+      // Check if repo already exists
+      if (prev.some((r) => r.id === payload.repo.id)) return prev
+      return [...prev, payload.repo]
+    })
+  }, [])
+
+  const handleSyncRepoRemoved = useCallback((payload: RepoRemovedPayload) => {
+    setRepos((prev) => prev.filter((r) => r.id !== payload.repoId))
+    // If the removed repo was active, clear selection
+    if (activeRepoId === payload.repoId) {
+      setActiveRepoId(null)
+      setActiveBranchId(null)
+    }
+  }, [activeRepoId])
+
+  const handleSyncExecutionStarted = useCallback((payload: ExecutionStartedPayload) => {
+    // Update branch status to running
+    setRepos((prev) =>
+      prev.map((r) => {
+        if (r.id !== payload.repoId) return r
+        return {
+          ...r,
+          branches: r.branches.map((b) => {
+            if (b.id !== payload.branchId) return b
+            return { ...b, status: "running" as const }
+          }),
+        }
+      })
+    )
+  }, [])
+
+  const handleSyncExecutionCompleted = useCallback((payload: ExecutionCompletedPayload) => {
+    // Update branch status based on completion status
+    setRepos((prev) =>
+      prev.map((r) => {
+        if (r.id !== payload.repoId) return r
+        return {
+          ...r,
+          branches: r.branches.map((b) => {
+            if (b.id !== payload.branchId) return b
+            return {
+              ...b,
+              status: payload.status === "error" ? "error" as const : "idle" as const,
+              lastActivity: "now",
+              lastActivityTs: Date.now(),
+            }
+          }),
+        }
+      })
+    )
+  }, [])
+
+  const handleSyncQuotaUpdated = useCallback((payload: QuotaUpdatedPayload) => {
+    setQuota(payload)
+  }, [])
+
+  // Initialize broadcast sync hook with handlers
+  const {
+    broadcastBranchAdded,
+    broadcastBranchRemoved,
+    broadcastBranchUpdated,
+    broadcastMessageAdded,
+    broadcastMessageUpdated,
+    broadcastRepoAdded,
+    broadcastRepoRemoved,
+    broadcastExecutionStarted,
+    broadcastExecutionCompleted,
+    broadcastQuotaUpdated,
+  } = useBroadcastSync({
+    onBranchAdded: handleSyncBranchAdded,
+    onBranchRemoved: handleSyncBranchRemoved,
+    onBranchUpdated: handleSyncBranchUpdated,
+    onMessageAdded: handleSyncMessageAdded,
+    onMessageUpdated: handleSyncMessageUpdated,
+    onRepoAdded: handleSyncRepoAdded,
+    onRepoRemoved: handleSyncRepoRemoved,
+    onExecutionStarted: handleSyncExecutionStarted,
+    onExecutionCompleted: handleSyncExecutionCompleted,
+    onQuotaUpdated: handleSyncQuotaUpdated,
+  })
+
   // Redirect to login if not authenticated
   useEffect(() => {
     if (status === "unauthenticated") {
@@ -205,6 +399,8 @@ export default function Home() {
     setRepos((prev) => [...prev, repo])
     setActiveRepoId(repo.id)
     setActiveBranchId(null)
+    // Broadcast to other windows
+    broadcastRepoAdded({ repo })
   }
 
   function handleRemoveRepo(repoId: string) {
@@ -231,6 +427,8 @@ export default function Home() {
       setActiveRepoId(remaining[0]?.id ?? null)
       setActiveBranchId(null)
     }
+    // Broadcast to other windows
+    broadcastRepoRemoved({ repoId })
   }
 
   const handleAddBranch = useCallback((branch: Branch) => {
@@ -244,12 +442,18 @@ export default function Home() {
     setActiveBranchId(branch.id)
     setMobileView("chat")
 
+    // Broadcast to other windows
+    broadcastBranchAdded({ repoId: activeRepo.id, branch })
+
     // Refresh quota
     fetch("/api/user/quota")
       .then((r) => r.json())
-      .then((q) => setQuota(q))
+      .then((q) => {
+        setQuota(q)
+        broadcastQuotaUpdated(q)
+      })
       .catch(() => {})
-  }, [activeRepo])
+  }, [activeRepo, broadcastBranchAdded, broadcastQuotaUpdated])
 
   const handleUpdateBranch = useCallback((branchId: string, updates: Partial<Branch>) => {
     if (!activeRepo) return
@@ -284,6 +488,14 @@ export default function Home() {
       setActiveBranchId(updates.id)
     }
 
+    // Broadcast to other windows
+    broadcastBranchUpdated({
+      repoId: activeRepo.id,
+      branchId,
+      updates,
+      newBranchId: updates.id,
+    })
+
     // Only update in database if branch exists there (not during creation)
     // When id is provided, we're transitioning from client-side to server-side ID
     const shouldPersist = !isBeingCreated || updates.id
@@ -294,7 +506,7 @@ export default function Home() {
         body: JSON.stringify({ branchId: dbBranchId, ...updates }),
       }).catch(() => {})
     }
-  }, [activeRepo])
+  }, [activeRepo, broadcastBranchUpdated])
 
   const handleRemoveBranch = useCallback((branchId: string, deleteRemote?: boolean) => {
     if (!activeRepo) return
@@ -341,12 +553,18 @@ export default function Home() {
       setActiveBranchId(remaining[0]?.id ?? null)
     }
 
+    // Broadcast to other windows
+    broadcastBranchRemoved({ repoId: activeRepo.id, branchId })
+
     // Refresh quota
     fetch("/api/user/quota")
       .then((r) => r.json())
-      .then((q) => setQuota(q))
+      .then((q) => {
+        setQuota(q)
+        broadcastQuotaUpdated(q)
+      })
       .catch(() => {})
-  }, [activeRepo, activeBranchId])
+  }, [activeRepo, activeBranchId, broadcastBranchRemoved, broadcastQuotaUpdated])
 
   const handleAddMessage = useCallback(async (branchId: string, message: Message): Promise<string> => {
     if (!activeRepo) return message.id
@@ -367,6 +585,9 @@ export default function Home() {
         }
       })
     )
+
+    // Broadcast to other windows (with temporary ID initially)
+    broadcastMessageAdded({ repoId: activeRepo.id, branchId, message })
 
     // Save message to database and get the real DB ID
     try {
@@ -411,6 +632,13 @@ export default function Home() {
             }
           })
         )
+        // Broadcast the ID update
+        broadcastMessageUpdated({
+          repoId: activeRepo.id,
+          branchId,
+          messageId: message.id,
+          updates: { id: dbId },
+        })
         return dbId
       }
       return message.id
@@ -418,7 +646,7 @@ export default function Home() {
       console.error("Error saving message to database:", error)
       return message.id
     }
-  }, [activeRepo])
+  }, [activeRepo, broadcastMessageAdded, broadcastMessageUpdated])
 
   const handleUpdateMessage = useCallback((branchId: string, messageId: string, updates: Partial<Message>) => {
     if (!activeRepo) return
@@ -441,6 +669,9 @@ export default function Home() {
       })
     )
 
+    // Broadcast to other windows
+    broadcastMessageUpdated({ repoId: activeRepo.id, branchId, messageId, updates })
+
     // Update message in database
     fetch("/api/branches/messages", {
       method: "PATCH",
@@ -453,7 +684,7 @@ export default function Home() {
     }).catch((error) => {
       console.error("Error updating message in database:", error)
     })
-  }, [activeRepo])
+  }, [activeRepo, broadcastMessageUpdated])
 
   const handleCredentialsUpdate = useCallback(() => {
     // Refresh credentials state
@@ -539,6 +770,7 @@ export default function Home() {
           {activeBranch && activeRepo ? (
             <ChatPanel
               branch={activeBranch}
+              repoId={activeRepo.id}
               repoFullName={`${activeRepo.owner}/${activeRepo.name}`}
               repoName={activeRepo.name}
               repoOwner={activeRepo.owner}
@@ -554,6 +786,12 @@ export default function Home() {
               onForceSave={() => {}}
               onCommitsDetected={() => setGitHistoryRefreshTrigger((n) => n + 1)}
               onBranchFromCommit={(hash) => setPendingStartCommit(hash)}
+              onExecutionStarted={(branchId, messageId, executionId) =>
+                broadcastExecutionStarted({ repoId: activeRepo.id, branchId, messageId, executionId })
+              }
+              onExecutionCompleted={(branchId, status) =>
+                broadcastExecutionCompleted({ repoId: activeRepo.id, branchId, status })
+              }
             />
           ) : (
             <EmptyChatPanel hasRepos={repos.length > 0} />

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -240,6 +240,7 @@ const headerActions = [
 
 interface ChatPanelProps {
   branch: Branch
+  repoId: string
   repoFullName: string
   repoName: string
   repoOwner: string
@@ -251,10 +252,13 @@ interface ChatPanelProps {
   onForceSave: () => void
   onCommitsDetected?: () => void
   onBranchFromCommit?: (commitHash: string) => void
+  onExecutionStarted?: (branchId: string, messageId: string, executionId: string) => void
+  onExecutionCompleted?: (branchId: string, status: "completed" | "error") => void
 }
 
 export function ChatPanel({
   branch,
+  repoId,
   repoFullName,
   repoName,
   repoOwner,
@@ -266,6 +270,8 @@ export function ChatPanel({
   onForceSave,
   onCommitsDetected,
   onBranchFromCommit,
+  onExecutionStarted,
+  onExecutionCompleted,
 }: ChatPanelProps) {
   const [input, setInput] = useState(branch.draftPrompt ?? "")
   const [renaming, setRenaming] = useState(false)
@@ -559,6 +565,9 @@ export function ChatPanel({
             } catch {}
           }
 
+          // Notify other windows that execution completed
+          onExecutionCompleted?.(branch.id, data.status as "completed" | "error")
+
           // Play notification sound
           try {
             const ctx = new AudioContext()
@@ -582,7 +591,7 @@ export function ChatPanel({
     // Start polling immediately, then every 500ms
     poll()
     pollingRef.current = setInterval(poll, 500)
-  }, [branch.sandboxId, branch.name, branch.messages, repoName, onUpdateMessage, onUpdateBranch, onAddMessage, onForceSave, onCommitsDetected])
+  }, [branch.sandboxId, branch.id, branch.name, branch.messages, repoName, onUpdateMessage, onUpdateBranch, onAddMessage, onForceSave, onCommitsDetected, onExecutionCompleted])
 
   const handleSend = useCallback(async () => {
     const prompt = input.trim()
@@ -636,6 +645,9 @@ export function ChatPanel({
       const { executionId } = await response.json()
       currentExecutionIdRef.current = executionId
 
+      // Notify other windows that execution started
+      onExecutionStarted?.(branch.id, messageId, executionId)
+
       // Start polling for updates
       startPolling(messageId, executionId)
 
@@ -643,10 +655,11 @@ export function ChatPanel({
       const message = err instanceof Error ? err.message : "Unknown error"
       onUpdateMessage(messageId, { content: `Error: ${message}` })
       onUpdateBranch({ status: "idle" })
+      onExecutionCompleted?.(branch.id, "error")
       currentMessageIdRef.current = null
       currentExecutionIdRef.current = null
     }
-  }, [input, branch, repoName, onAddMessage, onUpdateMessage, onUpdateBranch, startPolling])
+  }, [input, branch, repoName, onAddMessage, onUpdateMessage, onUpdateBranch, startPolling, onExecutionStarted, onExecutionCompleted])
 
   function handleStop() {
     // Stop polling

--- a/lib/use-broadcast-sync.ts
+++ b/lib/use-broadcast-sync.ts
@@ -1,0 +1,258 @@
+"use client"
+
+import { useEffect, useRef, useCallback } from "react"
+import type { Branch, Message, Repo } from "./types"
+
+// Channel name for cross-window communication
+const CHANNEL_NAME = "agenthub:sync"
+
+// Message types for different sync events
+export type SyncMessageType =
+  | "branch-added"
+  | "branch-removed"
+  | "branch-updated"
+  | "message-added"
+  | "message-updated"
+  | "repo-added"
+  | "repo-removed"
+  | "execution-started"
+  | "execution-completed"
+  | "quota-updated"
+
+export interface SyncMessage {
+  type: SyncMessageType
+  timestamp: number
+  senderId: string
+  payload: unknown
+}
+
+// Payload types for each message type
+export interface BranchAddedPayload {
+  repoId: string
+  branch: Branch
+}
+
+export interface BranchRemovedPayload {
+  repoId: string
+  branchId: string
+}
+
+export interface BranchUpdatedPayload {
+  repoId: string
+  branchId: string
+  updates: Partial<Branch>
+  // If the branch ID changed (e.g., from client-side to server-side ID)
+  newBranchId?: string
+}
+
+export interface MessageAddedPayload {
+  repoId: string
+  branchId: string
+  message: Message
+}
+
+export interface MessageUpdatedPayload {
+  repoId: string
+  branchId: string
+  messageId: string
+  updates: Partial<Message>
+}
+
+export interface RepoAddedPayload {
+  repo: Repo
+}
+
+export interface RepoRemovedPayload {
+  repoId: string
+}
+
+export interface ExecutionStartedPayload {
+  repoId: string
+  branchId: string
+  messageId: string
+  executionId: string
+}
+
+export interface ExecutionCompletedPayload {
+  repoId: string
+  branchId: string
+  status: "completed" | "error"
+}
+
+export interface QuotaUpdatedPayload {
+  current: number
+  max: number
+  remaining: number
+}
+
+// Generate a unique sender ID for this window/tab
+function generateSenderId(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 7)}`
+}
+
+interface UseBroadcastSyncOptions {
+  onBranchAdded?: (payload: BranchAddedPayload) => void
+  onBranchRemoved?: (payload: BranchRemovedPayload) => void
+  onBranchUpdated?: (payload: BranchUpdatedPayload) => void
+  onMessageAdded?: (payload: MessageAddedPayload) => void
+  onMessageUpdated?: (payload: MessageUpdatedPayload) => void
+  onRepoAdded?: (payload: RepoAddedPayload) => void
+  onRepoRemoved?: (payload: RepoRemovedPayload) => void
+  onExecutionStarted?: (payload: ExecutionStartedPayload) => void
+  onExecutionCompleted?: (payload: ExecutionCompletedPayload) => void
+  onQuotaUpdated?: (payload: QuotaUpdatedPayload) => void
+}
+
+export function useBroadcastSync(options: UseBroadcastSyncOptions = {}) {
+  const channelRef = useRef<BroadcastChannel | null>(null)
+  const senderIdRef = useRef<string>(generateSenderId())
+
+  // Initialize BroadcastChannel on mount
+  useEffect(() => {
+    // BroadcastChannel is not available in SSR
+    if (typeof window === "undefined" || typeof BroadcastChannel === "undefined") {
+      return
+    }
+
+    const channel = new BroadcastChannel(CHANNEL_NAME)
+    channelRef.current = channel
+
+    // Handle incoming messages
+    channel.onmessage = (event: MessageEvent<SyncMessage>) => {
+      const { type, senderId, payload } = event.data
+
+      // Ignore messages from self
+      if (senderId === senderIdRef.current) {
+        return
+      }
+
+      switch (type) {
+        case "branch-added":
+          options.onBranchAdded?.(payload as BranchAddedPayload)
+          break
+        case "branch-removed":
+          options.onBranchRemoved?.(payload as BranchRemovedPayload)
+          break
+        case "branch-updated":
+          options.onBranchUpdated?.(payload as BranchUpdatedPayload)
+          break
+        case "message-added":
+          options.onMessageAdded?.(payload as MessageAddedPayload)
+          break
+        case "message-updated":
+          options.onMessageUpdated?.(payload as MessageUpdatedPayload)
+          break
+        case "repo-added":
+          options.onRepoAdded?.(payload as RepoAddedPayload)
+          break
+        case "repo-removed":
+          options.onRepoRemoved?.(payload as RepoRemovedPayload)
+          break
+        case "execution-started":
+          options.onExecutionStarted?.(payload as ExecutionStartedPayload)
+          break
+        case "execution-completed":
+          options.onExecutionCompleted?.(payload as ExecutionCompletedPayload)
+          break
+        case "quota-updated":
+          options.onQuotaUpdated?.(payload as QuotaUpdatedPayload)
+          break
+      }
+    }
+
+    // Cleanup on unmount
+    return () => {
+      channel.close()
+      channelRef.current = null
+    }
+  }, [
+    options.onBranchAdded,
+    options.onBranchRemoved,
+    options.onBranchUpdated,
+    options.onMessageAdded,
+    options.onMessageUpdated,
+    options.onRepoAdded,
+    options.onRepoRemoved,
+    options.onExecutionStarted,
+    options.onExecutionCompleted,
+    options.onQuotaUpdated,
+  ])
+
+  // Generic broadcast function
+  const broadcast = useCallback((type: SyncMessageType, payload: unknown) => {
+    if (!channelRef.current) return
+
+    const message: SyncMessage = {
+      type,
+      timestamp: Date.now(),
+      senderId: senderIdRef.current,
+      payload,
+    }
+
+    channelRef.current.postMessage(message)
+  }, [])
+
+  // Typed broadcast functions for each message type
+  const broadcastBranchAdded = useCallback(
+    (payload: BranchAddedPayload) => broadcast("branch-added", payload),
+    [broadcast]
+  )
+
+  const broadcastBranchRemoved = useCallback(
+    (payload: BranchRemovedPayload) => broadcast("branch-removed", payload),
+    [broadcast]
+  )
+
+  const broadcastBranchUpdated = useCallback(
+    (payload: BranchUpdatedPayload) => broadcast("branch-updated", payload),
+    [broadcast]
+  )
+
+  const broadcastMessageAdded = useCallback(
+    (payload: MessageAddedPayload) => broadcast("message-added", payload),
+    [broadcast]
+  )
+
+  const broadcastMessageUpdated = useCallback(
+    (payload: MessageUpdatedPayload) => broadcast("message-updated", payload),
+    [broadcast]
+  )
+
+  const broadcastRepoAdded = useCallback(
+    (payload: RepoAddedPayload) => broadcast("repo-added", payload),
+    [broadcast]
+  )
+
+  const broadcastRepoRemoved = useCallback(
+    (payload: RepoRemovedPayload) => broadcast("repo-removed", payload),
+    [broadcast]
+  )
+
+  const broadcastExecutionStarted = useCallback(
+    (payload: ExecutionStartedPayload) => broadcast("execution-started", payload),
+    [broadcast]
+  )
+
+  const broadcastExecutionCompleted = useCallback(
+    (payload: ExecutionCompletedPayload) => broadcast("execution-completed", payload),
+    [broadcast]
+  )
+
+  const broadcastQuotaUpdated = useCallback(
+    (payload: QuotaUpdatedPayload) => broadcast("quota-updated", payload),
+    [broadcast]
+  )
+
+  return {
+    broadcastBranchAdded,
+    broadcastBranchRemoved,
+    broadcastBranchUpdated,
+    broadcastMessageAdded,
+    broadcastMessageUpdated,
+    broadcastRepoAdded,
+    broadcastRepoRemoved,
+    broadcastExecutionStarted,
+    broadcastExecutionCompleted,
+    broadcastQuotaUpdated,
+  }
+}


### PR DESCRIPTION
- Add BroadcastChannel-based cross-window synchronization

Implements real-time synchronization between browser windows using the
BroadcastChannel API. This eliminates the need for polling to keep
multiple windows in sync and provides immediate updates.

Changes:
- Add use-broadcast-sync hook with typed messages for all sync events
- Integrate sync handlers in main page for branch/message/repo updates
- Broadcast state changes from all CRUD operations
- Add execution start/complete notifications for status sync
- Include quota updates in broadcasts

Sync events supported:
- branch-added, branch-removed, branch-updated
- message-added, message-updated
- repo-added, repo-removed
- execution-started, execution-completed
- quota-updated

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>