### PR TITLE
Feat/Db Optimization

### DIFF
--- a/app/api/branches/route.ts
+++ b/app/api/branches/route.ts
@@ -6,6 +6,7 @@ import {
   getBranchWithAuth,
   badRequest,
   notFound,
+  internalError,
   getDaytonaApiKey,
   isDaytonaKeyError,
   decryptUserCredentials,
@@ -17,6 +18,7 @@ import {
 } from "@/lib/prisma-includes"
 import { Daytona } from "@daytonaio/sdk"
 import { getDefaultAgent } from "@/lib/types"
+import { deleteSandboxForBranch } from "@/lib/daytona-cleanup"
 
 export async function POST(req: Request) {
   const authResult = await requireAuth()
@@ -93,11 +95,29 @@ export async function DELETE(req: Request) {
     return notFound("Branch not found")
   }
 
-  await prisma.branch.delete({
-    where: { id: branchId },
-  })
+  try {
+    // 1. Delete Daytona sandbox first (cloud + DB record)
+    // This must happen before branch deletion since cascade would orphan the cloud resource
+    const cleanupResult = await deleteSandboxForBranch(branchId)
+    if (cleanupResult && !cleanupResult.success) {
+      console.warn(
+        `[branches/DELETE] Sandbox cleanup warning for branch ${branchId}:`,
+        cleanupResult.error
+      )
+      // Continue with branch deletion even if sandbox cleanup had issues
+      // The sandbox may already be deleted or inaccessible
+    }
 
-  return Response.json({ success: true })
+    // 2. Delete branch (cascade will clean up messages and any remaining sandbox record)
+    await prisma.branch.delete({
+      where: { id: branchId },
+    })
+
+    return Response.json({ success: true })
+  } catch (error) {
+    console.error(`[branches/DELETE] Error deleting branch ${branchId}:`, error)
+    return internalError(error)
+  }
 }
 
 // Update branch status/metadata

--- a/app/api/repos/route.ts
+++ b/app/api/repos/route.ts
@@ -11,6 +11,7 @@ import {
   INCLUDE_REPO_FOR_LIST,
   INCLUDE_REPO_WITH_BRANCHES,
 } from "@/lib/prisma-includes"
+import { deleteSandboxesForRepo } from "@/lib/daytona-cleanup"
 
 export async function GET() {
   const auth = await requireAuth()
@@ -95,12 +96,25 @@ export async function DELETE(req: Request) {
       return notFound("Repo not found")
     }
 
+    // 1. Delete all Daytona sandboxes for this repo first (cloud + DB records)
+    // This must happen before repo deletion since cascade would orphan cloud resources
+    const cleanupResult = await deleteSandboxesForRepo(repoId)
+    if (cleanupResult.failed > 0) {
+      console.warn(
+        `[repos/DELETE] Sandbox cleanup: ${cleanupResult.succeeded}/${cleanupResult.total} succeeded for repo ${repoId}`
+      )
+      // Continue with repo deletion even if some sandbox cleanups had issues
+      // The sandboxes may already be deleted or inaccessible
+    }
+
+    // 2. Delete repo (cascade will clean up branches, messages, and any remaining sandbox records)
     await prisma.repo.delete({
       where: { id: repoId },
     })
 
     return Response.json({ success: true })
   } catch (error) {
+    console.error(`[repos/DELETE] Error deleting repo ${repoId}:`, error)
     return internalError(error)
   }
 }

