### PR TITLE
Fix/Random Commits

### DIFF
--- a/app/api/sandbox/create/route.ts
+++ b/app/api/sandbox/create/route.ts
@@ -150,6 +150,7 @@ export async function POST(req: Request) {
           `cd ${repoPath} && git log -1 --format='%h' 2>&1`
         )
         const headCommit = headResult.exitCode ? null : headResult.result.trim()
+        console.log("[sandbox-create] Captured headCommit:", headCommit, "exitCode:", headResult.exitCode)
 
         send({ type: "progress", message: "Installing Claude Agent SDK..." })
 
@@ -245,6 +246,7 @@ export async function POST(req: Request) {
           },
         })
 
+        console.log("[sandbox-create] Sending done event with startCommit:", headCommit)
         send({
           type: "done",
           sandboxId: sandbox.id,

--- a/app/api/sandbox/create/route.ts
+++ b/app/api/sandbox/create/route.ts
@@ -252,6 +252,7 @@ export async function POST(req: Request) {
           previewUrlPattern,
           branchId: branchRecord.id,
           repoId: dbRepo.id,
+          startCommit: headCommit,
         })
       } catch (error: unknown) {
         const message = error instanceof Error ? error.message : "Unknown error"

--- a/components/branch-list.tsx
+++ b/components/branch-list.tsx
@@ -325,6 +325,7 @@ export function BranchList({
             try {
               const data = JSON.parse(line.slice(6))
               if (data.type === "done") {
+                console.log("[branch-list] Received done event, startCommit:", data.startCommit)
                 // Use server-side branchId to replace the temporary client-side ID
                 onUpdateBranch(branchId, {
                   id: data.branchId, // Replace client ID with server ID

--- a/components/branch-list.tsx
+++ b/components/branch-list.tsx
@@ -332,6 +332,7 @@ export function BranchList({
                   sandboxId: data.sandboxId,
                   contextId: data.contextId,
                   previewUrlPattern: data.previewUrlPattern,
+                  startCommit: data.startCommit,
                 })
               } else if (data.type === "error") {
                 onUpdateBranch(branchId, {


### PR DESCRIPTION
- Fix: Pass startCommit from sandbox creation to client

The startCommit was being saved to the database but not sent back
to the client in the SSE response. This meant newly created branches
had startCommit=null in the client state until a page refresh.

Now we include startCommit in the "done" event and update the branch
state with it on the client side.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
- Add debug logging for startCommit flow

Log when:
- headCommit is captured during sandbox creation (server)
- startCommit is sent in done event (server)
- startCommit is received by client (branch-list)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>