### PR TITLE
Fix GitHub compare endpoint to return proper status codes

### DIFF
--- a/packages/web/app/api/github/compare/route.ts
+++ b/packages/web/app/api/github/compare/route.ts
@@ -1,5 +1,5 @@
-import { requireGitHubAuth, isGitHubAuthError, badRequest, internalError } from "@/lib/shared/api-helpers"
-import { getDiff } from "@/lib/git/github-client"
+import { requireGitHubAuth, isGitHubAuthError, badRequest, notFound, internalError } from "@/lib/shared/api-helpers"
+import { getDiff, isGitHubApiError } from "@/lib/git/github-client"
 
 export async function POST(req: Request) {
   const auth = await requireGitHubAuth()
@@ -20,6 +20,20 @@ export async function POST(req: Request) {
     const diff = await getDiff(auth.token, owner, repo, { commitHash, base, head })
     return Response.json({ diff })
   } catch (error: unknown) {
+    // Handle GitHub API errors with appropriate status codes
+    if (isGitHubApiError(error)) {
+      // 404 - Branch or commit not found
+      if (error.status === 404) {
+        return notFound("Branch or commit not found")
+      }
+      // For "no commits between" errors (GitHub returns 404 with specific message),
+      // return empty diff instead of error
+      if (error.message.includes("No commits") || error.message.includes("nothing to compare")) {
+        return Response.json({ diff: "" })
+      }
+      // Return the actual GitHub error status for other cases
+      return Response.json({ error: error.message }, { status: error.status })
+    }
     return internalError(error)
   }
 }

--- a/packages/web/components/chat/chat-header.tsx
+++ b/packages/web/components/chat/chat-header.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/components/ui/tooltip"
 import type { UseGitActionsReturn } from "./hooks/useGitActions"
 import type { UseBranchRenamingReturn } from "./hooks/useBranchRenaming"
+import { DiffStatsTooltip, diffStatsTooltipClass } from "@/components/ui/diff-stats-tooltip"
 
 // ============================================================================
 // Header Actions Config
