### PR TITLE
Feat/Background Agents

### DIFF
--- a/app/api/agent/execute/route.ts
+++ b/app/api/agent/execute/route.ts
@@ -1,6 +1,5 @@
 import { prisma } from "@/lib/prisma"
 import { ensureSandboxReady } from "@/lib/sandbox-resume"
-import { getBackgroundAgentScript, getOutputFilePath } from "@/lib/background-agent-script"
 import { randomUUID } from "crypto"
 import {
   requireAuth,
@@ -15,6 +14,9 @@ import {
   updateSandboxAndBranchStatus,
   resetSandboxStatus,
 } from "@/lib/api-helpers"
+import { createAgentSession, getProviderEnv, validateCredentials } from "@/lib/agent-service"
+import { AGENT_PROVIDER, isAgentProvider } from "@/lib/constants"
+import type { ProviderName } from "@/lib/types"
 
 export const maxDuration = 60 // Only needs to start the background process
 
@@ -24,11 +26,14 @@ export async function POST(req: Request) {
   if (isAuthError(auth)) return auth
 
   const body = await req.json()
-  const { sandboxId, prompt, previewUrlPattern, repoName, messageId } = body
+  const { sandboxId, prompt, previewUrlPattern, repoName, messageId, agent, model, sessionId } = body
 
   if (!sandboxId || !prompt || !messageId) {
     return badRequest("Missing required fields")
   }
+
+  // Validate and set provider
+  const provider: ProviderName = isAgentProvider(agent) ? agent : AGENT_PROVIDER.CLAUDE
 
   // 2. Verify sandbox belongs to this user
   const sandboxRecord = await getSandboxWithAuth(sandboxId, auth.userId)
@@ -40,10 +45,14 @@ export async function POST(req: Request) {
   const daytonaApiKey = getDaytonaApiKey()
   if (isDaytonaKeyError(daytonaApiKey)) return daytonaApiKey
 
-  // Decrypt user's Anthropic credentials
-  const { anthropicApiKey, anthropicAuthToken, anthropicAuthType } = decryptUserCredentials(
-    sandboxRecord.user.credentials
-  )
+  // Decrypt user's credentials
+  const credentials = decryptUserCredentials(sandboxRecord.user.credentials)
+
+  // Validate credentials for the selected provider/model
+  const validation = validateCredentials(provider, model, credentials)
+  if (!validation.valid) {
+    return badRequest(`Missing credentials: ${validation.missing.join(", ")}`)
+  }
 
   // Determine repo name from database or request
   const actualRepoName = repoName || sandboxRecord.branch?.repo?.name || "repo"
@@ -51,23 +60,19 @@ export async function POST(req: Request) {
 
   try {
     // 4. Ensure sandbox is ready
-    const { sandbox, wasResumed, resumeSessionId } = await ensureSandboxReady(
+    const { sandbox, resumeSessionId } = await ensureSandboxReady(
       daytonaApiKey,
       sandboxId,
       actualRepoName,
       previewUrlPattern || sandboxRecord.previewUrlPattern || undefined,
-      anthropicApiKey,
-      anthropicAuthType,
-      anthropicAuthToken,
+      credentials.anthropicApiKey,
+      credentials.anthropicAuthType,
+      credentials.anthropicAuthToken,
     )
-
-    // Update context if it was recreated
-    if (wasResumed) {
-      // Context was recreated, but we don't need it for background execution
-    }
 
     // 5. Generate unique execution ID
     const executionId = randomUUID()
+    const outputFile = `/tmp/agent_output_${executionId}.jsonl`
 
     // 6. Verify message exists before creating AgentExecution (prevents FK constraint violation)
     const messageRecord = await prisma.message.findUnique({
@@ -95,35 +100,29 @@ export async function POST(req: Request) {
       { lastActiveAt: new Date() }
     )
 
-    // 9. Upload background agent script
-    const scriptContent = getBackgroundAgentScript(executionId)
-    const scriptB64 = Buffer.from(scriptContent).toString("base64")
-    await sandbox.process.executeCommand(
-      `echo '${scriptB64}' | base64 -d > /tmp/bg_agent_${executionId}.py`
-    )
-
-    // 10. Build environment variables
-    const envVars: string[] = [
-      `REPO_PATH="${repoPath}"`,
-      `MESSAGE_ID="${messageId}"`,
-      `PROMPT="${prompt.replace(/"/g, '\\"').replace(/\n/g, '\\n')}"`,
-    ]
-
+    // 9. Build environment variables for the provider
+    const env = getProviderEnv(provider, credentials, model)
+    env.REPO_PATH = repoPath
     if (previewUrlPattern || sandboxRecord.previewUrlPattern) {
-      envVars.push(`PREVIEW_URL_PATTERN="${previewUrlPattern || sandboxRecord.previewUrlPattern}"`)
-    }
-    if (resumeSessionId) {
-      envVars.push(`RESUME_SESSION_ID="${resumeSessionId}"`)
-    }
-    if (anthropicAuthType !== "claude-max" && anthropicApiKey) {
-      envVars.push(`ANTHROPIC_API_KEY="${anthropicApiKey}"`)
+      env.PREVIEW_URL_PATTERN = previewUrlPattern || sandboxRecord.previewUrlPattern || ""
     }
 
-    // 11. Start background process using nohup
-    const envString = envVars.join(" ")
-    const command = `cd ${repoPath} && ${envString} nohup python3 /tmp/bg_agent_${executionId}.py > /tmp/agent_log_${executionId}.txt 2>&1 &`
+    // Use session ID from request or from previous sandbox session
+    const activeSessionId = sessionId || resumeSessionId || undefined
 
-    await sandbox.process.executeCommand(command)
+    // 10. Create background session using SDK
+    const session = await createAgentSession({
+      provider,
+      sandbox,
+      model,
+      sessionId: activeSessionId,
+      env,
+      outputFile,
+      timeout: 600000, // 10 minutes
+    })
+
+    // 11. Start the agent
+    const startResult = await session.start(prompt)
 
     // 12. Reset auto-stop timer
     try {
@@ -136,7 +135,10 @@ export async function POST(req: Request) {
       success: true,
       executionId,
       messageId,
-      outputFile: getOutputFilePath(executionId),
+      outputFile,
+      cursor: startResult.cursor,
+      provider,
+      pid: startResult.pid,
     })
 
   } catch (error: unknown) {

--- a/app/api/agent/poll/route.ts
+++ b/app/api/agent/poll/route.ts
@@ -1,0 +1,134 @@
+import { prisma } from "@/lib/prisma"
+import { Daytona } from "@daytonaio/sdk"
+import {
+  requireAuth,
+  isAuthError,
+  getDaytonaApiKey,
+  isDaytonaKeyError,
+  badRequest,
+  notFound,
+  unauthorized,
+  internalError,
+} from "@/lib/api-helpers"
+import { createBackgroundSession } from "background-agents"
+import { AGENT_PROVIDER, isAgentProvider, BRANCH_STATUS } from "@/lib/constants"
+import type { ProviderName } from "@/lib/types"
+
+export const maxDuration = 30
+
+export async function POST(req: Request) {
+  const auth = await requireAuth()
+  if (isAuthError(auth)) return auth
+
+  const body = await req.json()
+  const { executionId, cursor, provider: requestProvider } = body
+
+  if (!executionId) {
+    return badRequest("Missing executionId")
+  }
+
+  // Validate provider
+  const provider: ProviderName = isAgentProvider(requestProvider)
+    ? requestProvider
+    : AGENT_PROVIDER.CLAUDE
+
+  // Find execution record
+  const execution = await prisma.agentExecution.findFirst({
+    where: { executionId },
+    include: {
+      message: {
+        include: {
+          branch: {
+            include: {
+              sandbox: true,
+            },
+          },
+        },
+      },
+    },
+  })
+
+  if (!execution) {
+    return notFound("Execution not found")
+  }
+
+  const sandbox = execution.message.branch.sandbox
+  if (!sandbox || sandbox.userId !== auth.userId) {
+    return unauthorized()
+  }
+
+  // Check if already completed
+  if (execution.status === "completed") {
+    return Response.json({
+      status: "completed",
+      events: [],
+      cursor: cursor || "",
+      sessionId: sandbox.sessionId,
+    })
+  }
+
+  if (execution.status === "error") {
+    return Response.json({
+      status: "error",
+      events: [],
+      cursor: cursor || "",
+      error: "Execution failed",
+    })
+  }
+
+  const daytonaApiKey = getDaytonaApiKey()
+  if (isDaytonaKeyError(daytonaApiKey)) return daytonaApiKey
+
+  try {
+    const daytona = new Daytona({ apiKey: daytonaApiKey })
+    const sandboxInstance = await daytona.get(execution.sandboxId)
+
+    // Use SDK to poll (it reads from outputFile)
+    const outputFile = `/tmp/agent_output_${executionId}.jsonl`
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const session = await createBackgroundSession(provider, {
+      sandbox: sandboxInstance as any,
+      outputFile,
+    })
+
+    const result = await session.poll(cursor || undefined)
+
+    // Update database on completion
+    if (result.status === "completed") {
+      await prisma.$transaction([
+        prisma.agentExecution.update({
+          where: { id: execution.id },
+          data: { status: "completed", completedAt: new Date() },
+        }),
+        prisma.sandbox.update({
+          where: { id: sandbox.id },
+          data: {
+            status: BRANCH_STATUS.IDLE,
+            sessionId: result.sessionId || sandbox.sessionId,
+          },
+        }),
+        prisma.branch.update({
+          where: { id: execution.message.branchId },
+          data: { status: BRANCH_STATUS.IDLE },
+        }),
+      ])
+    }
+
+    return Response.json({
+      status: result.status,
+      events: result.events,
+      cursor: result.cursor,
+      sessionId: result.sessionId,
+    })
+
+  } catch (error: unknown) {
+    console.error("Poll error:", error)
+    const message = error instanceof Error ? error.message : "Unknown error"
+    return Response.json({
+      status: "error",
+      error: message,
+      events: [],
+      cursor: cursor || "",
+    })
+  }
+}

--- a/app/api/branches/route.ts
+++ b/app/api/branches/route.ts
@@ -95,7 +95,7 @@ export async function PATCH(req: Request) {
   const { userId } = authResult
 
   const body = await req.json()
-  const { branchId, status, prUrl, name, draftPrompt } = body
+  const { branchId, status, prUrl, name, draftPrompt, agent, model } = body
 
   if (!branchId) {
     return badRequest("Missing branch ID")
@@ -114,6 +114,8 @@ export async function PATCH(req: Request) {
       ...(prUrl !== undefined && { prUrl }),
       ...(name && { name }),
       ...(draftPrompt !== undefined && { draftPrompt }),
+      ...(agent && { agent }),
+      ...(model !== undefined && { model }),
     },
     include: {
       sandbox: true,

--- a/app/api/sync/route.ts
+++ b/app/api/sync/route.ts
@@ -30,6 +30,8 @@ export async function GET() {
             status: true,
             baseBranch: true,
             prUrl: true,
+            agent: true,
+            model: true,
             sandbox: {
               select: {
                 sandboxId: true,
@@ -64,6 +66,8 @@ export async function GET() {
           status: b.status,
           baseBranch: b.baseBranch,
           prUrl: b.prUrl,
+          agent: b.agent,
+          model: b.model,
           sandboxId: b.sandbox?.sandboxId || null,
           sandboxStatus: b.sandbox?.status || null,
           lastMessageId: b.messages[0]?.id || null,

--- a/app/api/user/credentials/route.ts
+++ b/app/api/user/credentials/route.ts
@@ -12,7 +12,7 @@ export async function POST(req: Request) {
   const { userId } = authResult
 
   const body = await req.json()
-  const { anthropicApiKey, anthropicAuthType, anthropicAuthToken, sandboxAutoStopInterval } = body
+  const { anthropicApiKey, anthropicAuthType, anthropicAuthToken, openaiApiKey, sandboxAutoStopInterval } = body
 
   if (!anthropicAuthType || !["api-key", "claude-max"].includes(anthropicAuthType)) {
     return badRequest("Invalid auth type")
@@ -28,6 +28,7 @@ export async function POST(req: Request) {
   // Encrypt credentials before storing
   const encryptedApiKey = anthropicApiKey ? encrypt(anthropicApiKey) : null
   const encryptedAuthToken = anthropicAuthToken ? encrypt(anthropicAuthToken) : null
+  const encryptedOpenaiKey = openaiApiKey ? encrypt(openaiApiKey) : null
 
   await prisma.userCredentials.upsert({
     where: { userId },
@@ -35,6 +36,7 @@ export async function POST(req: Request) {
       anthropicApiKey: encryptedApiKey,
       anthropicAuthType,
       anthropicAuthToken: encryptedAuthToken,
+      openaiApiKey: encryptedOpenaiKey,
       ...(sandboxAutoStopInterval !== undefined && { sandboxAutoStopInterval }),
     },
     create: {
@@ -42,6 +44,7 @@ export async function POST(req: Request) {
       anthropicApiKey: encryptedApiKey,
       anthropicAuthType,
       anthropicAuthToken: encryptedAuthToken,
+      openaiApiKey: encryptedOpenaiKey,
       ...(sandboxAutoStopInterval !== undefined && { sandboxAutoStopInterval }),
     },
   })

--- a/app/api/user/me/route.ts
+++ b/app/api/user/me/route.ts
@@ -22,6 +22,7 @@ export async function GET() {
             // Don't send actual keys to client, just whether they exist
             anthropicApiKey: true,
             anthropicAuthToken: true,
+            openaiApiKey: true,
             sandboxAutoStopInterval: true,
           },
         },
@@ -61,6 +62,7 @@ export async function GET() {
           anthropicAuthType: user.credentials.anthropicAuthType,
           hasAnthropicApiKey: !!user.credentials.anthropicApiKey,
           hasAnthropicAuthToken: !!user.credentials.anthropicAuthToken,
+          hasOpenaiApiKey: !!user.credentials.openaiApiKey,
           sandboxAutoStopInterval: user.credentials.sandboxAutoStopInterval,
         }
       : null

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -291,6 +291,7 @@ export default function Home() {
                   onBranchFromCommit={(hash) => setPendingStartCommit(hash)}
                   messagesLoading={messagesLoading}
                   isMobile={true}
+                  credentials={credentials || undefined}
                 />
               ) : (
                 <EmptyChatPanel hasRepos={repos.length > 0} />
@@ -321,6 +322,7 @@ export default function Home() {
               onCommitsDetected={() => setGitHistoryRefreshTrigger((n) => n + 1)}
               onBranchFromCommit={(hash) => setPendingStartCommit(hash)}
               messagesLoading={messagesLoading}
+              credentials={credentials || undefined}
             />
           ) : (
             <EmptyChatPanel hasRepos={repos.length > 0} />

--- a/components/branch-list.tsx
+++ b/components/branch-list.tsx
@@ -2,7 +2,7 @@
 
 import { cn } from "@/lib/utils"
 import type { Repo, Branch } from "@/lib/types"
-import { agentLabels } from "@/lib/types"
+import { providerLabels } from "@/lib/types"
 import { generateId } from "@/lib/store"
 import { randomBranchName, validateBranchName } from "@/lib/branch-utils"
 import { BRANCH_STATUS } from "@/lib/constants"
@@ -158,7 +158,7 @@ export function BranchList({
     const branch: Branch = {
       id: branchId,
       name: branchName,
-      agent: "claude-code",
+      agent: "claude",
       messages: [],
       status: BRANCH_STATUS.CREATING,
       lastActivity: "now",
@@ -328,7 +328,7 @@ export function BranchList({
                       </div>
                       <div className="flex items-center gap-2">
                         <span className="text-[11px] text-muted-foreground">
-                          {branch.status === BRANCH_STATUS.CREATING ? "Setting up..." : agentLabels[branch.agent || "claude-code"]}
+                          {branch.status === BRANCH_STATUS.CREATING ? "Setting up..." : providerLabels[branch.agent]}
                         </span>
                       </div>
                     </div>

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -1,11 +1,11 @@
 "use client"
 
 import { cn } from "@/lib/utils"
-import type { Branch, Message } from "@/lib/types"
+import type { Branch, Message, ProviderName } from "@/lib/types"
 import { generateId } from "@/lib/store"
 import { BRANCH_STATUS } from "@/lib/constants"
 import { Terminal } from "lucide-react"
-import { useRef, useEffect, useCallback } from "react"
+import { useRef, useEffect, useCallback, useState } from "react"
 import { TooltipProvider } from "@/components/ui/tooltip"
 
 // Import hooks
@@ -21,6 +21,7 @@ import { ChatHeader } from "./chat/chat-header"
 import { MessageList } from "./chat/message-list"
 import { ChatInput } from "./chat/chat-input"
 import { ChatDialogs } from "./chat/chat-dialogs"
+import { AgentSwitchWarning } from "./chat/agent-switch-warning"
 
 // ============================================================================
 // Main ChatPanel Component
@@ -42,6 +43,11 @@ interface ChatPanelProps {
   onBranchFromCommit?: (commitHash: string) => void
   messagesLoading?: boolean
   isMobile?: boolean
+  credentials?: {
+    hasAnthropicApiKey?: boolean
+    hasAnthropicAuthToken?: boolean
+    hasOpenaiApiKey?: boolean
+  }
 }
 
 export function ChatPanel({
@@ -60,11 +66,18 @@ export function ChatPanel({
   onBranchFromCommit,
   messagesLoading = false,
   isMobile = false,
+  credentials = {},
 }: ChatPanelProps) {
   // Refs
   const scrollRef = useRef<HTMLDivElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const abortControllerRef = useRef<AbortController | null>(null)
+
+  // Agent switch warning state
+  const [pendingAgentSwitch, setPendingAgentSwitch] = useState<{
+    currentAgent: ProviderName
+    newAgent: ProviderName
+  } | null>(null)
 
   // Custom hooks
   const { input, setInput, isNearBottomRef } = useDraftSync({
@@ -157,6 +170,9 @@ export function ChatPanel({
           previewUrlPattern: branch.previewUrlPattern,
           repoName,
           messageId,
+          agent: branch.agent,
+          model: branch.model,
+          sessionId: branch.sessionId,
         }),
       })
 
@@ -165,9 +181,9 @@ export function ChatPanel({
         throw new Error(data.error || "Failed to start agent")
       }
 
-      const { executionId } = await response.json()
+      const { executionId, cursor, provider } = await response.json()
       currentExecutionIdRef.current = executionId
-      startPolling(messageId, executionId)
+      startPolling(messageId, executionId, cursor, provider)
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : "Unknown error"
       onUpdateMessage(messageId, { content: `Error: ${message}` })
@@ -188,6 +204,42 @@ export function ChatPanel({
     gitActions.setCommitDiffHash(hash)
     gitActions.setCommitDiffMessage(msg)
   }, [gitActions])
+
+  // Handle agent change - show warning if there are messages
+  const handleAgentChange = useCallback((newAgent: ProviderName) => {
+    if (branch.messages.length > 0 && branch.agent !== newAgent) {
+      // Show warning dialog
+      setPendingAgentSwitch({
+        currentAgent: branch.agent,
+        newAgent,
+      })
+    } else {
+      // No messages or same agent, change directly
+      onUpdateBranch({ agent: newAgent, sessionId: undefined })
+    }
+  }, [branch.messages.length, branch.agent, onUpdateBranch])
+
+  // Confirm agent switch
+  const handleConfirmAgentSwitch = useCallback(() => {
+    if (pendingAgentSwitch) {
+      // Clear session ID when switching agents (new session)
+      onUpdateBranch({
+        agent: pendingAgentSwitch.newAgent,
+        sessionId: undefined,
+      })
+      setPendingAgentSwitch(null)
+    }
+  }, [pendingAgentSwitch, onUpdateBranch])
+
+  // Cancel agent switch
+  const handleCancelAgentSwitch = useCallback(() => {
+    setPendingAgentSwitch(null)
+  }, [])
+
+  // Handle model change - no warning needed
+  const handleModelChange = useCallback((model: string) => {
+    onUpdateBranch({ model })
+  }, [onUpdateBranch])
 
   return (
     <TooltipProvider delayDuration={0}>
@@ -225,6 +277,9 @@ export function ChatPanel({
           onInputChange={setInput}
           onSend={handleSend}
           onStop={handleStop}
+          onAgentChange={handleAgentChange}
+          onModelChange={handleModelChange}
+          credentials={credentials}
           isMobile={isMobile}
         />
       </div>
@@ -236,6 +291,17 @@ export function ChatPanel({
         repoName={repoName}
         gitActions={gitActions}
       />
+
+      {/* Agent Switch Warning */}
+      {pendingAgentSwitch && (
+        <AgentSwitchWarning
+          open={true}
+          currentAgent={pendingAgentSwitch.currentAgent}
+          newAgent={pendingAgentSwitch.newAgent}
+          onConfirm={handleConfirmAgentSwitch}
+          onCancel={handleCancelAgentSwitch}
+        />
+      )}
     </TooltipProvider>
   )
 }

--- a/components/chat/agent-selector.tsx
+++ b/components/chat/agent-selector.tsx
@@ -1,0 +1,209 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+import { ChevronDown, Lock, Terminal, Code, Box, Sparkles } from "lucide-react"
+import { useState, useRef, useEffect } from "react"
+import {
+  type ProviderName,
+  type ModelConfig,
+  AGENT_CONFIGS,
+} from "@/lib/types"
+import { AGENT_PROVIDER, CREDENTIAL_TYPE } from "@/lib/constants"
+
+// Icon mapping for each provider
+const PROVIDER_ICONS: Record<ProviderName, React.ReactNode> = {
+  [AGENT_PROVIDER.CLAUDE]: <Terminal className="h-3 w-3" />,
+  [AGENT_PROVIDER.CODEX]: <Code className="h-3 w-3" />,
+  [AGENT_PROVIDER.OPENCODE]: <Box className="h-3 w-3" />,
+}
+
+interface AgentSelectorProps {
+  selectedAgent: ProviderName
+  selectedModel?: string
+  onAgentChange: (agent: ProviderName) => void
+  onModelChange: (model: string) => void
+  disabled?: boolean
+  credentials: {
+    hasAnthropicApiKey?: boolean
+    hasAnthropicAuthToken?: boolean
+    hasOpenaiApiKey?: boolean
+  }
+}
+
+// Check if a provider is enabled based on credentials
+function isProviderEnabled(
+  provider: ProviderName,
+  credentials: AgentSelectorProps["credentials"]
+): boolean {
+  switch (provider) {
+    case AGENT_PROVIDER.CLAUDE:
+      return !!(credentials.hasAnthropicApiKey || credentials.hasAnthropicAuthToken)
+    case AGENT_PROVIDER.CODEX:
+      return !!credentials.hasOpenaiApiKey
+    case AGENT_PROVIDER.OPENCODE:
+      // OpenCode is always enabled because it has free models
+      return true
+    default:
+      return false
+  }
+}
+
+// Check if a model is available based on credentials
+function isModelAvailable(
+  model: ModelConfig,
+  credentials: AgentSelectorProps["credentials"]
+): boolean {
+  switch (model.requiresKey) {
+    case CREDENTIAL_TYPE.ANTHROPIC:
+      return !!(credentials.hasAnthropicApiKey || credentials.hasAnthropicAuthToken)
+    case CREDENTIAL_TYPE.OPENAI:
+      return !!credentials.hasOpenaiApiKey
+    case CREDENTIAL_TYPE.NONE:
+      return true
+    default:
+      return false
+  }
+}
+
+export function AgentSelector({
+  selectedAgent,
+  selectedModel,
+  onAgentChange,
+  onModelChange,
+  disabled,
+  credentials,
+}: AgentSelectorProps) {
+  const [agentOpen, setAgentOpen] = useState(false)
+  const [modelOpen, setModelOpen] = useState(false)
+  const agentRef = useRef<HTMLDivElement>(null)
+  const modelRef = useRef<HTMLDivElement>(null)
+
+  const config = AGENT_CONFIGS[selectedAgent]
+  const currentModel = config.models.find((m) => m.id === selectedModel) || config.models[0]
+
+  // Close dropdowns when clicking outside
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (agentRef.current && !agentRef.current.contains(event.target as Node)) {
+        setAgentOpen(false)
+      }
+      if (modelRef.current && !modelRef.current.contains(event.target as Node)) {
+        setModelOpen(false)
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside)
+    return () => document.removeEventListener("mousedown", handleClickOutside)
+  }, [])
+
+  return (
+    <div className="flex items-center gap-1">
+      {/* Agent dropdown */}
+      <div className="relative" ref={agentRef}>
+        <button
+          type="button"
+          onClick={() => !disabled && setAgentOpen(!agentOpen)}
+          disabled={disabled}
+          className={cn(
+            "flex items-center gap-1.5 px-2 py-1 text-xs text-muted-foreground rounded-md transition-colors",
+            !disabled && "hover:text-foreground hover:bg-accent cursor-pointer",
+            disabled && "opacity-50 cursor-not-allowed"
+          )}
+        >
+          {PROVIDER_ICONS[selectedAgent]}
+          <span>{config.label}</span>
+          <ChevronDown className={cn("h-3 w-3 transition-transform", agentOpen && "rotate-180")} />
+        </button>
+
+        {agentOpen && (
+          <div className="absolute bottom-full left-0 mb-1 w-48 rounded-md border border-border bg-popover p-1 shadow-md z-50">
+            {(Object.keys(AGENT_CONFIGS) as ProviderName[]).map((agent) => {
+              const agentConfig = AGENT_CONFIGS[agent]
+              const enabled = isProviderEnabled(agent, credentials)
+              return (
+                <button
+                  key={agent}
+                  type="button"
+                  disabled={!enabled}
+                  onClick={() => {
+                    if (enabled) {
+                      onAgentChange(agent)
+                      setAgentOpen(false)
+                    }
+                  }}
+                  className={cn(
+                    "w-full flex items-center justify-between px-2 py-1.5 text-xs rounded transition-colors",
+                    enabled ? "hover:bg-accent cursor-pointer" : "opacity-50 cursor-not-allowed",
+                    agent === selectedAgent && "bg-accent"
+                  )}
+                >
+                  <div className="flex items-center gap-2">
+                    {PROVIDER_ICONS[agent]}
+                    <span>{agentConfig.label}</span>
+                  </div>
+                  {!enabled && <Lock className="h-3 w-3 text-muted-foreground" />}
+                </button>
+              )
+            })}
+          </div>
+        )}
+      </div>
+
+      <span className="text-muted-foreground/30">|</span>
+
+      {/* Model dropdown */}
+      <div className="relative" ref={modelRef}>
+        <button
+          type="button"
+          onClick={() => !disabled && setModelOpen(!modelOpen)}
+          disabled={disabled}
+          className={cn(
+            "flex items-center gap-1.5 px-2 py-1 text-xs text-muted-foreground rounded-md transition-colors",
+            !disabled && "hover:text-foreground hover:bg-accent cursor-pointer",
+            disabled && "opacity-50 cursor-not-allowed"
+          )}
+        >
+          <span>{currentModel?.label || "Select model"}</span>
+          <ChevronDown className={cn("h-3 w-3 transition-transform", modelOpen && "rotate-180")} />
+        </button>
+
+        {modelOpen && (
+          <div className="absolute bottom-full left-0 mb-1 w-56 rounded-md border border-border bg-popover p-1 shadow-md z-50">
+            {config.models.map((model) => {
+              const available = isModelAvailable(model, credentials)
+              return (
+                <button
+                  key={model.id}
+                  type="button"
+                  disabled={!available}
+                  onClick={() => {
+                    if (available) {
+                      onModelChange(model.id)
+                      setModelOpen(false)
+                    }
+                  }}
+                  className={cn(
+                    "w-full flex items-center justify-between px-2 py-1.5 text-xs rounded transition-colors",
+                    available ? "hover:bg-accent cursor-pointer" : "opacity-50 cursor-not-allowed",
+                    model.id === selectedModel && "bg-accent"
+                  )}
+                >
+                  <span>{model.label}</span>
+                  <div className="flex items-center gap-1.5">
+                    {model.requiresKey === CREDENTIAL_TYPE.NONE && (
+                      <span className="flex items-center gap-0.5 text-[10px] text-green-500 bg-green-500/10 px-1.5 py-0.5 rounded">
+                        <Sparkles className="h-2.5 w-2.5" />
+                        Free
+                      </span>
+                    )}
+                    {!available && <Lock className="h-3 w-3 text-muted-foreground" />}
+                  </div>
+                </button>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/chat/agent-switch-warning.tsx
+++ b/components/chat/agent-switch-warning.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { type ProviderName, AGENT_CONFIGS } from "@/lib/types"
+
+interface AgentSwitchWarningProps {
+  open: boolean
+  currentAgent: ProviderName
+  newAgent: ProviderName
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export function AgentSwitchWarning({
+  open,
+  currentAgent,
+  newAgent,
+  onConfirm,
+  onCancel,
+}: AgentSwitchWarningProps) {
+  const currentConfig = AGENT_CONFIGS[currentAgent]
+  const newConfig = AGENT_CONFIGS[newAgent]
+
+  return (
+    <AlertDialog open={open} onOpenChange={(isOpen) => !isOpen && onCancel()}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Switch Agent?</AlertDialogTitle>
+          <AlertDialogDescription>
+            Switching from <strong>{currentConfig.label}</strong> to <strong>{newConfig.label}</strong> will
+            start a new session. The current session history will not be available to the new agent.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={onCancel}>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm}>Switch Agent</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/components/chat/chat-input.tsx
+++ b/components/chat/chat-input.tsx
@@ -1,10 +1,11 @@
 "use client"
 
 import { cn } from "@/lib/utils"
-import type { Branch } from "@/lib/types"
+import type { Branch, ProviderName } from "@/lib/types"
 import { BRANCH_STATUS } from "@/lib/constants"
-import { Send, Terminal } from "lucide-react"
+import { Send } from "lucide-react"
 import { forwardRef, useEffect, useCallback } from "react"
+import { AgentSelector } from "./agent-selector"
 
 // ============================================================================
 // Chat Input Component
@@ -16,12 +17,19 @@ interface ChatInputProps {
   onInputChange: (value: string) => void
   onSend: () => void
   onStop: () => void
+  onAgentChange: (agent: ProviderName) => void
+  onModelChange: (model: string) => void
+  credentials: {
+    hasAnthropicApiKey?: boolean
+    hasAnthropicAuthToken?: boolean
+    hasOpenaiApiKey?: boolean
+  }
   isMobile?: boolean
 }
 
 export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
   function ChatInput(
-    { branch, input, onInputChange, onSend, onStop, isMobile },
+    { branch, input, onInputChange, onSend, onStop, onAgentChange, onModelChange, credentials, isMobile },
     ref
   ) {
     const canSend = input.trim() && branch.status !== BRANCH_STATUS.RUNNING && branch.status !== BRANCH_STATUS.CREATING && branch.sandboxId
@@ -90,10 +98,14 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
           </button>
         </div>
         <div className="mt-1.5 flex items-center">
-          <span className="flex items-center gap-1.5 px-2 py-1 text-xs text-muted-foreground">
-            <Terminal className="h-3 w-3" />
-            Claude Code
-          </span>
+          <AgentSelector
+            selectedAgent={branch.agent}
+            selectedModel={branch.model}
+            onAgentChange={onAgentChange}
+            onModelChange={onModelChange}
+            disabled={branch.status === BRANCH_STATUS.RUNNING || branch.status === BRANCH_STATUS.CREATING}
+            credentials={credentials}
+          />
         </div>
       </div>
     )

--- a/components/chat/hooks/useExecutionPolling.ts
+++ b/components/chat/hooks/useExecutionPolling.ts
@@ -1,7 +1,8 @@
 import { useRef, useCallback, useEffect } from "react"
-import type { Branch, Message } from "@/lib/types"
+import type { Branch, Message, ProviderName, ToolCall, ContentBlock } from "@/lib/types"
 import { generateId } from "@/lib/store"
-import { BRANCH_STATUS, EXECUTION_STATUS } from "@/lib/constants"
+import { BRANCH_STATUS, EXECUTION_STATUS, AGENT_PROVIDER } from "@/lib/constants"
+import type { AgentEvent } from "@/lib/agent-types"
 
 interface UseExecutionPollingOptions {
   branch: Branch
@@ -15,6 +16,7 @@ interface UseExecutionPollingOptions {
 
 /**
  * Handles polling for background agent execution status
+ * Now supports cursor-based polling with the background-agents SDK
  */
 export function useExecutionPolling({
   branch,
@@ -28,8 +30,16 @@ export function useExecutionPolling({
   const pollingRef = useRef<NodeJS.Timeout | null>(null)
   const currentExecutionIdRef = useRef<string | null>(null)
   const currentMessageIdRef = useRef<string | null>(null)
+  const currentCursorRef = useRef<string | null>(null)
+  const currentProviderRef = useRef<ProviderName>(AGENT_PROVIDER.CLAUDE)
   const startingCommitRef = useRef<string | null>(branch.startCommit || null)
-  const startPollingRef = useRef<(messageId: string, executionId?: string) => void>(() => {})
+  const startPollingRef = useRef<(messageId: string, executionId?: string, cursor?: string, provider?: ProviderName) => void>(() => {})
+
+  // Accumulated content for building the message
+  const accumulatedContentRef = useRef<string>("")
+  const accumulatedToolCallsRef = useRef<ToolCall[]>([])
+  const accumulatedContentBlocksRef = useRef<ContentBlock[]>([])
+  const currentToolRef = useRef<{ name: string; output: string } | null>(null)
 
   // Update startingCommitRef when branch changes
   useEffect(() => {
@@ -48,21 +58,134 @@ export function useExecutionPolling({
     }
   }, [])
 
+  // Process SDK events into message updates
+  const processEvents = useCallback((events: AgentEvent[], messageId: string) => {
+    let hasUpdates = false
+
+    for (const event of events) {
+      switch (event.type) {
+        case "session":
+          // Session ID received, update branch
+          onUpdateBranch({ sessionId: event.id })
+          break
+
+        case "token":
+          // Accumulate text content
+          accumulatedContentRef.current += event.text
+          hasUpdates = true
+
+          // If we have text accumulated after tool calls, add a text block
+          if (accumulatedContentBlocksRef.current.length > 0) {
+            const lastBlock = accumulatedContentBlocksRef.current[accumulatedContentBlocksRef.current.length - 1]
+            if (lastBlock.type === "text") {
+              lastBlock.text += event.text
+            } else {
+              accumulatedContentBlocksRef.current.push({
+                type: "text",
+                text: event.text,
+              })
+            }
+          } else if (accumulatedToolCallsRef.current.length > 0) {
+            // Started with tools, now have text - add text block
+            accumulatedContentBlocksRef.current.push({
+              type: "text",
+              text: event.text,
+            })
+          }
+          break
+
+        case "tool_start":
+          // Starting a new tool call
+          currentToolRef.current = { name: event.name, output: "" }
+          hasUpdates = true
+          break
+
+        case "tool_delta":
+          // Tool output streaming
+          if (currentToolRef.current) {
+            currentToolRef.current.output += event.text
+          }
+          break
+
+        case "tool_end":
+          // Tool call completed
+          if (currentToolRef.current) {
+            const toolCall: ToolCall = {
+              id: generateId(),
+              tool: currentToolRef.current.name,
+              summary: event.output || currentToolRef.current.output.slice(0, 100) || currentToolRef.current.name,
+              timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
+            }
+            accumulatedToolCallsRef.current.push(toolCall)
+
+            // Add to content blocks for interleaved display
+            const lastBlock = accumulatedContentBlocksRef.current[accumulatedContentBlocksRef.current.length - 1]
+            if (lastBlock?.type === "tool_calls") {
+              lastBlock.toolCalls.push(toolCall)
+            } else {
+              // If we had text content before, push it as a text block first
+              if (accumulatedContentRef.current && accumulatedContentBlocksRef.current.length === 0) {
+                accumulatedContentBlocksRef.current.push({
+                  type: "text",
+                  text: accumulatedContentRef.current,
+                })
+              }
+              accumulatedContentBlocksRef.current.push({
+                type: "tool_calls",
+                toolCalls: [toolCall],
+              })
+            }
+
+            currentToolRef.current = null
+            hasUpdates = true
+          }
+          break
+
+        case "end":
+          // Execution complete, handled by status
+          break
+      }
+    }
+
+    // Update message with accumulated content
+    if (hasUpdates) {
+      onUpdateMessage(messageId, {
+        content: accumulatedContentRef.current,
+        toolCalls: accumulatedToolCallsRef.current.length > 0 ? accumulatedToolCallsRef.current : undefined,
+        contentBlocks: accumulatedContentBlocksRef.current.length > 0 ? accumulatedContentBlocksRef.current : undefined,
+      })
+    }
+  }, [onUpdateBranch, onUpdateMessage])
+
   // Start polling for execution status
-  const startPolling = useCallback((messageId: string, executionId?: string) => {
+  const startPolling = useCallback((messageId: string, executionId?: string, cursor?: string, provider?: ProviderName) => {
     if (pollingRef.current) {
       clearInterval(pollingRef.current)
     }
+
+    // Reset accumulated state
+    accumulatedContentRef.current = ""
+    accumulatedToolCallsRef.current = []
+    accumulatedContentBlocksRef.current = []
+    currentToolRef.current = null
+
+    currentCursorRef.current = cursor || null
+    currentProviderRef.current = provider || branch.agent || AGENT_PROVIDER.CLAUDE
 
     let notFoundRetries = 0
     const MAX_NOT_FOUND_RETRIES = 10
 
     const poll = async () => {
       try {
-        const res = await fetch("/api/agent/status", {
+        // Use the new poll endpoint for cursor-based polling
+        const res = await fetch("/api/agent/poll", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ messageId, executionId }),
+          body: JSON.stringify({
+            executionId: executionId || currentExecutionIdRef.current,
+            cursor: currentCursorRef.current,
+            provider: currentProviderRef.current,
+          }),
         })
         const data = await res.json()
 
@@ -78,6 +201,7 @@ export function useExecutionPolling({
               }
               currentExecutionIdRef.current = null
               currentMessageIdRef.current = null
+              currentCursorRef.current = null
               onUpdateBranch({ status: BRANCH_STATUS.IDLE })
             }
             return
@@ -88,51 +212,36 @@ export function useExecutionPolling({
 
         notFoundRetries = 0
 
-        // Update message content
-        if (data.content || (data.toolCalls && data.toolCalls.length > 0) || (data.contentBlocks && data.contentBlocks.length > 0)) {
-          const toolCallsWithIds = (data.toolCalls || []).map((tc: { tool: string; summary: string }, idx: number) => ({
-            id: `tc-${idx}`,
-            tool: tc.tool,
-            summary: tc.summary,
-            timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
-          }))
-          const contentBlocksWithIds = (data.contentBlocks || []).map((block: { type: string; text?: string; toolCalls?: Array<{ tool: string; summary: string }> }, blockIdx: number) => {
-            if (block.type === "tool_calls" && block.toolCalls) {
-              return {
-                type: "tool_calls" as const,
-                toolCalls: block.toolCalls.map((tc, tcIdx) => ({
-                  id: `tc-${blockIdx}-${tcIdx}`,
-                  tool: tc.tool,
-                  summary: tc.summary,
-                  timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
-                })),
-              }
-            }
-            return block
-          })
-          onUpdateMessage(messageId, {
-            content: data.content || "",
-            toolCalls: toolCallsWithIds,
-            contentBlocks: contentBlocksWithIds.length > 0 ? contentBlocksWithIds : undefined,
-          })
+        // Update cursor for next poll
+        if (data.cursor) {
+          currentCursorRef.current = data.cursor
         }
 
+        // Process events incrementally
+        if (data.events && data.events.length > 0) {
+          processEvents(data.events, messageId)
+        }
+
+        // Update session ID if provided
         if (data.sessionId) {
           onUpdateBranch({ sessionId: data.sessionId })
         }
 
         // Check if completed or error
-        if (data.status === EXECUTION_STATUS.COMPLETED || data.status === EXECUTION_STATUS.ERROR) {
+        if (data.status === "completed" || data.status === "error") {
           if (pollingRef.current) {
             clearInterval(pollingRef.current)
             pollingRef.current = null
           }
           currentExecutionIdRef.current = null
           currentMessageIdRef.current = null
+          currentCursorRef.current = null
 
-          if (data.status === EXECUTION_STATUS.ERROR && data.error) {
+          if (data.status === "error" && data.error) {
             onUpdateMessage(messageId, {
-              content: data.content ? `${data.content}\n\nError: ${data.error}` : `Error: ${data.error}`,
+              content: accumulatedContentRef.current
+                ? `${accumulatedContentRef.current}\n\nError: ${data.error}`
+                : `Error: ${data.error}`,
             })
           }
 
@@ -212,7 +321,7 @@ export function useExecutionPolling({
       poll()
       pollingRef.current = setInterval(poll, 500)
     }, 150)
-  }, [branch.sandboxId, branch.name, branch.messages, repoName, onUpdateMessage, onUpdateBranch, onAddMessage, onForceSave, onCommitsDetected])
+  }, [branch.sandboxId, branch.name, branch.messages, branch.agent, repoName, onUpdateMessage, onUpdateBranch, onAddMessage, onForceSave, onCommitsDetected, processEvents])
 
   startPollingRef.current = startPolling
 
@@ -225,7 +334,7 @@ export function useExecutionPolling({
 
     if (currentMessageIdRef.current) {
       const lastMsg = branch.messages.find(m => m.id === currentMessageIdRef.current)
-      const currentContent = lastMsg?.content || ""
+      const currentContent = lastMsg?.content || accumulatedContentRef.current || ""
       onUpdateMessage(currentMessageIdRef.current, {
         content: currentContent ? `${currentContent}\n\n[Stopped by user]` : "[Stopped by user]"
       })
@@ -233,6 +342,7 @@ export function useExecutionPolling({
 
     currentExecutionIdRef.current = null
     currentMessageIdRef.current = null
+    currentCursorRef.current = null
     onUpdateBranch({ status: BRANCH_STATUS.IDLE })
   }, [branch.messages, onUpdateMessage, onUpdateBranch])
 
@@ -258,7 +368,7 @@ export function useExecutionPolling({
             const lastAssistantMsg = [...currentMessages].reverse().find(m => m.role === "assistant" && !m.commitHash)
             if (lastAssistantMsg) {
               currentMessageIdRef.current = lastAssistantMsg.id
-              startPollingRef.current(lastAssistantMsg.id)
+              startPollingRef.current(lastAssistantMsg.id, undefined, undefined, branch.agent)
             } else {
               onUpdateBranch({ status: BRANCH_STATUS.IDLE })
             }
@@ -273,7 +383,7 @@ export function useExecutionPolling({
                 if (execData.execution && execData.execution.status === EXECUTION_STATUS.RUNNING) {
                   currentMessageIdRef.current = execData.execution.messageId
                   currentExecutionIdRef.current = execData.execution.executionId
-                  startPollingRef.current(execData.execution.messageId, execData.execution.executionId)
+                  startPollingRef.current(execData.execution.messageId, execData.execution.executionId, undefined, branch.agent)
                 } else {
                   onUpdateBranch({ status: BRANCH_STATUS.IDLE })
                 }
@@ -292,6 +402,7 @@ export function useExecutionPolling({
     pollingRef,
     currentExecutionIdRef,
     currentMessageIdRef,
+    currentCursorRef,
     startPolling,
     stopPolling,
   }

--- a/components/mobile-sidebar-drawer.tsx
+++ b/components/mobile-sidebar-drawer.tsx
@@ -2,7 +2,7 @@
 
 import { cn } from "@/lib/utils"
 import type { Repo, Branch } from "@/lib/types"
-import { agentLabels } from "@/lib/types"
+import { providerLabels } from "@/lib/types"
 import { generateId } from "@/lib/store"
 import { randomBranchName, validateBranchName } from "@/lib/branch-utils"
 import { BRANCH_STATUS } from "@/lib/constants"
@@ -134,7 +134,7 @@ export function MobileSidebarDrawer({
     const branch: Branch = {
       id: branchId,
       name: branchName,
-      agent: "claude-code",
+      agent: "claude",
       messages: [],
       status: BRANCH_STATUS.CREATING,
       lastActivity: "now",
@@ -461,7 +461,7 @@ export function MobileSidebarDrawer({
                             {branch.name}
                           </span>
                           <span className="text-[10px] text-muted-foreground">
-                            {branch.status === BRANCH_STATUS.CREATING ? "Setting up..." : agentLabels[branch.agent || "claude-code"]}
+                            {branch.status === BRANCH_STATUS.CREATING ? "Setting up..." : providerLabels[branch.agent]}
                           </span>
                         </div>
                       </button>

--- a/components/settings-modal.tsx
+++ b/components/settings-modal.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { cn } from "@/lib/utils"
-import { X, Terminal, Copy, Check, Loader2, Clock } from "lucide-react"
+import { X, Terminal, Copy, Check, Loader2, Clock, Code } from "lucide-react"
 import { useState, useEffect } from "react"
 import { Input } from "@/components/ui/input"
 import type { AnthropicAuthType } from "@/lib/types"
@@ -13,6 +13,7 @@ interface SettingsModalProps {
     anthropicAuthType: string
     hasAnthropicApiKey: boolean
     hasAnthropicAuthToken: boolean
+    hasOpenaiApiKey: boolean
     sandboxAutoStopInterval?: number
   } | null
   onCredentialsUpdate: () => void
@@ -22,6 +23,7 @@ export function SettingsModal({ open, onClose, credentials, onCredentialsUpdate 
   const [anthropicApiKey, setAnthropicApiKey] = useState("")
   const [anthropicAuthType, setAnthropicAuthType] = useState<AnthropicAuthType>("api-key")
   const [anthropicAuthToken, setAnthropicAuthToken] = useState("")
+  const [openaiApiKey, setOpenaiApiKey] = useState("")
   const [sandboxAutoStopInterval, setSandboxAutoStopInterval] = useState(5)
   const [initialAutoStopInterval, setInitialAutoStopInterval] = useState(5)
   const [copied, setCopied] = useState(false)
@@ -35,6 +37,7 @@ export function SettingsModal({ open, onClose, credentials, onCredentialsUpdate 
       setAnthropicAuthType((credentials?.anthropicAuthType as AnthropicAuthType) ?? "api-key")
       setAnthropicApiKey("")
       setAnthropicAuthToken("")
+      setOpenaiApiKey("")
       const interval = credentials?.sandboxAutoStopInterval ?? 5
       setSandboxAutoStopInterval(interval)
       setInitialAutoStopInterval(interval)
@@ -47,12 +50,14 @@ export function SettingsModal({ open, onClose, credentials, onCredentialsUpdate 
   async function handleSave() {
     const newApiKey = anthropicApiKey.trim()
     const newAuthToken = anthropicAuthToken.trim()
+    const newOpenaiKey = openaiApiKey.trim()
     const autoStopChanged = sandboxAutoStopInterval !== initialAutoStopInterval
 
     // Check if there's anything to save
     const hasCredentialChanges =
       (anthropicAuthType === "api-key" && newApiKey) ||
-      (anthropicAuthType === "claude-max" && newAuthToken)
+      (anthropicAuthType === "claude-max" && newAuthToken) ||
+      newOpenaiKey
 
     if (!hasCredentialChanges && !autoStopChanged) {
       onClose()
@@ -70,6 +75,7 @@ export function SettingsModal({ open, onClose, credentials, onCredentialsUpdate 
           anthropicAuthType,
           anthropicApiKey: anthropicAuthType === "api-key" ? newApiKey : undefined,
           anthropicAuthToken: anthropicAuthType === "claude-max" ? newAuthToken : undefined,
+          openaiApiKey: newOpenaiKey || undefined,
           sandboxAutoStopInterval,
         }),
       })
@@ -146,6 +152,9 @@ export function SettingsModal({ open, onClose, credentials, onCredentialsUpdate 
             <div className="flex items-center gap-2">
               <Terminal className="h-3.5 w-3.5 text-muted-foreground" />
               <label className="text-xs font-medium text-foreground">Anthropic Authentication</label>
+              {(credentials?.hasAnthropicApiKey || credentials?.hasAnthropicAuthToken) && (
+                <span className="text-[10px] text-green-500 bg-green-500/10 px-1.5 py-0.5 rounded">Configured</span>
+              )}
             </div>
             <div className="flex rounded-md border border-border bg-secondary p-0.5">
               <button
@@ -213,6 +222,27 @@ export function SettingsModal({ open, onClose, credentials, onCredentialsUpdate 
                 </p>
               </>
             )}
+          </div>
+
+          {/* OpenAI API Key */}
+          <div className="flex flex-col gap-1.5 pt-2 border-t border-border">
+            <div className="flex items-center gap-2">
+              <Code className="h-3.5 w-3.5 text-muted-foreground" />
+              <label className="text-xs font-medium text-foreground">OpenAI API Key</label>
+              {credentials?.hasOpenaiApiKey && (
+                <span className="text-[10px] text-green-500 bg-green-500/10 px-1.5 py-0.5 rounded">Configured</span>
+              )}
+            </div>
+            <Input
+              type="password"
+              placeholder="sk-..."
+              value={openaiApiKey}
+              onChange={(e) => setOpenaiApiKey(e.target.value)}
+              className="h-9 bg-secondary border-border text-xs font-mono placeholder:text-muted-foreground/40"
+            />
+            <p className="text-[11px] text-muted-foreground">
+              Required for Codex agent and OpenCode with OpenAI models
+            </p>
           </div>
 
           {/* Sandbox Settings */}

--- a/hooks/use-branch-operations.ts
+++ b/hooks/use-branch-operations.ts
@@ -58,7 +58,7 @@ export function useBranchOperations({
     // Only update in database if branch exists there (not during creation)
     // When id is provided, we're transitioning from client-side to server-side ID
     const shouldPersist = !isBeingCreated || updates.id
-    if (shouldPersist && (updates.status || updates.prUrl || updates.name || updates.draftPrompt !== undefined)) {
+    if (shouldPersist && (updates.status || updates.prUrl || updates.name || updates.draftPrompt !== undefined || updates.agent || updates.model !== undefined)) {
       fetch("/api/branches", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },

--- a/hooks/use-cross-device-sync.ts
+++ b/hooks/use-cross-device-sync.ts
@@ -12,6 +12,8 @@ interface SyncBranch {
   sandboxStatus: string | null
   lastMessageId: string | null
   lastMessageAt: number | null
+  agent: string
+  model: string | null
 }
 
 interface SyncRepo {

--- a/hooks/use-sync-data.ts
+++ b/hooks/use-sync-data.ts
@@ -11,6 +11,8 @@ export interface SyncBranch {
   prUrl: string | null
   sandboxId: string | null
   lastMessageId: string | null
+  agent: string
+  model: string | null
 }
 
 export interface SyncRepo {
@@ -87,12 +89,14 @@ export function useSyncData({ setRepos, activeBranchIdRef }: UseSyncDataOptions)
                 return {
                   id: syncBranch.id,
                   name: syncBranch.name,
+                  agent: syncBranch.agent || "claude",
+                  model: syncBranch.model,
                   status: syncBranch.status as Branch["status"],
                   baseBranch: syncBranch.baseBranch || "main",
                   prUrl: syncBranch.prUrl || undefined,
                   sandboxId: syncBranch.sandboxId || undefined,
                   messages: [],
-                }
+                } as Branch
               }),
             }
           }
@@ -106,12 +110,14 @@ export function useSyncData({ setRepos, activeBranchIdRef }: UseSyncDataOptions)
             branches: syncRepo.branches.map((b) => ({
               id: b.id,
               name: b.name,
+              agent: b.agent || "claude",
+              model: b.model,
               status: b.status as Branch["status"],
               baseBranch: b.baseBranch || "main",
               prUrl: b.prUrl || undefined,
               sandboxId: b.sandboxId || undefined,
               messages: [],
-            })),
+            } as Branch)),
           }
         })
         return newRepos
@@ -150,12 +156,14 @@ export function useSyncData({ setRepos, activeBranchIdRef }: UseSyncDataOptions)
                   return {
                     id: syncBranch.id,
                     name: syncBranch.name,
+                    agent: syncBranch.agent || "claude",
+                    model: syncBranch.model,
                     status: syncBranch.status as Branch["status"],
                     baseBranch: syncBranch.baseBranch || "main",
                     prUrl: syncBranch.prUrl || undefined,
                     sandboxId: syncBranch.sandboxId || undefined,
                     messages: [],
-                  }
+                  } as Branch
                 }),
               }
             })

--- a/lib/agent-service.ts
+++ b/lib/agent-service.ts
@@ -1,0 +1,175 @@
+/**
+ * Agent Service - Unified interface for background agent execution
+ * Wraps the background-agents SDK with application-specific configuration
+ */
+
+import { createBackgroundSession } from "background-agents"
+import type { ProviderName, ModelConfig } from "./types"
+import { AGENT_CONFIGS } from "./types"
+import { AGENT_PROVIDER, CREDENTIAL_TYPE } from "./constants"
+import type {
+  BackgroundSession,
+  AgentServiceOptions,
+  DecryptedCredentials,
+} from "./agent-types"
+
+/**
+ * Creates and configures a background agent session
+ * Wraps the background-agents SDK with our specific configuration
+ */
+export async function createAgentSession(
+  options: AgentServiceOptions
+): Promise<BackgroundSession> {
+  const { provider, sandbox, model, sessionId, env, outputFile, timeout } = options
+
+  // Create the session using the SDK
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const session = await createBackgroundSession(provider, {
+    sandbox: sandbox as any,
+    env,
+    model,
+    sessionId,
+    outputFile,
+    timeout: timeout || 600000, // 10 minutes default
+  })
+
+  return session
+}
+
+/**
+ * Build environment variables required for a specific provider
+ */
+export function getProviderEnv(
+  provider: ProviderName,
+  credentials: DecryptedCredentials,
+  model?: string
+): Record<string, string> {
+  const env: Record<string, string> = {}
+
+  switch (provider) {
+    case AGENT_PROVIDER.CLAUDE:
+      // Claude requires Anthropic API key
+      if (credentials.anthropicApiKey) {
+        env.ANTHROPIC_API_KEY = credentials.anthropicApiKey
+      }
+      // Claude Max auth token is handled differently (via credentials file)
+      break
+
+    case AGENT_PROVIDER.CODEX:
+      // Codex requires OpenAI API key
+      if (credentials.openaiApiKey) {
+        env.OPENAI_API_KEY = credentials.openaiApiKey
+      }
+      break
+
+    case AGENT_PROVIDER.OPENCODE:
+      // OpenCode can use multiple providers depending on the model
+      // Add all available keys, the CLI will use the appropriate one
+      if (credentials.anthropicApiKey) {
+        env.ANTHROPIC_API_KEY = credentials.anthropicApiKey
+      }
+      if (credentials.openaiApiKey) {
+        env.OPENAI_API_KEY = credentials.openaiApiKey
+      }
+      // Free models (Groq, OpenRouter) don't require keys
+      break
+  }
+
+  return env
+}
+
+/**
+ * Validate that required credentials are available for a provider/model combination
+ */
+export function validateCredentials(
+  provider: ProviderName,
+  model: string | undefined,
+  credentials: DecryptedCredentials
+): { valid: boolean; missing: string[] } {
+  const missing: string[] = []
+  const config = AGENT_CONFIGS[provider]
+
+  // Find the model config if specified
+  let modelConfig: ModelConfig | undefined
+  if (model) {
+    modelConfig = config.models.find((m: ModelConfig) => m.id === model)
+  }
+
+  // If model requires a specific key, check for it
+  if (modelConfig) {
+    switch (modelConfig.requiresKey) {
+      case CREDENTIAL_TYPE.ANTHROPIC:
+        if (!credentials.anthropicApiKey && !credentials.anthropicAuthToken) {
+          missing.push("Anthropic API key or Claude Max subscription")
+        }
+        break
+      case CREDENTIAL_TYPE.OPENAI:
+        if (!credentials.openaiApiKey) {
+          missing.push("OpenAI API key")
+        }
+        break
+      case CREDENTIAL_TYPE.NONE:
+        // Free model, no credentials required
+        break
+    }
+  } else {
+    // No model specified, check provider's default requirements
+    for (const req of config.requiredCredentials) {
+      if (req === "anthropicApiKey" && !credentials.anthropicApiKey && !credentials.anthropicAuthToken) {
+        missing.push("Anthropic API key")
+      }
+      if (req === "openaiApiKey" && !credentials.openaiApiKey) {
+        missing.push("OpenAI API key")
+      }
+    }
+  }
+
+  return {
+    valid: missing.length === 0,
+    missing,
+  }
+}
+
+/**
+ * Get the default model for a provider
+ */
+export function getDefaultModelForProvider(provider: ProviderName): string {
+  const config = AGENT_CONFIGS[provider]
+  return config.models[0]?.id || ""
+}
+
+/**
+ * Check if a model is a free model (no API key required)
+ */
+export function isFreeModel(provider: ProviderName, modelId: string): boolean {
+  const config = AGENT_CONFIGS[provider]
+  const model = config.models.find((m: ModelConfig) => m.id === modelId)
+  return model?.requiresKey === CREDENTIAL_TYPE.NONE
+}
+
+/**
+ * Get available models for a provider based on credentials
+ */
+export function getAvailableModels(
+  provider: ProviderName,
+  credentials: {
+    hasAnthropicApiKey?: boolean
+    hasAnthropicAuthToken?: boolean
+    hasOpenaiApiKey?: boolean
+  }
+): ModelConfig[] {
+  const config = AGENT_CONFIGS[provider]
+
+  return config.models.filter((model: ModelConfig) => {
+    switch (model.requiresKey) {
+      case CREDENTIAL_TYPE.ANTHROPIC:
+        return credentials.hasAnthropicApiKey || credentials.hasAnthropicAuthToken
+      case CREDENTIAL_TYPE.OPENAI:
+        return credentials.hasOpenaiApiKey
+      case CREDENTIAL_TYPE.NONE:
+        return true // Free models always available
+      default:
+        return false
+    }
+  })
+}

--- a/lib/agent-types.ts
+++ b/lib/agent-types.ts
@@ -1,0 +1,130 @@
+/**
+ * Types for the background-agents SDK integration
+ * These types mirror the SDK's internal types for type safety
+ */
+
+import type { ProviderName } from "./types"
+
+// =============================================================================
+// Session Options
+// =============================================================================
+
+export interface SessionOptions {
+  sandbox?: unknown // Daytona sandbox instance
+  env?: Record<string, string>
+  model?: string
+  sessionId?: string
+  timeout?: number
+  skipInstall?: boolean
+}
+
+export interface BackgroundSessionOptions extends SessionOptions {
+  /**
+   * Path to the JSONL log file inside the sandbox where the provider CLI
+   * will append its stream-json events.
+   */
+  outputFile: string
+}
+
+// =============================================================================
+// Execution Results
+// =============================================================================
+
+export interface StartResult {
+  executionId: string
+  pid: number
+  outputFile: string
+  cursor: string
+}
+
+export interface PollResult {
+  status: "running" | "completed"
+  sessionId: string | null
+  events: AgentEvent[]
+  cursor: string
+}
+
+// =============================================================================
+// Agent Events (from SDK)
+// =============================================================================
+
+export interface SessionEvent {
+  type: "session"
+  id: string
+}
+
+export interface TokenEvent {
+  type: "token"
+  text: string
+}
+
+export interface ToolStartEvent {
+  type: "tool_start"
+  name: string
+  input?: unknown
+}
+
+export interface ToolDeltaEvent {
+  type: "tool_delta"
+  text: string
+}
+
+export interface ToolEndEvent {
+  type: "tool_end"
+  output?: string
+}
+
+export interface EndEvent {
+  type: "end"
+}
+
+export type AgentEvent =
+  | SessionEvent
+  | TokenEvent
+  | ToolStartEvent
+  | ToolDeltaEvent
+  | ToolEndEvent
+  | EndEvent
+
+// =============================================================================
+// Background Session Interface
+// =============================================================================
+
+export interface BackgroundSession {
+  /**
+   * Start a background run with the given prompt. Returns execution metadata
+   * and the initial cursor for polling.
+   */
+  start(prompt: string, options?: Omit<SessionOptions, "outputFile">): Promise<StartResult>
+
+  /**
+   * Poll for new events since the last cursor. Events have the same shape
+   * as those yielded by session.run().
+   */
+  poll(cursor?: string | null): Promise<PollResult>
+}
+
+// =============================================================================
+// Agent Service Options
+// =============================================================================
+
+export interface AgentServiceOptions {
+  provider: ProviderName
+  sandbox: unknown // Daytona sandbox instance
+  model?: string
+  sessionId?: string
+  env: Record<string, string>
+  outputFile: string
+  timeout?: number
+}
+
+// =============================================================================
+// Decrypted Credentials
+// =============================================================================
+
+export interface DecryptedCredentials {
+  anthropicApiKey?: string
+  anthropicAuthToken?: string
+  anthropicAuthType: string
+  openaiApiKey?: string
+}

--- a/lib/api-helpers.ts
+++ b/lib/api-helpers.ts
@@ -17,6 +17,7 @@ export interface DecryptedCredentials {
   anthropicApiKey?: string
   anthropicAuthToken?: string
   anthropicAuthType: AnthropicAuthType
+  openaiApiKey?: string
 }
 
 export type SandboxStatus = BranchStatus
@@ -36,11 +37,14 @@ export interface SandboxWithCredentials {
       anthropicApiKey: string | null
       anthropicAuthToken: string | null
       anthropicAuthType: string | null
+      openaiApiKey: string | null
     } | null
   }
   branch: {
     id: string
     name: string
+    agent: string
+    model: string | null
     repo: {
       id: string
       name: string
@@ -170,12 +174,14 @@ export function decryptUserCredentials(
     anthropicApiKey: string | null
     anthropicAuthToken: string | null
     anthropicAuthType: string | null
+    openaiApiKey: string | null
   } | null
 ): DecryptedCredentials {
   const anthropicAuthType = (credentials?.anthropicAuthType || "api-key") as AnthropicAuthType
 
   let anthropicApiKey: string | undefined
   let anthropicAuthToken: string | undefined
+  let openaiApiKey: string | undefined
 
   if (credentials?.anthropicApiKey) {
     anthropicApiKey = decrypt(credentials.anthropicApiKey)
@@ -183,11 +189,15 @@ export function decryptUserCredentials(
   if (credentials?.anthropicAuthToken) {
     anthropicAuthToken = decrypt(credentials.anthropicAuthToken)
   }
+  if (credentials?.openaiApiKey) {
+    openaiApiKey = decrypt(credentials.openaiApiKey)
+  }
 
   return {
     anthropicApiKey,
     anthropicAuthToken,
     anthropicAuthType,
+    openaiApiKey,
   }
 }
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -122,3 +122,32 @@ export const ANTHROPIC_AUTH_TYPE = {
 } as const
 
 export type AnthropicAuthType = (typeof ANTHROPIC_AUTH_TYPE)[keyof typeof ANTHROPIC_AUTH_TYPE]
+
+// =============================================================================
+// Agent Providers
+// =============================================================================
+
+export const AGENT_PROVIDER = {
+  CLAUDE: "claude",
+  CODEX: "codex",
+  OPENCODE: "opencode",
+} as const
+
+export type AgentProvider = (typeof AGENT_PROVIDER)[keyof typeof AGENT_PROVIDER]
+
+// Type guard to check if a string is a valid AgentProvider
+export function isAgentProvider(value: string): value is AgentProvider {
+  return Object.values(AGENT_PROVIDER).includes(value as AgentProvider)
+}
+
+// =============================================================================
+// Model Credential Requirements
+// =============================================================================
+
+export const CREDENTIAL_TYPE = {
+  ANTHROPIC: "anthropic",
+  OPENAI: "openai",
+  NONE: "none",
+} as const
+
+export type CredentialType = (typeof CREDENTIAL_TYPE)[keyof typeof CREDENTIAL_TYPE]

--- a/lib/db-types.ts
+++ b/lib/db-types.ts
@@ -3,7 +3,8 @@
  * These are the "raw" shapes before transformation to frontend types
  */
 
-import type { Message, Branch } from "@/lib/types"
+import type { Message, Branch, ProviderName } from "@/lib/types"
+import { AGENT_PROVIDER } from "@/lib/constants"
 
 export interface DbSandbox {
   id: string
@@ -33,6 +34,8 @@ export interface DbBranch {
   status: string
   prUrl: string | null
   draftPrompt: string | null
+  agent: string
+  model: string | null
   sandbox: DbSandbox | null
   messages?: DbMessage[]
 }
@@ -56,6 +59,8 @@ export interface UserCredentials {
   anthropicAuthType: string
   hasAnthropicApiKey: boolean
   hasAnthropicAuthToken: boolean
+  hasOpenaiApiKey: boolean
+  sandboxAutoStopInterval?: number
 }
 
 /**
@@ -86,6 +91,8 @@ export function transformBranch(dbBranch: DbBranch): Branch {
     status: dbBranch.status as Branch["status"],
     prUrl: dbBranch.prUrl || undefined,
     draftPrompt: dbBranch.draftPrompt || undefined,
+    agent: (dbBranch.agent || AGENT_PROVIDER.CLAUDE) as ProviderName,
+    model: dbBranch.model || undefined,
     sandboxId: dbBranch.sandbox?.sandboxId,
     contextId: dbBranch.sandbox?.contextId || undefined,
     sessionId: dbBranch.sandbox?.sessionId || undefined,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,6 +1,67 @@
-import { type BranchStatus, type AnthropicAuthType as ConstantsAnthropicAuthType } from "./constants"
+import {
+  type BranchStatus,
+  type AnthropicAuthType as ConstantsAnthropicAuthType,
+  type AgentProvider,
+  type CredentialType,
+  AGENT_PROVIDER,
+  CREDENTIAL_TYPE,
+} from "./constants"
 
+// Legacy type for backwards compatibility
 export type Agent = "claude-code"
+
+// New multi-agent types
+export type ProviderName = AgentProvider
+
+// Model configuration for each provider
+export interface ModelConfig {
+  id: string
+  label: string
+  provider: ProviderName
+  requiresKey: CredentialType
+}
+
+// Agent configuration with available models
+export interface AgentConfig {
+  label: string
+  description: string
+  models: ModelConfig[]
+  requiredCredentials: ("anthropicApiKey" | "anthropicAuthToken" | "openaiApiKey")[]
+}
+
+// Agent configurations for all supported providers
+export const AGENT_CONFIGS: Record<ProviderName, AgentConfig> = {
+  [AGENT_PROVIDER.CLAUDE]: {
+    label: "Claude",
+    description: "Anthropic's Claude coding agent",
+    models: [
+      { id: "claude-sonnet-4-20250514", label: "Sonnet 4", provider: AGENT_PROVIDER.CLAUDE, requiresKey: CREDENTIAL_TYPE.ANTHROPIC },
+      { id: "claude-opus-4-20250514", label: "Opus 4", provider: AGENT_PROVIDER.CLAUDE, requiresKey: CREDENTIAL_TYPE.ANTHROPIC },
+    ],
+    requiredCredentials: ["anthropicApiKey"],
+  },
+  [AGENT_PROVIDER.CODEX]: {
+    label: "Codex",
+    description: "OpenAI's Codex coding agent",
+    models: [
+      { id: "gpt-4o", label: "GPT-4o", provider: AGENT_PROVIDER.CODEX, requiresKey: CREDENTIAL_TYPE.OPENAI },
+      { id: "o3", label: "o3", provider: AGENT_PROVIDER.CODEX, requiresKey: CREDENTIAL_TYPE.OPENAI },
+      { id: "codex-mini-latest", label: "Codex Mini", provider: AGENT_PROVIDER.CODEX, requiresKey: CREDENTIAL_TYPE.OPENAI },
+    ],
+    requiredCredentials: ["openaiApiKey"],
+  },
+  [AGENT_PROVIDER.OPENCODE]: {
+    label: "OpenCode",
+    description: "Multi-provider coding agent with free model support",
+    models: [
+      { id: "anthropic/claude-sonnet-4-20250514", label: "Claude Sonnet 4", provider: AGENT_PROVIDER.OPENCODE, requiresKey: CREDENTIAL_TYPE.ANTHROPIC },
+      { id: "openai/gpt-4o", label: "GPT-4o", provider: AGENT_PROVIDER.OPENCODE, requiresKey: CREDENTIAL_TYPE.OPENAI },
+      { id: "groq/llama-3.3-70b-versatile", label: "Llama 3.3 70B (Free)", provider: AGENT_PROVIDER.OPENCODE, requiresKey: CREDENTIAL_TYPE.NONE },
+      { id: "openrouter/deepseek/deepseek-r1", label: "DeepSeek R1 (Free)", provider: AGENT_PROVIDER.OPENCODE, requiresKey: CREDENTIAL_TYPE.NONE },
+    ],
+    requiredCredentials: [], // Can work with free models
+  },
+}
 
 export interface ToolCall {
   id: string
@@ -36,7 +97,8 @@ export interface Message {
 export interface Branch {
   id: string
   name: string
-  agent?: Agent
+  agent: ProviderName
+  model?: string
   messages: Message[]
   status: BranchStatus
   lastActivity?: string
@@ -68,11 +130,20 @@ export interface Settings {
   anthropicApiKey: string
   anthropicAuthType: AnthropicAuthType
   anthropicAuthToken: string
+  openaiApiKey: string
   daytonaApiKey: string
 }
 
+// Legacy agent labels (for backwards compatibility)
 export const agentLabels: Record<Agent, string> = {
   "claude-code": "Claude Code",
+}
+
+// New provider labels
+export const providerLabels: Record<ProviderName, string> = {
+  [AGENT_PROVIDER.CLAUDE]: "Claude",
+  [AGENT_PROVIDER.CODEX]: "Codex",
+  [AGENT_PROVIDER.OPENCODE]: "OpenCode",
 }
 
 export const defaultSettings: Settings = {
@@ -80,5 +151,38 @@ export const defaultSettings: Settings = {
   anthropicApiKey: "",
   anthropicAuthType: "api-key",
   anthropicAuthToken: "",
+  openaiApiKey: "",
   daytonaApiKey: "",
+}
+
+// Helper to get default model for a provider
+export function getDefaultModel(provider: ProviderName): string {
+  const config = AGENT_CONFIGS[provider]
+  return config.models[0]?.id || ""
+}
+
+// Helper to check if credentials are available for a provider
+export function hasRequiredCredentials(
+  provider: ProviderName,
+  credentials: {
+    hasAnthropicApiKey?: boolean
+    hasAnthropicAuthToken?: boolean
+    hasOpenaiApiKey?: boolean
+  }
+): boolean {
+  const config = AGENT_CONFIGS[provider]
+
+  // OpenCode can work with free models, so always enabled
+  if (provider === AGENT_PROVIDER.OPENCODE) {
+    return true
+  }
+
+  // Check if any required credential is present
+  for (const req of config.requiredCredentials) {
+    if (req === "anthropicApiKey" && credentials.hasAnthropicApiKey) return true
+    if (req === "anthropicAuthToken" && credentials.hasAnthropicAuthToken) return true
+    if (req === "openaiApiKey" && credentials.hasOpenaiApiKey) return true
+  }
+
+  return config.requiredCredentials.length === 0
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "@radix-ui/react-tooltip": "1.2.8",
         "@vercel/analytics": "1.6.1",
         "autoprefixer": "^10.4.20",
+        "background-agents": "^0.1.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "1.1.1",
@@ -5917,6 +5918,68 @@
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/background-agents": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/background-agents/-/background-agents-0.1.0.tgz",
+      "integrity": "sha512-GbAXwL7J1lMVOHEWbTs404og2LIGgvllBYl/SVN5yKtcA2/4faLYXn7Xk9ddEUJsBzzV8+ni/9cBlU3jLEudUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@daytonaio/sdk": "^0.150.0",
+        "dotenv": "^17.3.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/background-agents/node_modules/@daytonaio/api-client": {
+      "version": "0.150.0",
+      "resolved": "https://registry.npmjs.org/@daytonaio/api-client/-/api-client-0.150.0.tgz",
+      "integrity": "sha512-NXGE1sgd8+VBzu3B7P/pLrlpci9nMoZecvLmK3zFDh8hr5Ra5vuXJN9pEVJmev93zUItQxHbuvaxaWrYzHevVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "axios": "^1.6.1"
+      }
+    },
+    "node_modules/background-agents/node_modules/@daytonaio/sdk": {
+      "version": "0.150.0",
+      "resolved": "https://registry.npmjs.org/@daytonaio/sdk/-/sdk-0.150.0.tgz",
+      "integrity": "sha512-JmNulFaLhmpjVVFtaRDZa84fxPuy0axQYVLrj1lvRgcZzcrwJRdHv9FZPMLbKdrbicMh3D7GYA9XeBMYVZBTIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-s3": "^3.787.0",
+        "@aws-sdk/lib-storage": "^3.798.0",
+        "@daytonaio/api-client": "0.150.0",
+        "@daytonaio/toolbox-api-client": "0.150.0",
+        "@iarna/toml": "^2.2.5",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.207.0",
+        "@opentelemetry/instrumentation-http": "^0.207.0",
+        "@opentelemetry/otlp-exporter-base": "0.207.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/sdk-node": "^0.207.0",
+        "@opentelemetry/sdk-trace-base": "^2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.37.0",
+        "axios": "^1.13.5",
+        "busboy": "^1.0.0",
+        "dotenv": "^17.0.1",
+        "expand-tilde": "^2.0.2",
+        "fast-glob": "^3.3.0",
+        "form-data": "^4.0.4",
+        "isomorphic-ws": "^5.0.0",
+        "pathe": "^2.0.3",
+        "shell-quote": "^1.8.2",
+        "tar": "^7.5.7"
+      }
+    },
+    "node_modules/background-agents/node_modules/@daytonaio/toolbox-api-client": {
+      "version": "0.150.0",
+      "resolved": "https://registry.npmjs.org/@daytonaio/toolbox-api-client/-/toolbox-api-client-0.150.0.tgz",
+      "integrity": "sha512-7MCbD1FrzYjOaOmqpMDQe7cyoQTSImEOjQ+6Js4NlBOwPlz2PMi352XuG9qrBp9ngNpo8fpduYr35iDOjrpIVg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "axios": "^1.6.1"
       }
     },
     "node_modules/bail": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@radix-ui/react-tooltip": "1.2.8",
     "@vercel/analytics": "1.6.1",
     "autoprefixer": "^10.4.20",
+    "background-agents": "^0.1.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "1.1.1",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -72,6 +72,9 @@ model UserCredentials {
   anthropicAuthType  String  @default("api-key") // "api-key" | "claude-max"
   anthropicAuthToken String? @db.Text
 
+  // Encrypted OpenAI credentials (for Codex and OpenCode agents)
+  openaiApiKey String? @db.Text
+
   // Sandbox settings
   sandboxAutoStopInterval Int @default(5) // 5-20 minutes
 
@@ -107,6 +110,10 @@ model Branch {
   status      String  @default("idle") // "idle" | "running" | "creating" | "stopped" | "error"
   prUrl       String?
   draftPrompt String? @db.Text // Persisted draft input for chat continuity
+
+  // Agent configuration
+  agent String @default("claude") // "claude" | "codex" | "opencode"
+  model String? // e.g., "claude-sonnet-4-20250514", "gpt-4o"
 
   sandbox  Sandbox?
   messages Message[]


### PR DESCRIPTION
- feat: integrate background-agents SDK for multi-agent support

This change integrates the background-agents SDK to support multiple AI
coding agents (Claude, Codex, OpenCode) with unified background execution.

Key changes:
- Database: Add openaiApiKey to UserCredentials, agent/model fields to Branch
- Types: Add ProviderName, AGENT_CONFIGS, ModelConfig types
- Settings: Add OpenAI API key input to Settings modal
- UI: Add agent/model selector dropdowns below chat input
- Backend: Refactor execute route to use SDK, create poll endpoint
- Polling: Implement cursor-based polling with SDK event processing
- Warning: Add dialog when switching agents mid-conversation

Supported agents:
- Claude (default): Requires Anthropic API key or Max subscription
- Codex: Requires OpenAI API key
- OpenCode: Multi-provider with free models (Groq, OpenRouter)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>