--- a/app/api/sandbox/create/route.ts
+++ b/app/api/sandbox/create/route.ts
@@ -14,6 +14,7 @@ import {
 import { createSSEStream, sendProgress, sendError, sendDone } from "@/lib/streaming-helpers"
 import { SANDBOX_CONFIG, PATHS } from "@/lib/constants"
 import { getDefaultAgent } from "@/lib/types"
+import { cleanupDaytonaSandbox } from "@/lib/daytona-cleanup"
 
 // Sandbox creation timeout - 300 seconds (must be literal for Next.js static analysis)
 export const maxDuration = 300
@@ -80,18 +81,20 @@ export async function POST(req: Request) {
   // Track records for cleanup on error
   let sandboxRecord: { id: string; sandboxId: string } | null = null
   let branchRecord: { id: string } | null = null
+  let daytonaClient: Daytona | null = null
+  let daytonaSandboxId: string | null = null
 
   return createSSEStream({
     onStart: async (controller) => {
       try {
         sendProgress(controller, "Creating sandbox...")
 
-        const daytona = new Daytona({ apiKey: daytonaApiKey })
+        daytonaClient = new Daytona({ apiKey: daytonaApiKey })
         const sandboxName = generateSandboxName(userId)
 
         // Only inject Anthropic API key if using claude-code agent or opencode with Anthropic models
         // For opencode with free models, no API key is needed
-        const sandbox = await daytona.create({
+        const sandbox = await daytonaClient.create({
           name: sandboxName,
           snapshot: SANDBOX_CONFIG.DEFAULT_SNAPSHOT,
           autoStopInterval: sandboxAutoStopInterval,
@@ -106,6 +109,9 @@ export async function POST(req: Request) {
               envVars: { ANTHROPIC_API_KEY: anthropicApiKey },
             }),
         })
+
+        // Track sandbox ID for cleanup if subsequent steps fail
+        daytonaSandboxId = sandbox.id
 
         // For Claude Max, write stored credentials so the Agent SDK picks them up
         if (anthropicAuthType === "claude-max" && anthropicAuthToken) {
@@ -247,14 +253,29 @@ export async function POST(req: Request) {
         })
       } catch (error: unknown) {
         const message = error instanceof Error ? error.message : "Unknown error"
+        console.error(`[sandbox/create] Error creating sandbox: ${message}`)
         sendError(controller, message)
 
-        // Clean up database records if created
+        // Clean up in reverse order of creation:
+        // 1. Database sandbox record
+        // 2. Database branch record
+        // 3. Daytona cloud sandbox (if created but DB records failed)
+
         if (sandboxRecord) {
-          await prisma.sandbox.delete({ where: { id: sandboxRecord.id } }).catch(() => {})
+          await prisma.sandbox.delete({ where: { id: sandboxRecord.id } }).catch((err: unknown) => {
+            console.warn(`[sandbox/create] Failed to cleanup sandbox record: ${err}`)
+          })
         }
         if (branchRecord) {
-          await prisma.branch.delete({ where: { id: branchRecord.id } }).catch(() => {})
+          await prisma.branch.delete({ where: { id: branchRecord.id } }).catch((err: unknown) => {
+            console.warn(`[sandbox/create] Failed to cleanup branch record: ${err}`)
+          })
+        }
+
+        // Clean up Daytona cloud sandbox if it was created but subsequent steps failed
+        // This prevents orphaned cloud resources
+        if (daytonaSandboxId && daytonaClient) {
+          await cleanupDaytonaSandbox(daytonaClient, daytonaSandboxId)
         }
       }
     },

--- a/hooks/use-repo-operations.ts
+++ b/hooks/use-repo-operations.ts
@@ -65,27 +65,14 @@ export function useRepoOperations({
   )
 
   // Remove a repo and its sandboxes
-  const handleRemoveRepo = useCallback((repoId: string) => {
+  const handleRemoveRepo = useCallback(async (repoId: string) => {
     const repo = repos.find((r) => r.id === repoId)
     if (!repo) return
 
-    // Clean up sandboxes for all branches
-    for (const branch of repo.branches) {
-      if (branch.sandboxId) {
-        fetch("/api/sandbox/delete", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ sandboxId: branch.sandboxId }),
-        }).catch(() => {})
-      }
-    }
-
-    // Delete repo from database
-    fetch(`/api/repos?id=${repoId}`, { method: "DELETE" }).catch(() => {})
-
+    // Update UI state immediately for responsiveness
     setRepos((prev) => {
       const newRepos = removeRepo(prev, repoId)
-      // Persist the new order to database (fire and forget)
+      // Persist the new order to database (fire and forget - non-critical)
       fetch("/api/user/repo-order", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
@@ -93,10 +80,21 @@ export function useRepoOperations({
       }).catch(() => {})
       return newRepos
     })
+
     if (activeRepoId === repoId) {
       const remaining = repos.filter((r) => r.id !== repoId)
       selectRepo(remaining[0]?.id ?? "")
       setActiveBranchId(null)
+    }
+
+    // Server handles Daytona sandbox cleanup
+    try {
+      const res = await fetch(`/api/repos?id=${repoId}`, { method: "DELETE" })
+      if (!res.ok) {
+        console.error(`[handleRemoveRepo] Failed to delete repo ${repoId}: ${res.status}`)
+      }
+    } catch (error) {
+      console.error(`[handleRemoveRepo] Error deleting repo ${repoId}:`, error)
     }
   }, [repos, activeRepoId, setRepos, selectRepo, setActiveBranchId])
 
@@ -122,19 +120,22 @@ export function useRepoOperations({
   }, [activeRepo, setRepos, setActiveBranchId])
 
   // Remove a branch from the active repo
-  const handleRemoveBranch = useCallback((branchId: string, deleteRemote?: boolean, activeBranchId?: string) => {
+  const handleRemoveBranch = useCallback(async (branchId: string, deleteRemote?: boolean, activeBranchId?: string) => {
     if (!activeRepo) return
     const branch = activeRepo.branches.find((b) => b.id === branchId)
 
-    if (branch?.sandboxId) {
-      fetch("/api/sandbox/delete", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sandboxId: branch.sandboxId }),
-      }).catch(() => {})
+    // Update UI state immediately for responsiveness
+    setRepos((prev) => removeBranchFromRepo(prev, activeRepo.id, branchId))
 
-      if (deleteRemote && branch) {
-        fetch("/api/sandbox/git", {
+    if (activeBranchId === branchId) {
+      const remaining = activeRepo.branches.filter((b) => b.id !== branchId)
+      setActiveBranchId(remaining[0]?.id ?? null)
+    }
+
+    // Delete remote branch if requested (must happen before sandbox is deleted)
+    if (deleteRemote && branch?.sandboxId) {
+      try {
+        await fetch("/api/sandbox/git", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -145,18 +146,21 @@ export function useRepoOperations({
             repoOwner: activeRepo.owner,
             repoApiName: activeRepo.name,
           }),
-        }).catch(() => {})
+        })
+      } catch (error) {
+        console.error(`[handleRemoveBranch] Error deleting remote branch:`, error)
+        // Continue with branch deletion even if remote delete fails
       }
     }
 
-    // Delete from database
-    fetch(`/api/branches?id=${branchId}`, { method: "DELETE" }).catch(() => {})
-
-    setRepos((prev) => removeBranchFromRepo(prev, activeRepo.id, branchId))
-
-    if (activeBranchId === branchId) {
-      const remaining = activeRepo.branches.filter((b) => b.id !== branchId)
-      setActiveBranchId(remaining[0]?.id ?? null)
+    // Server handles Daytona sandbox cleanup
+    try {
+      const res = await fetch(`/api/branches?id=${branchId}`, { method: "DELETE" })
+      if (!res.ok) {
+        console.error(`[handleRemoveBranch] Failed to delete branch ${branchId}: ${res.status}`)
+      }
+    } catch (error) {
+      console.error(`[handleRemoveBranch] Error deleting branch ${branchId}:`, error)
     }
 
     // Refresh quota

--- a/lib/daytona-cleanup.ts
+++ b/lib/daytona-cleanup.ts
@@ -1,0 +1,81 @@
+// Daytona cleanup utilities - ensures both DB records AND cloud resources are deleted
+
+import { Daytona } from "@daytonaio/sdk"
+import { prisma } from "@/lib/prisma"
+import { getDaytonaApiKey } from "@/lib/api-helpers"
+
+// Deletes a Daytona sandbox from both cloud and database
+async function deleteSandbox(sandboxId: string, apiKey: string): Promise<boolean> {
+  // 1. Delete from Daytona cloud
+  try {
+    const daytona = new Daytona({ apiKey })
+    const sandbox = await daytona.get(sandboxId)
+    await sandbox.delete()
+  } catch (error) {
+    // Sandbox may already be deleted - continue to DB cleanup
+    console.warn(`[daytona-cleanup] Cloud delete warning for ${sandboxId}:`, error)
+  }
+
+  // 2. Delete from database
+  try {
+    await prisma.sandbox.deleteMany({ where: { sandboxId } })
+    return true
+  } catch (error) {
+    console.error(`[daytona-cleanup] DB delete error for ${sandboxId}:`, error)
+    return false
+  }
+}
+
+// Deletes the sandbox associated with a branch. Call BEFORE deleting branch from DB.
+export async function deleteSandboxForBranch(branchId: string): Promise<{ success: boolean; error?: string }> {
+  const sandbox = await prisma.sandbox.findUnique({
+    where: { branchId },
+    select: { sandboxId: true },
+  })
+
+  if (!sandbox) {
+    return { success: true } // No sandbox to clean up
+  }
+
+  const apiKey = getDaytonaApiKey()
+  if (typeof apiKey !== "string") {
+    return { success: false, error: "Daytona API key not configured" }
+  }
+
+  const success = await deleteSandbox(sandbox.sandboxId, apiKey)
+  return { success }
+}
+
+// Deletes all sandboxes for a repo's branches. Call BEFORE deleting repo from DB.
+export async function deleteSandboxesForRepo(repoId: string): Promise<{ succeeded: number; failed: number; total: number }> {
+  const sandboxes = await prisma.sandbox.findMany({
+    where: { branch: { repoId } },
+    select: { sandboxId: true },
+  })
+
+  if (sandboxes.length === 0) {
+    return { succeeded: 0, failed: 0, total: 0 }
+  }
+
+  const apiKey = getDaytonaApiKey()
+  if (typeof apiKey !== "string") {
+    return { succeeded: 0, failed: sandboxes.length, total: sandboxes.length }
+  }
+
+  const results = await Promise.all(
+    sandboxes.map((s) => deleteSandbox(s.sandboxId, apiKey))
+  )
+
+  const succeeded = results.filter(Boolean).length
+  return { succeeded, failed: results.length - succeeded, total: results.length }
+}
+
+// Cleans up a Daytona sandbox during creation rollback
+export async function cleanupDaytonaSandbox(daytona: Daytona, sandboxId: string): Promise<void> {
+  try {
+    const sandbox = await daytona.get(sandboxId)
+    await sandbox.delete()
+  } catch (error) {
+    console.warn(`[daytona-cleanup] Failed to cleanup sandbox ${sandboxId}:`, error)
+  }
+}


### PR DESCRIPTION
- Fix Daytona sandbox cleanup on branch/repo deletion

Previously, deleting branches or repos only removed database records,
leaving Daytona cloud sandboxes orphaned and running indefinitely.

Changes:
- Add lib/daytona-cleanup.ts with centralized cleanup utilities
- Branch DELETE now cleans up associated Daytona sandbox before DB deletion
- Repo DELETE now cleans up all associated Daytona sandboxes before DB deletion
- Sandbox creation error handling now properly cleans up Daytona resources
- Client-side hooks use proper async/await instead of fire-and-forget calls
- Server-side now handles all cleanup, simplifying client code

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>