@@ -264,17 +265,8 @@ export function ChatHeader({
           let tooltipClassName = "text-xs"
           if (isDiff && gitActions.diffStats) {
             const { additions, deletions } = gitActions.diffStats
-            // Use white background for better contrast with colored text
-            tooltipClassName = "text-xs bg-white text-gray-900 dark:bg-white dark:text-gray-900"
-            tooltipContent = (
-              <span className="flex items-center gap-2">
-                <span>Diff</span>
-                <span className="flex items-center gap-1.5">
-                  <span className="text-green-600">+{additions}</span>
-                  <span className="text-red-600">−{deletions}</span>
-                </span>
-              </span>
-            )
+            tooltipClassName = diffStatsTooltipClass
+            tooltipContent = <DiffStatsTooltip additions={additions} deletions={deletions} />
           }
 
           return (

--- a/packages/web/components/chat/chat-header.tsx
+++ b/packages/web/components/chat/chat-header.tsx
@@ -263,10 +263,12 @@ export function ChatHeader({
           // Build tooltip content for diff action
           let tooltipContent: ReactNode = hasPR ? "Open PR" : action.label
           let tooltipClassName = "text-xs"
+          let hideArrow = false
           if (isDiff && gitActions.diffStats) {
             const { additions, deletions } = gitActions.diffStats
             tooltipClassName = diffStatsTooltipClass
             tooltipContent = <DiffStatsTooltip additions={additions} deletions={deletions} />
+            hideArrow = true
           }
 
           return (
@@ -292,7 +294,7 @@ export function ChatHeader({
                     )}
                   </button>
                 </TooltipTrigger>
-                <TooltipContent side="bottom" className={tooltipClassName}>
+                <TooltipContent side="bottom" className={tooltipClassName} hideArrow={hideArrow}>
                   {tooltipContent}
                 </TooltipContent>
               </Tooltip>

--- a/packages/web/components/chat/chat-header.tsx
+++ b/packages/web/components/chat/chat-header.tsx
@@ -261,14 +261,17 @@ export function ChatHeader({
 
           // Build tooltip content for diff action
           let tooltipContent: ReactNode = hasPR ? "Open PR" : action.label
+          let tooltipClassName = "text-xs"
           if (isDiff && gitActions.diffStats) {
             const { additions, deletions } = gitActions.diffStats
+            // Use white background for better contrast with colored text
+            tooltipClassName = "text-xs bg-white text-gray-900 dark:bg-white dark:text-gray-900"
             tooltipContent = (
               <span className="flex items-center gap-2">
                 <span>Diff</span>
                 <span className="flex items-center gap-1.5">
-                  <span className="text-green-400">+{additions}</span>
-                  <span className="text-red-400">−{deletions}</span>
+                  <span className="text-green-600">+{additions}</span>
+                  <span className="text-red-600">−{deletions}</span>
                 </span>
               </span>
             )
@@ -297,7 +300,7 @@ export function ChatHeader({
                     )}
                   </button>
                 </TooltipTrigger>
-                <TooltipContent side="bottom" className="text-xs">
+                <TooltipContent side="bottom" className={tooltipClassName}>
                   {tooltipContent}
                 </TooltipContent>
               </Tooltip>

--- a/packages/web/components/chat/chat-header.tsx
+++ b/packages/web/components/chat/chat-header.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import type { ReactNode } from "react"
 import { cn } from "@/lib/shared/utils"
 import type { Branch } from "@/lib/shared/types"
 import { BRANCH_STATUS } from "@/lib/shared/constants"
@@ -258,6 +259,21 @@ export function ChatHeader({
             return null
           }
 
+          // Build tooltip content for diff action
+          let tooltipContent: ReactNode = hasPR ? "Open PR" : action.label
+          if (isDiff && gitActions.diffStats) {
+            const { additions, deletions } = gitActions.diffStats
+            tooltipContent = (
+              <span className="flex items-center gap-2">
+                <span>Diff</span>
+                <span className="flex items-center gap-1.5">
+                  <span className="text-green-400">+{additions}</span>
+                  <span className="text-red-400">−{deletions}</span>
+                </span>
+              </span>
+            )
+          }
+
           return (
             <span key={action.label} className="contents">
               <Tooltip>
@@ -282,7 +298,7 @@ export function ChatHeader({
                   </button>
                 </TooltipTrigger>
                 <TooltipContent side="bottom" className="text-xs">
-                  {hasPR ? "Open PR" : action.label}
+                  {tooltipContent}
                 </TooltipContent>
               </Tooltip>
               {action.action === "rebase" && <div className="mx-1.5 h-4 w-px bg-border shrink-0" />}

--- a/packages/web/components/chat/hooks/useGitActions.ts
+++ b/packages/web/components/chat/hooks/useGitActions.ts
@@ -84,6 +84,11 @@ export function useGitActions({
           head: branch.name,
         }),
       })
+      // Handle non-200 responses gracefully (e.g., branch not found, no commits)
+      if (!res.ok) {
+        setHasChanges(false)
+        return
+      }
       const data = await res.json()
       // Check if there's any actual diff content
       const hasDiff = data.diff && data.diff.trim() !== "" && data.diff !== "No differences found."

--- a/packages/web/components/chat/hooks/useGitActions.ts
+++ b/packages/web/components/chat/hooks/useGitActions.ts
@@ -54,6 +54,7 @@ export function useGitActions({
   const [rsyncCopied, setRsyncCopied] = useState(false)
   const [sandboxToggleLoading, setSandboxToggleLoading] = useState(false)
   const [hasChanges, setHasChanges] = useState(false)
+  const [diffStats, setDiffStats] = useState<{ additions: number; deletions: number } | null>(null)
 
   const addSystemMessage = useCallback((content: string) => {
     // System messages go to the current branch (user-initiated git actions)
@@ -70,6 +71,7 @@ export function useGitActions({
   const checkForChanges = useCallback(async () => {
     if (!branch.sandboxId) {
       setHasChanges(false)
+      setDiffStats(null)
       return
     }
     const [owner, repo] = repoFullName.split("/")
@@ -87,14 +89,34 @@ export function useGitActions({
       // Handle non-200 responses gracefully (e.g., branch not found, no commits)
       if (!res.ok) {
         setHasChanges(false)
+        setDiffStats(null)
         return
       }
       const data = await res.json()
       // Check if there's any actual diff content
       const hasDiff = data.diff && data.diff.trim() !== "" && data.diff !== "No differences found."
       setHasChanges(hasDiff)
+
+      // Parse diff to extract line stats
+      if (hasDiff && data.diff) {
+        const lines = data.diff.split("\n")
+        let additions = 0
+        let deletions = 0
+        for (const line of lines) {
+          // Count lines starting with + or - but not diff headers (+++, ---)
+          if (line.startsWith("+") && !line.startsWith("+++")) {
+            additions++
+          } else if (line.startsWith("-") && !line.startsWith("---")) {
+            deletions++
+          }
+        }
+        setDiffStats({ additions, deletions })
+      } else {
+        setDiffStats(null)
+      }
     } catch {
       setHasChanges(false)
+      setDiffStats(null)
     }
   }, [branch.sandboxId, branch.baseBranch, branch.name, repoFullName])
 
@@ -235,6 +257,7 @@ export function useGitActions({
 
     // Changes detection
     hasChanges,
+    diffStats,
 
     // Actions
     handleSandboxToggle,

--- a/packages/web/components/modals/diff-modal.tsx
+++ b/packages/web/components/modals/diff-modal.tsx
@@ -158,7 +158,12 @@ export function DiffModal({ open, onClose, repoOwner, repoName, branchName, base
         }),
       })
       const data = await res.json()
-      setDiff(data.diff || "No differences found.")
+      if (!res.ok) {
+        // Handle expected errors gracefully (branch not found, etc.)
+        setDiff(data.error || "No differences found.")
+      } else {
+        setDiff(data.diff || "No differences found.")
+      }
     } catch {
       setDiff("Failed to load diff.")
     } finally {
@@ -180,7 +185,12 @@ export function DiffModal({ open, onClose, repoOwner, repoName, branchName, base
         }),
       })
       const data = await res.json()
-      setDiff(data.diff || "No differences found.")
+      if (!res.ok) {
+        // Handle expected errors gracefully (commit not found, etc.)
+        setDiff(data.error || "No differences found.")
+      } else {
+        setDiff(data.diff || "No differences found.")
+      }
     } catch {
       setDiff("Failed to load diff.")
     } finally {

--- a/packages/web/components/sidebar/branch-list.tsx
+++ b/packages/web/components/sidebar/branch-list.tsx
@@ -31,6 +31,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
+import { DiffStatsTooltip, diffStatsTooltipClass } from "@/components/ui/diff-stats-tooltip"
 import { useBranchDiffStats } from "./hooks/useBranchDiffStats"
 
 interface BranchListProps {
@@ -355,11 +356,8 @@ export function BranchList({
                       <TooltipTrigger asChild>
                         {branchButton}
                       </TooltipTrigger>
-                      <TooltipContent side="right" className="text-xs bg-white text-gray-900 dark:bg-white dark:text-gray-900">
-                        <span className="flex items-center gap-1.5">
-                          <span className="text-green-600">+{branchDiffStats.additions}</span>
-                          <span className="text-red-600">−{branchDiffStats.deletions}</span>
-                        </span>
+                      <TooltipContent side="right" className={diffStatsTooltipClass}>
+                        <DiffStatsTooltip additions={branchDiffStats.additions} deletions={branchDiffStats.deletions} />
                       </TooltipContent>
                     </Tooltip>
                   ) : (

--- a/packages/web/components/sidebar/branch-list.tsx
+++ b/packages/web/components/sidebar/branch-list.tsx
@@ -26,6 +26,12 @@ import {
   CommandGroup,
   CommandItem,
 } from "@/components/ui/command"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { useBranchDiffStats } from "./hooks/useBranchDiffStats"
 
 interface BranchListProps {
   repo: Repo
@@ -73,6 +79,13 @@ export function BranchList({
   const [githubBranches, setGithubBranches] = useState<string[]>([])
   const [githubBranchesLoading, setGithubBranchesLoading] = useState(false)
   const isResizing = useRef(false)
+
+  // Fetch diff stats for branches with sandboxes
+  const { diffStatsMap } = useBranchDiffStats({
+    branches: repo.branches,
+    repoOwner: repo.owner,
+    repoName: repo.name,
+  })
 
   const filtered = repo.branches
     .filter((b) => b.name.toLowerCase().includes(search.toLowerCase()))
@@ -289,6 +302,18 @@ export function BranchList({
               const isBold = branch.status === BRANCH_STATUS.RUNNING || branch.status === BRANCH_STATUS.CREATING || (branch.unread && !isActive)
               const isDeleting = deleteDialog.deletingBranchId === branch.id
               const isCreating = branch.status === BRANCH_STATUS.CREATING
+              const branchDiffStats = diffStatsMap.get(branch.id)
+
+              // Branch name element - wrapped with tooltip if has diff stats
+              const branchNameElement = (
+                <span className={cn(
+                  "truncate text-sm",
+                  isBold ? "font-semibold text-foreground" : "font-medium"
+                )}>
+                  {branch.name}
+                </span>
+              )
+
               return (
                 <div key={branch.id} className="group relative">
                   <button
@@ -317,12 +342,21 @@ export function BranchList({
                       isDeleting && "opacity-40"
                     )}>
                       <div className="flex items-center gap-2">
-                        <span className={cn(
-                          "truncate text-sm",
-                          isBold ? "font-semibold text-foreground" : "font-medium"
-                        )}>
-                          {branch.name}
-                        </span>
+                        {branchDiffStats ? (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              {branchNameElement}
+                            </TooltipTrigger>
+                            <TooltipContent side="right" className="text-xs">
+                              <span className="flex items-center gap-1.5">
+                                <span className="text-green-400">+{branchDiffStats.additions}</span>
+                                <span className="text-red-400">−{branchDiffStats.deletions}</span>
+                              </span>
+                            </TooltipContent>
+                          </Tooltip>
+                        ) : (
+                          branchNameElement
+                        )}
                       </div>
                       <div className="flex items-center gap-2">
                         <span className="flex items-center gap-1 text-[11px] text-muted-foreground">

--- a/packages/web/components/sidebar/branch-list.tsx
+++ b/packages/web/components/sidebar/branch-list.tsx
@@ -304,68 +304,67 @@ export function BranchList({
               const isCreating = branch.status === BRANCH_STATUS.CREATING
               const branchDiffStats = diffStatsMap.get(branch.id)
 
-              // Branch name element - wrapped with tooltip if has diff stats
-              const branchNameElement = (
-                <span className={cn(
-                  "truncate text-sm",
-                  isBold ? "font-semibold text-foreground" : "font-medium"
-                )}>
-                  {branch.name}
-                </span>
+              const branchButton = (
+                <button
+                  type="button"
+                  onClick={() => onSelectBranch(branch.id)}
+                  disabled={isDeleting}
+                  className={cn(
+                    "flex w-full cursor-pointer items-center gap-2.5 rounded-md px-3 text-left transition-colors",
+                    // Larger touch targets on mobile
+                    isMobile ? "py-3.5 min-h-[56px]" : "py-2.5",
+                    isActive
+                      ? "bg-accent text-foreground"
+                      : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+                    isDeleting && "cursor-not-allowed"
+                  )}
+                >
+                  {isDeleting ? (
+                    <span className="flex h-4 w-4 shrink-0 items-center justify-center">
+                      <Loader2 className="h-4 w-4 animate-spin text-muted-foreground opacity-40" />
+                    </span>
+                  ) : (
+                    <StatusDot status={branch.status} unread={branch.unread} isActive={isActive} />
+                  )}
+                  <div className={cn(
+                    "flex min-w-0 flex-1 flex-col gap-0.5 transition-opacity",
+                    isDeleting && "opacity-40"
+                  )}>
+                    <div className="flex items-center gap-2">
+                      <span className={cn(
+                        "truncate text-sm",
+                        isBold ? "font-semibold text-foreground" : "font-medium"
+                      )}>
+                        {branch.name}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span className="flex items-center gap-1 text-[11px] text-muted-foreground">
+                        <AgentIcon agent={branch.agent || "claude-code"} className="h-2.5 w-2.5" />
+                        {branch.status === BRANCH_STATUS.CREATING ? "Setting up..." : agentLabels[branch.agent || "claude-code"]}
+                      </span>
+                    </div>
+                  </div>
+                </button>
               )
 
               return (
                 <div key={branch.id} className="group relative">
-                  <button
-                    type="button"
-                    onClick={() => onSelectBranch(branch.id)}
-                    disabled={isDeleting}
-                    className={cn(
-                      "flex w-full cursor-pointer items-center gap-2.5 rounded-md px-3 text-left transition-colors",
-                      // Larger touch targets on mobile
-                      isMobile ? "py-3.5 min-h-[56px]" : "py-2.5",
-                      isActive
-                        ? "bg-accent text-foreground"
-                        : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
-                      isDeleting && "cursor-not-allowed"
-                    )}
-                  >
-                    {isDeleting ? (
-                      <span className="flex h-4 w-4 shrink-0 items-center justify-center">
-                        <Loader2 className="h-4 w-4 animate-spin text-muted-foreground opacity-40" />
-                      </span>
-                    ) : (
-                      <StatusDot status={branch.status} unread={branch.unread} isActive={isActive} />
-                    )}
-                    <div className={cn(
-                      "flex min-w-0 flex-1 flex-col gap-0.5 transition-opacity",
-                      isDeleting && "opacity-40"
-                    )}>
-                      <div className="flex items-center gap-2">
-                        {branchDiffStats ? (
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              {branchNameElement}
-                            </TooltipTrigger>
-                            <TooltipContent side="right" className="text-xs">
-                              <span className="flex items-center gap-1.5">
-                                <span className="text-green-400">+{branchDiffStats.additions}</span>
-                                <span className="text-red-400">−{branchDiffStats.deletions}</span>
-                              </span>
-                            </TooltipContent>
-                          </Tooltip>
-                        ) : (
-                          branchNameElement
-                        )}
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <span className="flex items-center gap-1 text-[11px] text-muted-foreground">
-                          <AgentIcon agent={branch.agent || "claude-code"} className="h-2.5 w-2.5" />
-                          {branch.status === BRANCH_STATUS.CREATING ? "Setting up..." : agentLabels[branch.agent || "claude-code"]}
+                  {branchDiffStats ? (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        {branchButton}
+                      </TooltipTrigger>
+                      <TooltipContent side="right" className="text-xs bg-white text-gray-900 dark:bg-white dark:text-gray-900">
+                        <span className="flex items-center gap-1.5">
+                          <span className="text-green-600">+{branchDiffStats.additions}</span>
+                          <span className="text-red-600">−{branchDiffStats.deletions}</span>
                         </span>
-                      </div>
-                    </div>
-                  </button>
+                      </TooltipContent>
+                    </Tooltip>
+                  ) : (
+                    branchButton
+                  )}
                   {!isDeleting && (
                     <button
                       type="button"

--- a/packages/web/components/sidebar/branch-list.tsx
+++ b/packages/web/components/sidebar/branch-list.tsx
@@ -356,7 +356,7 @@ export function BranchList({
                       <TooltipTrigger asChild>
                         {branchButton}
                       </TooltipTrigger>
-                      <TooltipContent side="right" className={diffStatsTooltipClass}>
+                      <TooltipContent side="right" className={diffStatsTooltipClass} hideArrow>
                         <DiffStatsTooltip additions={branchDiffStats.additions} deletions={branchDiffStats.deletions} />
                       </TooltipContent>
                     </Tooltip>

--- a/packages/web/components/sidebar/hooks/useBranchDiffStats.ts
+++ b/packages/web/components/sidebar/hooks/useBranchDiffStats.ts
@@ -1,0 +1,119 @@
+import { useState, useEffect, useRef, useCallback } from "react"
+import type { Branch } from "@/lib/shared/types"
+
+export interface DiffStats {
+  additions: number
+  deletions: number
+}
+
+interface UseBranchDiffStatsOptions {
+  branches: Branch[]
+  repoOwner: string
+  repoName: string
+}
+
+/**
+ * Fetches and caches diff stats for branches that have sandboxes.
+ * Only fetches for branches with sandboxId (active branches).
+ */
+export function useBranchDiffStats({
+  branches,
+  repoOwner,
+  repoName,
+}: UseBranchDiffStatsOptions) {
+  // Map of branchId -> diffStats
+  const [diffStatsMap, setDiffStatsMap] = useState<Map<string, DiffStats>>(new Map())
+  // Track which branches we've already fetched to avoid duplicate requests
+  const fetchedRef = useRef<Set<string>>(new Set())
+  // Track in-flight requests
+  const pendingRef = useRef<Set<string>>(new Set())
+
+  const fetchDiffStats = useCallback(async (branch: Branch) => {
+    if (!branch.sandboxId || !branch.baseBranch) return
+    if (fetchedRef.current.has(branch.id) || pendingRef.current.has(branch.id)) return
+
+    pendingRef.current.add(branch.id)
+
+    try {
+      const res = await fetch("/api/github/compare", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          owner: repoOwner,
+          repo: repoName,
+          base: branch.baseBranch,
+          head: branch.name,
+        }),
+      })
+
+      if (!res.ok) {
+        fetchedRef.current.add(branch.id)
+        pendingRef.current.delete(branch.id)
+        return
+      }
+
+      const data = await res.json()
+      const hasDiff = data.diff && data.diff.trim() !== "" && data.diff !== "No differences found."
+
+      if (hasDiff && data.diff) {
+        const lines = data.diff.split("\n")
+        let additions = 0
+        let deletions = 0
+        for (const line of lines) {
+          if (line.startsWith("+") && !line.startsWith("+++")) {
+            additions++
+          } else if (line.startsWith("-") && !line.startsWith("---")) {
+            deletions++
+          }
+        }
+
+        if (additions > 0 || deletions > 0) {
+          setDiffStatsMap(prev => {
+            const next = new Map(prev)
+            next.set(branch.id, { additions, deletions })
+            return next
+          })
+        }
+      }
+
+      fetchedRef.current.add(branch.id)
+    } catch {
+      // Ignore errors
+    } finally {
+      pendingRef.current.delete(branch.id)
+    }
+  }, [repoOwner, repoName])
+
+  // Fetch diff stats for branches with sandboxes
+  useEffect(() => {
+    const branchesWithSandbox = branches.filter(b => b.sandboxId && b.baseBranch)
+    for (const branch of branchesWithSandbox) {
+      fetchDiffStats(branch)
+    }
+  }, [branches, fetchDiffStats])
+
+  // Method to refresh stats for a specific branch (e.g., after status change)
+  const refreshBranch = useCallback((branchId: string) => {
+    fetchedRef.current.delete(branchId)
+    const branch = branches.find(b => b.id === branchId)
+    if (branch) {
+      fetchDiffStats(branch)
+    }
+  }, [branches, fetchDiffStats])
+
+  // Method to clear cache for a branch (e.g., when deleted)
+  const clearBranch = useCallback((branchId: string) => {
+    fetchedRef.current.delete(branchId)
+    setDiffStatsMap(prev => {
+      const next = new Map(prev)
+      next.delete(branchId)
+      return next
+    })
+  }, [])
+
+  return {
+    diffStatsMap,
+    refreshBranch,
+    clearBranch,
+  }
+}

--- a/packages/web/components/ui/diff-stats-tooltip.tsx
+++ b/packages/web/components/ui/diff-stats-tooltip.tsx
@@ -1,0 +1,64 @@
+"use client"
+
+import { cn } from "@/lib/shared/utils"
+
+interface DiffStatsTooltipProps {
+  additions: number
+  deletions: number
+  className?: string
+}
+
+/**
+ * GitHub-style diff stats display with segmented bar.
+ * Shows +additions / -deletions with a 5-segment proportional bar.
+ */
+export function DiffStatsTooltip({ additions, deletions, className }: DiffStatsTooltipProps) {
+  const total = additions + deletions
+
+  // Calculate segments (5 total, like GitHub)
+  // Each segment represents 20% of changes
+  let greenSegments = 0
+  let redSegments = 0
+
+  if (total > 0) {
+    // Calculate proportions and round to nearest segment
+    const greenRatio = additions / total
+    greenSegments = Math.round(greenRatio * 5)
+    redSegments = 5 - greenSegments
+
+    // Ensure at least 1 segment for non-zero values
+    if (additions > 0 && greenSegments === 0) greenSegments = 1
+    if (deletions > 0 && redSegments === 0) redSegments = 1
+
+    // Adjust if we went over 5
+    if (greenSegments + redSegments > 5) {
+      if (additions > deletions) redSegments = 5 - greenSegments
+      else greenSegments = 5 - redSegments
+    }
+  }
+
+  return (
+    <div className={cn("flex items-center gap-2", className)}>
+      <span className="text-green-600 font-medium">+{additions}</span>
+      <span className="text-red-600 font-medium">−{deletions}</span>
+      {total > 0 && (
+        <span className="flex gap-px">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <span
+              key={i}
+              className={cn(
+                "w-1.5 h-2 rounded-[1px]",
+                i < greenSegments ? "bg-green-500" : "bg-red-500"
+              )}
+            />
+          ))}
+        </span>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Tooltip class for diff stats - white background with shadow, no arrow
+ */
+export const diffStatsTooltipClass = "text-xs bg-white text-gray-900 shadow-lg border border-gray-200 [&>svg]:hidden"

--- a/packages/web/components/ui/diff-stats-tooltip.tsx
+++ b/packages/web/components/ui/diff-stats-tooltip.tsx
@@ -59,6 +59,7 @@ export function DiffStatsTooltip({ additions, deletions, className }: DiffStatsT
 }
 
 /**
- * Tooltip class for diff stats - white background with shadow, no arrow
+ * Tooltip class for diff stats - white background with shadow
+ * Use with hideArrow prop on TooltipContent
  */
-export const diffStatsTooltipClass = "text-xs bg-white text-gray-900 shadow-lg border border-gray-200 [&>svg]:hidden"
+export const diffStatsTooltipClass = "text-xs bg-white text-gray-900 shadow-lg border border-gray-200"

--- a/packages/web/components/ui/tooltip.tsx
+++ b/packages/web/components/ui/tooltip.tsx
@@ -38,8 +38,9 @@ function TooltipContent({
   className,
   sideOffset = 0,
   children,
+  hideArrow = false,
   ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+}: React.ComponentProps<typeof TooltipPrimitive.Content> & { hideArrow?: boolean }) {
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Content
@@ -52,7 +53,9 @@ function TooltipContent({
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+        {!hideArrow && (
+          <TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+        )}
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   )


### PR DESCRIPTION
**Summary**  
This PR improves the GitHub compare API error handling, adds informative diff‑stat tooltips in the UI, introduces a hook for caching diff data, and refines tooltip styling and interaction.  

## Changes  

- **API Enhancements**  
  - `/api/github/compare` now returns appropriate GitHub status codes: 404 for missing branches/commits, an empty diff when there are no commits between branches, and passes through other errors unchanged.  
  - Client-side code updated to handle non‑200 responses gracefully without throwing errors.  

- **Diff UI Improvements**  
  - Tooltip on the diff icon in the chat header now shows the count of lines added (green) and removed (red) parsed from the unified diff.  
  - Branch names in the sidebar display a tooltip with added/removed line counts when that branch differs from its base branch.  

- **New Hook**  
  - `useBranchDiffStats` fetches and caches diff statistics using the existing compare endpoint, but only for branches that have active sandboxes and shows tooltips when changes are present.  

- **Tooltip Styling & Interaction**  
  - Diff‑stat tooltips now have a white background with darker green/red text (600) for better readability.  
  - Sidebar branch tooltip trigger now wraps the entire button, fixing hover behavior.  

These updates provide clearer feedback to users, improve error visibility, and streamline diff‑stat access across the application.