### PR TITLE
Feat/adding smithery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,5 +16,8 @@ ENCRYPTION_KEY="generate-with-openssl-rand-hex-32"
 # Daytona API (shared for all users, server-side only)
 DAYTONA_API_KEY="dtn_your_api_key"
 
+# Smithery MCP Registry API (shared for all users, server-side only)
+SMITHERY_API_KEY="your-smithery-api-key"
+
 # Optional: use local coding-agents-sdk from /Users/jamie/codeagentsdk (for dev only; run USE_LOCAL_SDK=1 npm install first)
 # USE_LOCAL_SDK=1

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A sophisticated multi-tenant web application that enables users to run AI coding
 - **Git Diff Viewer** - Compare branches and view changes
 - **Git History** - Browse commit history per branch
 - **Advanced Git Operations** - Merge, rebase, reset, tag, rename, and delete remote branches
+- **MCP Server Registry** - Browse and connect 3,000+ MCP servers via [Smithery](https://smithery.ai)
 - **Environment Variables** - Per-repository encrypted env vars for sandboxes
 - **Auto-Stop** - Configurable sandbox auto-stop intervals (5-20 minutes)
 - **Safe Push Handling** - Branch checks plus retry and graceful "already up-to-date" handling
@@ -57,11 +58,11 @@ A sophisticated multi-tenant web application that enables users to run AI coding
           └────────┬────────┘ └─────────────────┘ └─────────────────┘
                    │
                    ▼
-          ┌─────────────────┐
-          │  Coding Agents  │
-          │  - Claude Code  │
-          │  - OpenCode     │
-          │  - Codex        │
+          ┌─────────────────┐         ┌─────────────────┐
+          │  Coding Agents  │────────▶│  Smithery       │
+          │  - Claude Code  │         │  (MCP Registry  │
+          │  - OpenCode     │◀────────│   + Connect)    │
+          │  - Codex        │         └─────────────────┘
           └─────────────────┘
 ```
 
@@ -84,6 +85,8 @@ A sophisticated multi-tenant web application that enables users to run AI coding
 | Anthropic API Key | AES encrypted in database | User provides, decrypted at runtime |
 | OpenAI API Key | AES encrypted in database | User provides, decrypted at runtime |
 | OpenCode API Key | AES encrypted in database | User provides, decrypted at runtime |
+| Smithery API Key | Environment variable | Shared infrastructure, server-side |
+| MCP Server Tokens | AES encrypted in database | Per-repo per-server, managed by Smithery Connect |
 | Repository Env Vars | AES encrypted in database | Per-repo, injected into sandbox |
 
 ---
@@ -111,6 +114,7 @@ A sophisticated multi-tenant web application that enables users to run AI coding
 - **Sandboxes**: Daytona SDK (@daytonaio/sdk)
 - **Agent Runner**: background-agents
 - **LLM Providers**: Anthropic SDK, OpenAI SDK
+- **MCP Registry**: [Smithery](https://smithery.ai) (server discovery + managed connections)
 
 ---
 
@@ -175,6 +179,7 @@ Add these to Vercel (Settings → Environment Variables):
 | `ENCRYPTION_KEY` | For encrypting API keys | (output of `openssl rand -hex 32`) |
 | `DAYTONA_API_KEY` | Your shared Daytona API key | `dtn_...` |
 | `DAYTONA_API_URL` | Daytona API endpoint | `https://api.daytona.io` |
+| `SMITHERY_API_KEY` | Smithery API key for MCP registry | (from [smithery.ai/account/api-keys](https://smithery.ai/account/api-keys)) |
 | `CRON_SECRET` | Secret for Vercel cron jobs (loop mode) | (output of `openssl rand -base64 32`) |
 
 ### 5. Deploy
@@ -209,6 +214,7 @@ Or push to Vercel - the build script handles migrations automatically.
 [ ] ENCRYPTION_KEY set
 [ ] DAYTONA_API_KEY set
 [ ] DAYTONA_API_URL set
+[ ] SMITHERY_API_KEY set (optional, for MCP server registry)
 [ ] CRON_SECRET set (optional, for loop mode)
 ```
 
@@ -439,6 +445,35 @@ A Vercel cron job runs every minute to check for completed executions where loop
 
 When loop continues, the agent receives:
 > "If you have finished all tasks, respond with just the phrase FINISHED. Otherwise, continue working on the remaining tasks."
+
+---
+
+## MCP Server Integration
+
+The platform integrates with [Smithery](https://smithery.ai) to provide a registry of 3,000+ MCP (Model Context Protocol) servers that extend agent capabilities with external tools and services.
+
+### How It Works
+
+1. **Browse** - Users open repo settings → MCP Servers → Browse Registry to search Smithery's catalog
+2. **Connect** - Clicking "Connect" creates a managed connection via [Smithery Connect](https://smithery.ai/docs/use/connect)
+   - **Authless servers** (e.g. Context7) connect instantly, no popup needed
+   - **OAuth servers** (e.g. GitHub, Slack) open a popup for user authorization
+3. **Agent Access** - Connected servers are injected into the agent's MCP config at sandbox startup
+4. **Execution** - MCP tool calls route through `api.smithery.ai/connect/{namespace}/{connectionId}/mcp`
+
+### Setup
+
+1. Get a free API key from [smithery.ai/account/api-keys](https://smithery.ai/account/api-keys)
+2. Add `SMITHERY_API_KEY` to your `.env.local` or Vercel environment variables
+3. The app auto-creates a Smithery namespace (`upstream-agents`) on first connection
+
+### Pricing
+
+Smithery's free tier includes **25,000 RPCs/month**. Each MCP tool call from an agent counts as one RPC. Registry browsing and connection setup are separate. See [smithery.ai/pricing](https://smithery.ai/pricing) for details.
+
+### Connection Isolation
+
+Each connection is scoped to `{repoId}-{serverSlug}`, so OAuth credentials are isolated per repo per server. Smithery stores credentials encrypted and write-only — they can execute requests but are never readable. All connections share a single `SMITHERY_API_KEY` and namespace.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ The platform integrates with [Smithery](https://smithery.ai) to provide a regist
 
 1. Get a free API key from [smithery.ai/account/api-keys](https://smithery.ai/account/api-keys)
 2. Add `SMITHERY_API_KEY` to your `.env.local` or Vercel environment variables
-3. The app auto-creates a Smithery namespace (`upstream-agents`) on first connection
+3. The app auto-detects or creates a Smithery namespace on first connection (or set `SMITHERY_NAMESPACE` to use a specific one)
 
 ### Pricing
 
@@ -473,7 +473,7 @@ Smithery's free tier includes **25,000 RPCs/month**. Each MCP tool call from an 
 
 ### Connection Isolation
 
-Each connection is scoped to `{repoId}-{serverSlug}`, so OAuth credentials are isolated per repo per server. Smithery stores credentials encrypted and write-only — they can execute requests but are never readable. All connections share a single `SMITHERY_API_KEY` and namespace.
+Each connection is scoped to `{repoId}-{serverSlug}`, so OAuth credentials are isolated per repo per server. Smithery stores credentials encrypted and write-only — they can execute requests but are never readable. All connections share a single `SMITHERY_API_KEY`. The namespace is auto-resolved per API key.
 
 ---
 

--- a/app/api/mcp-registry/[...slug]/route.ts
+++ b/app/api/mcp-registry/[...slug]/route.ts
@@ -1,0 +1,75 @@
+import { NextResponse } from "next/server"
+
+// GET - Fetch server details from Smithery by qualifiedName
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ slug: string[] }> }
+) {
+  const { slug } = await params
+
+  // Reconstruct qualifiedName from slug segments (e.g. ["namespace", "name"] → "namespace/name")
+  const qualifiedName = slug.join("/")
+
+  if (slug.length < 2) {
+    return NextResponse.json(
+      { error: "Invalid server identifier. Expected format: namespace/name" },
+      { status: 400 }
+    )
+  }
+
+  const apiKey = process.env.SMITHERY_API_KEY
+  if (!apiKey) {
+    console.error("SMITHERY_API_KEY is not configured")
+    return NextResponse.json(
+      { error: "MCP registry is not configured" },
+      { status: 500 }
+    )
+  }
+
+  try {
+    const response = await fetch(
+      `https://api.smithery.ai/servers/${encodeURIComponent(qualifiedName)}`,
+      {
+        headers: {
+          "Accept": "application/json",
+          "Authorization": `Bearer ${apiKey}`,
+        },
+        next: { revalidate: 300 },
+      }
+    )
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        return NextResponse.json(
+          { error: "Server not found" },
+          { status: 404 }
+        )
+      }
+      console.error("Smithery server detail fetch failed:", response.status)
+      return NextResponse.json(
+        { error: "Failed to fetch server details" },
+        { status: 502 }
+      )
+    }
+
+    const data = await response.json()
+
+    return NextResponse.json({
+      slug: qualifiedName,
+      name: data.displayName || qualifiedName,
+      description: data.description || "",
+      iconUrl: data.iconUrl || null,
+      url: data.connectionUrl || data.url || null,
+      tools: data.tools || [],
+      toolCount: data.tools?.length || 0,
+      verified: data.verified || false,
+      useCount: data.useCount || 0,
+    })
+  } catch (err) {
+    console.error("Smithery server detail error:", err)
+    return NextResponse.json(
+      { error: "Failed to fetch server details" },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/mcp-registry/route.ts
+++ b/app/api/mcp-registry/route.ts
@@ -1,127 +1,112 @@
 import { NextResponse } from "next/server"
 
-// MCP Registry API types
-interface RegistryServerMeta {
-  slug?: string
-  displayName?: string
-  oneLiner?: string
-  iconUrl?: string
-  documentation?: string
-  toolNames?: string[]
-  isAuthless?: boolean
-  worksWith?: string[]
-  useCases?: string[]
-  popularityScore?: number
+// Smithery Registry API types
+interface SmitheryServer {
+  id: string
+  qualifiedName: string
+  displayName: string
+  description: string
+  iconUrl: string | null
+  verified: boolean
+  useCount: number
+  remote: boolean | null
+  isDeployed: boolean
+  createdAt: string
+  homepage: string | null
+  owner: string | null
 }
 
-interface RegistryServer {
-  server: {
-    name: string
-    title?: string
-    description?: string
-    version?: string
-    remotes?: Array<{
-      type: string
-      url: string
-    }>
-  }
-  _meta?: {
-    "com.anthropic.api/mcp-registry"?: RegistryServerMeta
+interface SmitheryResponse {
+  servers: SmitheryServer[]
+  pagination: {
+    currentPage: number
+    pageSize: number
+    totalPages: number
+    totalCount: number
   }
 }
 
-interface RegistryResponse {
-  servers: RegistryServer[]
-  metadata?: {
-    count?: number
-    nextCursor?: string
-  }
-}
-
-// Transform registry server to simplified format
-function transformServer(server: RegistryServer) {
-  const meta = server._meta?.["com.anthropic.api/mcp-registry"]
-  const remote = server.server.remotes?.[0]
+// Transform Smithery server to our frontend format
+function transformServer(server: SmitheryServer) {
+  // For deployed servers, construct the MCP URL; others need a detail fetch on connect
+  const url = server.isDeployed
+    ? `https://server.smithery.ai/${server.qualifiedName}/mcp`
+    : null
 
   return {
-    slug: meta?.slug || server.server.name.split("/").pop() || server.server.name,
-    name: server.server.title || meta?.displayName || server.server.name,
-    description: meta?.oneLiner || server.server.description || "",
-    iconUrl: meta?.iconUrl || null,
-    url: remote?.url || null,
-    transportType: remote?.type === "streamable-http" ? "http" : remote?.type || "http",
-    documentation: meta?.documentation || null,
-    tools: meta?.toolNames || [],
-    toolCount: meta?.toolNames?.length || 0,
-    requiresAuth: !meta?.isAuthless,
-    useCases: meta?.useCases || [],
-    popularityScore: meta?.popularityScore || 0,
-    worksWith: meta?.worksWith || [],
+    slug: server.qualifiedName,
+    name: server.displayName,
+    description: server.description || "",
+    iconUrl: server.iconUrl,
+    url,
+    toolCount: 0,
+    requiresAuth: true,
+    useCases: [] as string[],
+    verified: server.verified,
+    useCount: server.useCount,
+    isDeployed: server.isDeployed,
   }
 }
 
-// GET - Proxy to Anthropic MCP registry
+// GET - Proxy to Smithery MCP registry
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url)
 
   const search = searchParams.get("search") || ""
-  const cursor = searchParams.get("cursor") || ""
-  const limit = Math.min(parseInt(searchParams.get("limit") || "20"), 50)
+  const page = Math.max(parseInt(searchParams.get("page") || "1"), 1)
+  const pageSize = Math.min(Math.max(parseInt(searchParams.get("pageSize") || "20"), 1), 50)
+
+  const apiKey = process.env.SMITHERY_API_KEY
+  if (!apiKey) {
+    console.error("SMITHERY_API_KEY is not configured")
+    return NextResponse.json(
+      { error: "MCP registry is not configured" },
+      { status: 500 }
+    )
+  }
 
   try {
-    // Build registry URL
-    const registryUrl = new URL("https://api.anthropic.com/mcp-registry/v0/servers")
-    registryUrl.searchParams.set("visibility", "commercial")
-    registryUrl.searchParams.set("limit", String(limit))
+    // Build Smithery registry URL
+    const registryUrl = new URL("https://api.smithery.ai/servers")
+    registryUrl.searchParams.set("page", String(page))
+    registryUrl.searchParams.set("pageSize", String(pageSize))
+    registryUrl.searchParams.set("remote", "true")
 
     if (search) {
-      registryUrl.searchParams.set("search", search)
-    }
-    if (cursor) {
-      registryUrl.searchParams.set("cursor", cursor)
+      registryUrl.searchParams.set("q", search)
     }
 
-    // Fetch from registry
+    // Fetch from Smithery registry
     const response = await fetch(registryUrl.toString(), {
       headers: {
         "Accept": "application/json",
+        "Authorization": `Bearer ${apiKey}`,
       },
       // Cache for 5 minutes
       next: { revalidate: 300 },
     })
 
     if (!response.ok) {
-      console.error("Registry fetch failed:", response.status, await response.text())
+      console.error("Smithery registry fetch failed:", response.status, await response.text())
       return NextResponse.json(
         { error: "Failed to fetch registry" },
         { status: 502 }
       )
     }
 
-    const data: RegistryResponse = await response.json()
+    const data: SmitheryResponse = await response.json()
 
-    // Filter for Claude Code compatible servers and transform
-    const servers = data.servers
-      .filter((s) => {
-        const worksWith = s._meta?.["com.anthropic.api/mcp-registry"]?.worksWith || []
-        // Include servers that work with claude-code, or don't specify (assume compatible)
-        return worksWith.length === 0 || worksWith.includes("claude-code")
-      })
-      .filter((s) => {
-        // Must have a remote URL
-        return s.server.remotes && s.server.remotes.length > 0
-      })
-      .map(transformServer)
-      // Sort by popularity
-      .sort((a, b) => b.popularityScore - a.popularityScore)
+    const servers = data.servers.map(transformServer)
 
     return NextResponse.json({
       servers,
-      nextCursor: data.metadata?.nextCursor || null,
-      total: data.metadata?.count || servers.length,
+      page: data.pagination.currentPage,
+      pageSize: data.pagination.pageSize,
+      totalPages: data.pagination.totalPages,
+      totalCount: data.pagination.totalCount,
     })
   } catch (err) {
-    console.error("Registry proxy error:", err)
+    console.error("Smithery registry proxy error:", err)
     return NextResponse.json(
       { error: "Failed to fetch registry" },
       { status: 500 }

--- a/app/api/repo/[repoId]/mcp-servers/oauth/route.ts
+++ b/app/api/repo/[repoId]/mcp-servers/oauth/route.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@/lib/prisma"
+import { encrypt } from "@/lib/encryption"
 import {
   requireAuth,
   isAuthError,
@@ -13,6 +14,11 @@ import {
   registerClient,
   type McpOAuthState,
 } from "@/lib/mcp-oauth"
+import {
+  isSmitheryServer,
+  createSmitheryConnection,
+  getSmitheryConnectionId,
+} from "@/lib/smithery-connect"
 
 // GET - Start OAuth flow for MCP server
 export async function GET(
@@ -83,6 +89,52 @@ export async function GET(
   }
 
   try {
+    // Smithery-hosted servers use Smithery Connect instead of standard OAuth
+    if (isSmitheryServer(url)) {
+      const apiKey = process.env.SMITHERY_API_KEY
+      if (!apiKey) {
+        return Response.json(
+          { error: "Smithery is not configured" },
+          { status: 500 }
+        )
+      }
+
+      const connectionId = getSmitheryConnectionId(repoId, slug)
+      const result = await createSmitheryConnection(url, connectionId, name, apiKey)
+
+      if (result.status === "auth_required" && result.authorizationUrl) {
+        // Store connection metadata for callback
+        await prisma.repoMcpServer.update({
+          where: { id: serverId },
+          data: { clientId: connectionId },
+        })
+
+        return Response.json({
+          authUrl: result.authorizationUrl,
+          serverId,
+          smitheryConnect: true,
+        })
+      }
+
+      if (result.status === "connected") {
+        // No OAuth needed — mark as connected immediately
+        await prisma.repoMcpServer.update({
+          where: { id: serverId },
+          data: {
+            url: result.mcpEndpoint,
+            accessToken: encrypt(apiKey),
+            status: "connected",
+            lastError: null,
+          },
+        })
+        return Response.json({ authUrl: null, serverId, connected: true })
+      }
+
+      // Error case
+      throw new Error(result.error || "Smithery connection failed")
+    }
+
+    // Non-Smithery servers: use standard MCP OAuth discovery
     // Get OAuth endpoints via discovery or defaults
     const endpoints = await getOAuthEndpoints(url)
 

--- a/app/api/repo/[repoId]/mcp-servers/smithery-finalize/route.ts
+++ b/app/api/repo/[repoId]/mcp-servers/smithery-finalize/route.ts
@@ -1,0 +1,64 @@
+import { prisma } from "@/lib/prisma"
+import { requireAuth, isAuthError, badRequest, notFound } from "@/lib/api-helpers"
+import { finalizeSmitheryConnection } from "@/lib/smithery-connect"
+
+// POST - Finalize a Smithery Connect connection after OAuth
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ repoId: string }> }
+) {
+  const authResult = await requireAuth()
+  if (isAuthError(authResult)) return authResult
+  const { userId } = authResult
+
+  const { repoId } = await params
+  const body = await req.json()
+  const { serverId } = body
+
+  if (!serverId) {
+    return badRequest("Missing serverId")
+  }
+
+  // Verify repo ownership
+  const repo = await prisma.repo.findUnique({
+    where: { id: repoId },
+    select: { userId: true },
+  })
+
+  if (!repo || repo.userId !== userId) {
+    return notFound("Repository not found")
+  }
+
+  // Find the server and get the connectionId (stored in clientId field)
+  const server = await prisma.repoMcpServer.findUnique({
+    where: { id: serverId },
+  })
+
+  if (!server || server.repoId !== repoId) {
+    return notFound("Server not found")
+  }
+
+  const connectionId = server.clientId
+  if (!connectionId) {
+    return badRequest("No Smithery connection ID found")
+  }
+
+  const apiKey = process.env.SMITHERY_API_KEY
+  if (!apiKey) {
+    return Response.json(
+      { error: "Smithery is not configured" },
+      { status: 500 }
+    )
+  }
+
+  const success = await finalizeSmitheryConnection(serverId, connectionId, apiKey)
+
+  if (success) {
+    return Response.json({ connected: true })
+  }
+
+  return Response.json(
+    { error: "Connection not yet authorized. Please try again." },
+    { status: 400 }
+  )
+}

--- a/components/repo-settings-modal.tsx
+++ b/components/repo-settings-modal.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { cn } from "@/lib/utils"
-import { X, Plus, Trash2, Loader2, Variable, AlertTriangle, Plug, ExternalLink, Search, CheckCircle2, XCircle, Clock } from "lucide-react"
+import { X, Plus, Trash2, Loader2, Variable, AlertTriangle, Plug, ExternalLink, Search, CheckCircle2, XCircle, Clock, BadgeCheck } from "lucide-react"
 import { useState, useEffect, useCallback } from "react"
 import { Input } from "@/components/ui/input"
 
@@ -30,6 +30,9 @@ interface RegistryServer {
   toolCount: number
   requiresAuth: boolean
   useCases: string[]
+  verified: boolean
+  useCount: number
+  isDeployed: boolean
 }
 
 type SettingsTab = "env-vars" | "mcp-servers"
@@ -68,6 +71,9 @@ export function RepoSettingsModal({
   const [isLoadingRegistry, setIsLoadingRegistry] = useState(false)
   const [registrySearch, setRegistrySearch] = useState("")
   const [connectingSlug, setConnectingSlug] = useState<string | null>(null)
+  const [registryPage, setRegistryPage] = useState(1)
+  const [registryTotalPages, setRegistryTotalPages] = useState(1)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
 
   // UI state
   const [isSaving, setIsSaving] = useState(false)
@@ -90,21 +96,30 @@ export function RepoSettingsModal({
   }, [repoId])
 
   // Load registry servers
-  const loadRegistry = useCallback(async (search: string = "") => {
-    setIsLoadingRegistry(true)
+  const loadRegistry = useCallback(async (search: string = "", page: number = 1, append: boolean = false) => {
+    if (append) {
+      setIsLoadingMore(true)
+    } else {
+      setIsLoadingRegistry(true)
+    }
     try {
-      const url = search
-        ? `/api/mcp-registry?search=${encodeURIComponent(search)}`
-        : "/api/mcp-registry"
-      const response = await fetch(url)
+      const params = new URLSearchParams({ page: String(page) })
+      if (search) params.set("search", search)
+      const response = await fetch(`/api/mcp-registry?${params}`)
       if (response.ok) {
         const data = await response.json()
-        setRegistryServers(data.servers || [])
+        if (append) {
+          setRegistryServers((prev) => [...prev, ...(data.servers || [])])
+        } else {
+          setRegistryServers(data.servers || [])
+        }
+        setRegistryTotalPages(data.totalPages || 1)
       }
     } catch (err) {
       console.error("Failed to load registry:", err)
     } finally {
       setIsLoadingRegistry(false)
+      setIsLoadingMore(false)
     }
   }, [])
 
@@ -127,6 +142,7 @@ export function RepoSettingsModal({
   // Load registry when showing
   useEffect(() => {
     if (showRegistry) {
+      setRegistryPage(1)
       loadRegistry(registrySearch)
     }
   }, [showRegistry, loadRegistry, registrySearch])
@@ -135,6 +151,7 @@ export function RepoSettingsModal({
   useEffect(() => {
     if (!showRegistry) return
     const timer = setTimeout(() => {
+      setRegistryPage(1)
       loadRegistry(registrySearch)
     }, 300)
     return () => clearTimeout(timer)
@@ -215,15 +232,27 @@ export function RepoSettingsModal({
 
   // MCP servers handlers
   async function handleConnectServer(server: RegistryServer) {
-    if (!server.url) return
-
     setConnectingSlug(server.slug)
 
     try {
+      // If no URL (non-deployed server), fetch details first
+      let serverUrl = server.url
+      if (!serverUrl) {
+        const detailRes = await fetch(`/api/mcp-registry/${server.slug}`)
+        if (!detailRes.ok) {
+          throw new Error("Failed to fetch server details")
+        }
+        const detail = await detailRes.json()
+        serverUrl = detail.url
+        if (!serverUrl) {
+          throw new Error("Server does not have a remote URL")
+        }
+      }
+
       // Start OAuth flow
       const params = new URLSearchParams({
         slug: server.slug,
-        url: server.url,
+        url: serverUrl,
         name: server.name,
         ...(server.iconUrl && { iconUrl: server.iconUrl }),
       })
@@ -235,17 +264,48 @@ export function RepoSettingsModal({
         throw new Error(data.error || "Failed to start OAuth")
       }
 
-      // Open OAuth popup
+      // Smithery server connected immediately (no OAuth needed)
+      if (data.connected) {
+        setConnectingSlug(null)
+        loadMcpServers()
+        setShowRegistry(false)
+        return
+      }
+
+      // Open OAuth popup (works for both Smithery auth and standard MCP OAuth)
       const popup = window.open(
         data.authUrl,
         "mcp-oauth",
         "width=600,height=700,scrollbars=yes"
       )
 
+      // Handle popup blocked by browser
+      if (!popup || popup.closed) {
+        setConnectingSlug(null)
+        return
+      }
+
+      const isSmithery = !!data.smitheryConnect
+      const serverId = data.serverId
+
       // Poll for popup close and refresh
-      const checkPopup = setInterval(() => {
+      const checkPopup = setInterval(async () => {
         if (popup?.closed) {
           clearInterval(checkPopup)
+
+          // For Smithery connections, finalize after popup closes
+          if (isSmithery && serverId) {
+            try {
+              await fetch(`/api/repo/${repoId}/mcp-servers/smithery-finalize`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ serverId }),
+              })
+            } catch (err) {
+              console.error("Failed to finalize Smithery connection:", err)
+            }
+          }
+
           setConnectingSlug(null)
           loadMcpServers()
           setShowRegistry(false)
@@ -524,11 +584,18 @@ export function RepoSettingsModal({
                           </div>
                         )}
                         <div className="flex-1 min-w-0">
-                          <p className="text-xs font-medium text-foreground">{server.name}</p>
+                          <div className="flex items-center gap-1">
+                            <p className="text-xs font-medium text-foreground">{server.name}</p>
+                            {server.verified && (
+                              <BadgeCheck className="h-3.5 w-3.5 text-blue-500 shrink-0" />
+                            )}
+                          </div>
                           <p className="text-[10px] text-muted-foreground line-clamp-2">{server.description}</p>
-                          {server.toolCount > 0 && (
+                          {server.useCount > 0 && (
                             <p className="text-[10px] text-muted-foreground/70 mt-0.5">
-                              {server.toolCount} tools
+                              {server.useCount >= 1000
+                                ? `${(server.useCount / 1000).toFixed(1).replace(/\.0$/, "")}k uses`
+                                : `${server.useCount} uses`}
                             </p>
                           )}
                         </div>
@@ -538,7 +605,7 @@ export function RepoSettingsModal({
                           ) : (
                             <button
                               onClick={() => handleConnectServer(server)}
-                              disabled={isConnecting || !server.url}
+                              disabled={isConnecting}
                               className="flex items-center gap-1 rounded bg-primary px-2 py-1 text-[10px] font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
                             >
                               {isConnecting ? (
@@ -555,6 +622,23 @@ export function RepoSettingsModal({
                       </div>
                     )
                   })}
+                  {registryPage < registryTotalPages && (
+                    <button
+                      onClick={() => {
+                        const nextPage = registryPage + 1
+                        setRegistryPage(nextPage)
+                        loadRegistry(registrySearch, nextPage, true)
+                      }}
+                      disabled={isLoadingMore}
+                      className="flex items-center justify-center gap-1.5 rounded-md bg-secondary px-3 py-2 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground cursor-pointer disabled:opacity-50"
+                    >
+                      {isLoadingMore ? (
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                      ) : (
+                        "Load More"
+                      )}
+                    </button>
+                  )}
                 </div>
               )}
             </>

--- a/lib/smithery-connect.ts
+++ b/lib/smithery-connect.ts
@@ -1,5 +1,6 @@
 import { encrypt } from "@/lib/encryption"
 import { prisma } from "@/lib/prisma"
+import { createHash } from "crypto"
 
 const SMITHERY_API_BASE = "https://api.smithery.ai"
 
@@ -43,8 +44,9 @@ async function getNamespace(apiKey: string): Promise<string | null> {
     console.error("[Smithery Connect] Failed to list namespaces:", err)
   }
 
-  // No namespaces exist — create one
-  const newName = `upstream-agents`
+  // No namespaces exist — create a unique one per API key
+  const keyHash = createHash("sha256").update(apiKey).digest("hex").slice(0, 8)
+  const newName = `upstream-${keyHash}`
   console.log("[Smithery Connect] Creating namespace:", newName)
   const ok = await ensureNamespace(newName, apiKey)
   if (ok) {
@@ -96,8 +98,12 @@ async function ensureNamespace(name: string, apiKey: string): Promise<boolean> {
       }
     )
 
-    if (!response.ok && response.status !== 409) {
+    if (!response.ok) {
       const body = await response.text()
+      // 409 means namespace already exists — only OK if we own it
+      if (response.status === 409 && !body.includes("another user")) {
+        return true
+      }
       console.error("[Smithery Connect] Failed to create namespace:", response.status, body)
       return false
     }

--- a/lib/smithery-connect.ts
+++ b/lib/smithery-connect.ts
@@ -22,7 +22,7 @@ async function getNamespace(apiKey: string): Promise<string | null> {
     return null
   }
 
-  // Auto-detect: fetch user's existing namespaces
+  // Auto-detect: fetch user's existing namespaces or create one
   try {
     const response = await fetch(`${SMITHERY_API_BASE}/namespaces`, {
       headers: { "Authorization": `Bearer ${apiKey}` },
@@ -32,15 +32,20 @@ async function getNamespace(apiKey: string): Promise<string | null> {
       const namespaces = data.data || data.namespaces || data
       if (Array.isArray(namespaces) && namespaces.length > 0) {
         resolvedNamespace = namespaces[0].name
+        console.log("[Smithery Connect] Using existing namespace:", resolvedNamespace)
         return resolvedNamespace
       }
+    } else {
+      const body = await response.text()
+      console.error("[Smithery Connect] Failed to list namespaces:", response.status, body)
     }
   } catch (err) {
     console.error("[Smithery Connect] Failed to list namespaces:", err)
   }
 
   // No namespaces exist — create one
-  const newName = `upstream-${Date.now().toString(36)}`
+  const newName = `upstream-agents`
+  console.log("[Smithery Connect] Creating namespace:", newName)
   const ok = await ensureNamespace(newName, apiKey)
   if (ok) {
     resolvedNamespace = newName
@@ -92,7 +97,8 @@ async function ensureNamespace(name: string, apiKey: string): Promise<boolean> {
     )
 
     if (!response.ok && response.status !== 409) {
-      console.error("[Smithery Connect] Failed to create namespace:", response.status)
+      const body = await response.text()
+      console.error("[Smithery Connect] Failed to create namespace:", response.status, body)
       return false
     }
 

--- a/lib/smithery-connect.ts
+++ b/lib/smithery-connect.ts
@@ -1,0 +1,218 @@
+import { encrypt } from "@/lib/encryption"
+import { prisma } from "@/lib/prisma"
+
+const SMITHERY_API_BASE = "https://api.smithery.ai"
+const SMITHERY_NAMESPACE = "upstream-agents"
+
+/**
+ * Check if a URL points to a Smithery-hosted MCP server
+ */
+export function isSmitheryServer(url: string): boolean {
+  try {
+    const parsed = new URL(url)
+    return parsed.hostname === "server.smithery.ai"
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Generate a deterministic connection ID for a repo + server combo
+ */
+export function getSmitheryConnectionId(repoId: string, slug: string): string {
+  return `${repoId}-${slug.replace(/\//g, "-")}`
+}
+
+/**
+ * Get the Smithery Connect MCP endpoint URL for a connection
+ */
+export function getSmitheryMcpEndpoint(connectionId: string): string {
+  return `${SMITHERY_API_BASE}/connect/${SMITHERY_NAMESPACE}/${connectionId}/mcp`
+}
+
+/**
+ * Ensure the Smithery namespace exists (idempotent PUT)
+ */
+async function ensureNamespace(apiKey: string): Promise<boolean> {
+  try {
+    const response = await fetch(
+      `${SMITHERY_API_BASE}/namespaces/${SMITHERY_NAMESPACE}`,
+      {
+        method: "PUT",
+        headers: {
+          "Authorization": `Bearer ${apiKey}`,
+        },
+      }
+    )
+
+    if (!response.ok && response.status !== 409) {
+      console.error("[Smithery Connect] Failed to create namespace:", response.status)
+      return false
+    }
+
+    return true
+  } catch (err) {
+    console.error("[Smithery Connect] Namespace creation error:", err)
+    return false
+  }
+}
+
+interface SmitheryConnectionResult {
+  status: "connected" | "auth_required" | "error"
+  authorizationUrl?: string
+  connectionId: string
+  mcpEndpoint: string
+  error?: string
+}
+
+/**
+ * Create or retrieve a Smithery Connect connection.
+ *
+ * Smithery Connect manages OAuth and credentials for hosted MCP servers.
+ * - If the server requires no auth, returns status "connected" immediately.
+ * - If OAuth is required, returns status "auth_required" with authorizationUrl.
+ * - After user completes OAuth, calling again returns "connected".
+ */
+export async function createSmitheryConnection(
+  mcpUrl: string,
+  connectionId: string,
+  name: string,
+  apiKey: string
+): Promise<SmitheryConnectionResult> {
+  const mcpEndpoint = getSmitheryMcpEndpoint(connectionId)
+
+  try {
+    // Ensure namespace exists first (idempotent)
+    const nsOk = await ensureNamespace(apiKey)
+    if (!nsOk) {
+      return {
+        status: "error",
+        connectionId,
+        mcpEndpoint,
+        error: "Failed to create Smithery namespace",
+      }
+    }
+
+    // Create or update connection via PUT
+    const response = await fetch(
+      `${SMITHERY_API_BASE}/connect/${SMITHERY_NAMESPACE}/${connectionId}`,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          mcpUrl,
+          name,
+        }),
+      }
+    )
+
+    if (!response.ok) {
+      const errorText = await response.text()
+      console.error("[Smithery Connect] API error:", response.status, errorText)
+      return {
+        status: "error",
+        connectionId,
+        mcpEndpoint,
+        error: `Smithery API returned ${response.status}`,
+      }
+    }
+
+    const data = await response.json()
+    const state = data.status?.state || data.status
+
+    if (state === "auth_required") {
+      return {
+        status: "auth_required",
+        authorizationUrl: data.status?.authorizationUrl,
+        connectionId: data.connectionId || connectionId,
+        mcpEndpoint,
+      }
+    }
+
+    if (state === "connected") {
+      return {
+        status: "connected",
+        connectionId: data.connectionId || connectionId,
+        mcpEndpoint,
+      }
+    }
+
+    if (state === "error") {
+      return {
+        status: "error",
+        connectionId,
+        mcpEndpoint,
+        error: data.status?.message || "Smithery connection error",
+      }
+    }
+
+    // Unknown status
+    return {
+      status: "error",
+      connectionId,
+      mcpEndpoint,
+      error: `Unexpected status: ${JSON.stringify(data.status)}`,
+    }
+  } catch (err) {
+    console.error("[Smithery Connect] Connection error:", err)
+    return {
+      status: "error",
+      connectionId,
+      mcpEndpoint,
+      error: err instanceof Error ? err.message : "Connection failed",
+    }
+  }
+}
+
+/**
+ * Finalize a Smithery connection after OAuth callback.
+ * Checks connection status and updates the DB record.
+ */
+export async function finalizeSmitheryConnection(
+  serverId: string,
+  connectionId: string,
+  apiKey: string
+): Promise<boolean> {
+  const mcpEndpoint = getSmitheryMcpEndpoint(connectionId)
+
+  try {
+    // Check connection status via GET
+    const response = await fetch(
+      `${SMITHERY_API_BASE}/connect/${SMITHERY_NAMESPACE}/${connectionId}`,
+      {
+        headers: {
+          "Authorization": `Bearer ${apiKey}`,
+        },
+      }
+    )
+
+    if (!response.ok) {
+      console.error("[Smithery Connect] Status check failed:", response.status)
+      return false
+    }
+
+    const data = await response.json()
+    const state = data.status?.state || data.status
+
+    if (state === "connected") {
+      await prisma.repoMcpServer.update({
+        where: { id: serverId },
+        data: {
+          url: mcpEndpoint,
+          accessToken: encrypt(apiKey),
+          status: "connected",
+          lastError: null,
+        },
+      })
+      return true
+    }
+
+    return false
+  } catch (err) {
+    console.error("[Smithery Connect] Finalize error:", err)
+    return false
+  }
+}

--- a/lib/smithery-connect.ts
+++ b/lib/smithery-connect.ts
@@ -2,7 +2,53 @@ import { encrypt } from "@/lib/encryption"
 import { prisma } from "@/lib/prisma"
 
 const SMITHERY_API_BASE = "https://api.smithery.ai"
-const SMITHERY_NAMESPACE = "upstream-agents"
+
+// Each Smithery API key owns its own namespaces.
+// Use SMITHERY_NAMESPACE env var if set, otherwise auto-create one.
+let resolvedNamespace: string | null = null
+
+async function getNamespace(apiKey: string): Promise<string | null> {
+  // Return cached namespace
+  if (resolvedNamespace) return resolvedNamespace
+
+  // Use explicit env var if set
+  const envNamespace = process.env.SMITHERY_NAMESPACE
+  if (envNamespace) {
+    const ok = await ensureNamespace(envNamespace, apiKey)
+    if (ok) {
+      resolvedNamespace = envNamespace
+      return resolvedNamespace
+    }
+    return null
+  }
+
+  // Auto-detect: fetch user's existing namespaces
+  try {
+    const response = await fetch(`${SMITHERY_API_BASE}/namespaces`, {
+      headers: { "Authorization": `Bearer ${apiKey}` },
+    })
+    if (response.ok) {
+      const data = await response.json()
+      const namespaces = data.data || data.namespaces || data
+      if (Array.isArray(namespaces) && namespaces.length > 0) {
+        resolvedNamespace = namespaces[0].name
+        return resolvedNamespace
+      }
+    }
+  } catch (err) {
+    console.error("[Smithery Connect] Failed to list namespaces:", err)
+  }
+
+  // No namespaces exist — create one
+  const newName = `upstream-${Date.now().toString(36)}`
+  const ok = await ensureNamespace(newName, apiKey)
+  if (ok) {
+    resolvedNamespace = newName
+    return resolvedNamespace
+  }
+
+  return null
+}
 
 /**
  * Check if a URL points to a Smithery-hosted MCP server
@@ -26,17 +72,17 @@ export function getSmitheryConnectionId(repoId: string, slug: string): string {
 /**
  * Get the Smithery Connect MCP endpoint URL for a connection
  */
-export function getSmitheryMcpEndpoint(connectionId: string): string {
-  return `${SMITHERY_API_BASE}/connect/${SMITHERY_NAMESPACE}/${connectionId}/mcp`
+export function getSmitheryMcpEndpoint(namespace: string, connectionId: string): string {
+  return `${SMITHERY_API_BASE}/connect/${namespace}/${connectionId}/mcp`
 }
 
 /**
  * Ensure the Smithery namespace exists (idempotent PUT)
  */
-async function ensureNamespace(apiKey: string): Promise<boolean> {
+async function ensureNamespace(name: string, apiKey: string): Promise<boolean> {
   try {
     const response = await fetch(
-      `${SMITHERY_API_BASE}/namespaces/${SMITHERY_NAMESPACE}`,
+      `${SMITHERY_API_BASE}/namespaces/${name}`,
       {
         method: "PUT",
         headers: {
@@ -79,23 +125,23 @@ export async function createSmitheryConnection(
   name: string,
   apiKey: string
 ): Promise<SmitheryConnectionResult> {
-  const mcpEndpoint = getSmitheryMcpEndpoint(connectionId)
-
   try {
-    // Ensure namespace exists first (idempotent)
-    const nsOk = await ensureNamespace(apiKey)
-    if (!nsOk) {
+    // Resolve namespace for this API key
+    const namespace = await getNamespace(apiKey)
+    if (!namespace) {
       return {
         status: "error",
         connectionId,
-        mcpEndpoint,
-        error: "Failed to create Smithery namespace",
+        mcpEndpoint: "",
+        error: "Failed to resolve Smithery namespace",
       }
     }
 
+    const mcpEndpoint = getSmitheryMcpEndpoint(namespace, connectionId)
+
     // Create or update connection via PUT
     const response = await fetch(
-      `${SMITHERY_API_BASE}/connect/${SMITHERY_NAMESPACE}/${connectionId}`,
+      `${SMITHERY_API_BASE}/connect/${namespace}/${connectionId}`,
       {
         method: "PUT",
         headers: {
@@ -161,7 +207,7 @@ export async function createSmitheryConnection(
     return {
       status: "error",
       connectionId,
-      mcpEndpoint,
+      mcpEndpoint: "",
       error: err instanceof Error ? err.message : "Connection failed",
     }
   }
@@ -176,12 +222,15 @@ export async function finalizeSmitheryConnection(
   connectionId: string,
   apiKey: string
 ): Promise<boolean> {
-  const mcpEndpoint = getSmitheryMcpEndpoint(connectionId)
-
   try {
+    const namespace = await getNamespace(apiKey)
+    if (!namespace) return false
+
+    const mcpEndpoint = getSmitheryMcpEndpoint(namespace, connectionId)
+
     // Check connection status via GET
     const response = await fetch(
-      `${SMITHERY_API_BASE}/connect/${SMITHERY_NAMESPACE}/${connectionId}`,
+      `${SMITHERY_API_BASE}/connect/${namespace}/${connectionId}`,
       {
         headers: {
           "Authorization": `Bearer ${apiKey}`,


### PR DESCRIPTION
## Problem

Our current MCP server registry proxies Anthropic's API, which has poor data quality — most servers don't work, many are missing icons, and the catalog is small. Users browsing the registry get a bad experience and often can't connect to the servers listed.

## Solution

Swap the registry backend to [Smithery](https://smithery.ai), a dedicated MCP marketplace with 3,000+ servers, better icon coverage, verified badges, and semantic search. Also integrate Smithery Connect for managed authentication — Smithery handles OAuth flows and credential storage for hosted servers, so users don't hit broken auth endpoints.

## What changed

**Registry API** (`app/api/mcp-registry/`)
- Rewrite the proxy to hit `api.smithery.ai/servers` instead of Anthropic
- Add a `[...slug]` detail endpoint for fetching individual server info
- Filter for remote-only servers (stdio can't run in Daytona sandboxes)
- Switch from cursor-based to page-based pagination

**Smithery Connect** (`lib/smithery-connect.ts`)
- Detect `server.smithery.ai` URLs and route through Smithery Connect API
- Handle two flows: instant connect (authless servers) and OAuth popup (servers requiring auth)
- Add `/smithery-finalize` endpoint to confirm connection after OAuth popup closes
- Existing OAuth flow preserved for non-Smithery servers

**Frontend** (`components/repo-settings-modal.tsx`)
- Show verified badges and use counts on registry cards
- Add "Load More" pagination
- Handle instant-connect response without opening a popup
- Stop spinner if browser blocks popup

## How to test

1. Set `SMITHERY_API_KEY` in `.env.local`
2. Open repo settings → MCP Servers → Browse Registry
3. Verify servers load with icons, verified badges, use counts
4. Connect an authless server (e.g. Context7) — should connect instantly
5. Connect an OAuth server — popup opens Smithery auth flow
6. Verify search works
7. Verify existing connected MCP servers still function
