### PR TITLE
Fix/Error

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -355,18 +355,25 @@ export function ChatPanel({
         } else if (branch.status === "running" && !pollingRef.current) {
           // Branch shows "running" - check for active execution and resume polling
           // Find the last assistant message that might have a running execution
-          const lastAssistantMsg = [...branch.messages].reverse().find(m => m.role === "assistant" && !m.commitHash)
-          if (lastAssistantMsg) {
-            currentMessageIdRef.current = lastAssistantMsg.id
-            startPolling(lastAssistantMsg.id)
-          } else {
-            // No message to poll for, reset status
+          // Note: branch.messages comes from closure, which should be current since it's in deps
+          if (!branch.messages || branch.messages.length === 0) {
+            // No messages at all - this is likely a stale "running" status, reset it
+            console.log("[chat-panel] Branch shows running but has no messages, resetting to idle")
             onUpdateBranch({ status: "idle" })
+          } else {
+            const lastAssistantMsg = [...branch.messages].reverse().find(m => m.role === "assistant" && !m.commitHash)
+            if (lastAssistantMsg) {
+              currentMessageIdRef.current = lastAssistantMsg.id
+              startPolling(lastAssistantMsg.id)
+            } else {
+              // No message to poll for, reset status
+              onUpdateBranch({ status: "idle" })
+            }
           }
         }
       })
       .catch(() => {})
-  }, [branch.id, branch.sandboxId, branch.status, onUpdateBranch])
+  }, [branch.id, branch.sandboxId, branch.status, branch.messages, onUpdateBranch, startPolling])
 
   // Update startingCommitRef when branch changes (e.g., switching branches)
   useEffect(() => {

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -450,6 +450,17 @@ export function ChatPanel({
 
         if (!res.ok) {
           console.error("Polling error:", data.error)
+          // Stop polling on "Execution not found" - the execution record doesn't exist
+          if (res.status === 404 && data.error === "Execution not found") {
+            if (pollingRef.current) {
+              clearInterval(pollingRef.current)
+              pollingRef.current = null
+            }
+            currentExecutionIdRef.current = null
+            currentMessageIdRef.current = null
+            // Reset branch status to idle since there's no valid execution
+            onUpdateBranch({ status: "idle" })
+          }
           return
         }
 

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,11 +1,10 @@
 "use client"
 
-import { useState, useEffect, useCallback, useRef } from "react"
-import type { Repo, Settings } from "./types"
+import { useState, useCallback } from "react"
+import type { Settings } from "./types"
 import { defaultSettings } from "./types"
 
 const SETTINGS_KEY = "agenthub:settings"
-const REPOS_KEY = "agenthub:repos"
 
 function loadFromLocalStorage<T>(key: string, fallback: T): T {
   if (typeof window === "undefined") return fallback
@@ -18,47 +17,17 @@ function loadFromLocalStorage<T>(key: string, fallback: T): T {
   }
 }
 
-export function useStore() {
-  const [repos, setReposRaw] = useState<Repo[]>([])
-  const [settings, setSettingsRaw] = useState<Settings>(defaultSettings)
-  const [loaded, setLoaded] = useState(false)
-  const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+export function useSettings() {
+  const [settings, setSettingsRaw] = useState<Settings>(() => {
+    return { ...defaultSettings, ...loadFromLocalStorage(SETTINGS_KEY, defaultSettings) }
+  })
 
-  // Load from localStorage on mount
-  useEffect(() => {
-    setReposRaw(loadFromLocalStorage(REPOS_KEY, []))
-    setSettingsRaw({ ...defaultSettings, ...loadFromLocalStorage(SETTINGS_KEY, defaultSettings) })
-    setLoaded(true)
-  }, [])
-
-  // Debounced save for repos (supports high-frequency updates during streaming)
-  const setRepos = useCallback((updater: Repo[] | ((prev: Repo[]) => Repo[])) => {
-    setReposRaw(prev => {
-      const next = typeof updater === "function" ? updater(prev) : updater
-      if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current)
-      saveTimeoutRef.current = setTimeout(() => {
-        localStorage.setItem(REPOS_KEY, JSON.stringify(next))
-      }, 200)
-      return next
-    })
-  }, [])
-
-  // Immediate save for settings (infrequent updates)
   const setSettings = useCallback((newSettings: Settings) => {
     setSettingsRaw(newSettings)
     localStorage.setItem(SETTINGS_KEY, JSON.stringify(newSettings))
   }, [])
 
-  // Force immediate save (call when streaming ends or on important state changes)
-  const forceSave = useCallback(() => {
-    if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current)
-    setReposRaw(current => {
-      localStorage.setItem(REPOS_KEY, JSON.stringify(current))
-      return current
-    })
-  }, [])
-
-  return { repos, settings, loaded, setRepos, setSettings, forceSave }
+  return { settings, setSettings }
 }
 
 export function generateId(): string {


### PR DESCRIPTION
- fix: stop polling and reset status when execution not found

When the /api/agent/status endpoint returns 404 with "Execution not found",
the polling would continue indefinitely logging errors. This fix:
- Clears the polling interval when execution is not found
- Resets the branch status to "idle" so the UI is usable
- Cleans up the execution/message refs

This commonly occurs when starting a new chat on a branch that was
previously in "running" status but has no valid execution record.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
- fix: remove localStorage persistence for repos to prevent stale state

The localStorage was persisting repo/branch state including "running" status
that could become stale if an execution ended abnormally. This caused the
polling system to try resuming executions that no longer existed, resulting
in repeated "Execution not found" 404 errors.

Now the app relies solely on the database as the source of truth for repo
and branch state. Settings are still persisted to localStorage.

Also includes the previous fix to stop polling when execution is not found.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>