### PR TITLE
Fix/Branch List Ui

### DIFF
--- a/components/branch-list.tsx
+++ b/components/branch-list.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { cn } from "@/lib/utils"
+import { cn, formatRelativeTime } from "@/lib/utils"
 import type { Repo, Branch } from "@/lib/types"
 import { agentLabels } from "@/lib/types"
 import { generateId } from "@/lib/store"
@@ -330,9 +330,9 @@ export function BranchList({
                         <span className="text-[11px] text-muted-foreground">
                           {branch.status === BRANCH_STATUS.CREATING ? "Setting up..." : agentLabels[branch.agent || "claude-code"]}
                         </span>
-                        {branch.lastActivity && (
+                        {branch.lastActivityTs && (
                           <span className="ml-auto text-[10px] text-muted-foreground/60">
-                            {branch.lastActivity}
+                            {formatRelativeTime(branch.lastActivityTs)}
                           </span>
                         )}
                       </div>

--- a/components/branch-list.tsx
+++ b/components/branch-list.tsx
@@ -330,6 +330,11 @@ export function BranchList({
                         <span className="text-[11px] text-muted-foreground">
                           {branch.status === BRANCH_STATUS.CREATING ? "Setting up..." : agentLabels[branch.agent || "claude-code"]}
                         </span>
+                        {branch.lastActivity && (
+                          <span className="ml-auto text-[10px] text-muted-foreground/60">
+                            {branch.lastActivity}
+                          </span>
+                        )}
                       </div>
                     </div>
                   </button>

--- a/components/mobile-sidebar-drawer.tsx
+++ b/components/mobile-sidebar-drawer.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { cn } from "@/lib/utils"
+import { cn, formatRelativeTime } from "@/lib/utils"
 import type { Repo, Branch } from "@/lib/types"
 import { agentLabels } from "@/lib/types"
 import { generateId } from "@/lib/store"
@@ -464,9 +464,9 @@ export function MobileSidebarDrawer({
                             <span className="text-[10px] text-muted-foreground">
                               {branch.status === BRANCH_STATUS.CREATING ? "Setting up..." : agentLabels[branch.agent || "claude-code"]}
                             </span>
-                            {branch.lastActivity && (
+                            {branch.lastActivityTs && (
                               <span className="ml-auto text-[10px] text-muted-foreground/60">
-                                {branch.lastActivity}
+                                {formatRelativeTime(branch.lastActivityTs)}
                               </span>
                             )}
                           </div>

--- a/components/mobile-sidebar-drawer.tsx
+++ b/components/mobile-sidebar-drawer.tsx
@@ -460,9 +460,16 @@ export function MobileSidebarDrawer({
                           )}>
                             {branch.name}
                           </span>
-                          <span className="text-[10px] text-muted-foreground">
-                            {branch.status === BRANCH_STATUS.CREATING ? "Setting up..." : agentLabels[branch.agent || "claude-code"]}
-                          </span>
+                          <div className="flex items-center gap-2">
+                            <span className="text-[10px] text-muted-foreground">
+                              {branch.status === BRANCH_STATUS.CREATING ? "Setting up..." : agentLabels[branch.agent || "claude-code"]}
+                            </span>
+                            {branch.lastActivity && (
+                              <span className="ml-auto text-[10px] text-muted-foreground/60">
+                                {branch.lastActivity}
+                              </span>
+                            )}
+                          </div>
                         </div>
                       </button>
                     )

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,22 @@ import { twMerge } from 'tailwind-merge'
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function formatRelativeTime(timestamp: number | undefined): string {
+  if (!timestamp) return ""
+
+  const now = Date.now()
+  const diff = now - timestamp
+
+  const seconds = Math.floor(diff / 1000)
+  const minutes = Math.floor(seconds / 60)
+  const hours = Math.floor(minutes / 60)
+  const days = Math.floor(hours / 24)
+
+  if (seconds < 60) return "now"
+  if (minutes < 60) return `${minutes}m ago`
+  if (hours < 24) return `${hours}h ago`
+  if (days < 7) return `${days}d ago`
+
+  return new Date(timestamp).toLocaleDateString()
+}


### PR DESCRIPTION
- feat: restore timestamp to branch list second line

Brings back the last activity timestamp on the right side of the second
line in branch list items. This was previously removed in commit d5c6993.

The branch list now shows:
- Line 1: Branch name
- Line 2: Agent label + timestamp (right-aligned)

Updated both desktop (branch-list.tsx) and mobile (mobile-sidebar-drawer.tsx)
components.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
- fix: compute relative time from lastActivityTs for branch list

The previous implementation used the static `lastActivity` string which
was only set to "now" on branch creation and never updated. Now we use
`lastActivityTs` (the actual timestamp) and compute the relative time
dynamically with a new formatRelativeTime() helper.

Shows: "now", "2m ago", "1h ago", "3d ago", or the date for older items.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>