### PR TITLE
Capture and display shell command output in Tool Call timeline

### DIFF
--- a/packages/agents/src/agents/gemini/index.ts
+++ b/packages/agents/src/agents/gemini/index.ts
@@ -58,7 +58,7 @@ export const geminiAgent: AgentDefinition = {
     }
   },
 
-  parse(line: string, context: ParseContext): Event | null {
+  parse(line: string, context: ParseContext): Event | Event[] | null {
     return parseGeminiLine(line, this.toolMappings, context)
   },
 }

--- a/packages/agents/src/agents/gemini/parser.ts
+++ b/packages/agents/src/agents/gemini/parser.ts
@@ -3,6 +3,20 @@
  *
  * Pure function for parsing Gemini CLI JSON output.
  * Note: Gemini requires stateful parsing for tool output buffering.
+ *
+ * Reference schema (from actual CLI output):
+ *   { type: "init", session_id }
+ *   { type: "message", role, content, delta? }
+ *   { type: "tool_use", tool_name, tool_id, parameters }   ← tool starts
+ *   { type: "tool_result", tool_id, status, output? }      ← tool ends
+ *   { type: "result", status, stats }                      ← turn end
+ *
+ * Legacy schema (older CLI versions — kept for compatibility):
+ *   { type: "assistant.delta", text }
+ *   { type: "tool.start", name, input? }
+ *   { type: "tool.delta", text }
+ *   { type: "tool.end" }
+ *   { type: "assistant.complete" }
  */
 
 import type { Event } from "../../types/events.js"
@@ -35,6 +49,23 @@ interface GeminiResult {
   status: string
 }
 
+/** Current Gemini CLI: tool invocation */
+interface GeminiToolUse {
+  type: "tool_use"
+  tool_name: string
+  tool_id: string
+  parameters?: unknown
+}
+
+/** Current Gemini CLI: tool result (output of invocation) */
+interface GeminiToolResult {
+  type: "tool_result"
+  tool_id: string
+  status: string
+  output?: string
+}
+
+/** Legacy Gemini CLI */
 interface GeminiToolStart {
   type: "tool.start"
   name: string
@@ -59,6 +90,8 @@ type GeminiEvent =
   | GeminiAssistantDelta
   | GeminiMessage
   | GeminiResult
+  | GeminiToolUse
+  | GeminiToolResult
   | GeminiToolStart
   | GeminiToolDelta
   | GeminiToolEnd
@@ -67,13 +100,15 @@ type GeminiEvent =
 /**
  * Parse a line of Gemini CLI output into event(s).
  *
- * Uses context.state.toolOutputBuffer for stateful tool output accumulation.
+ * Uses context.state for stateful tracking:
+ *   - pendingToolIds: Map<tool_id, true> — tracks tool_use events awaiting their tool_result
+ *   - toolOutputBuffer: string — legacy streaming buffer
  */
 export function parseGeminiLine(
   line: string,
   toolMappings: Record<string, string>,
   context: ParseContext
-): Event | null {
+): Event | Event[] | null {
   const json = safeJsonParse<GeminiEvent>(line)
   if (!json) {
     return null
@@ -89,7 +124,7 @@ export function parseGeminiLine(
     return { type: "token", text: json.text }
   }
 
-  // Message event (new format)
+  // Message event (current Gemini format) — text only, tool calls are separate
   if (json.type === "message") {
     if (json.role === "assistant" && json.content) {
       return { type: "token", text: json.content }
@@ -98,12 +133,42 @@ export function parseGeminiLine(
     return null
   }
 
-  // Result event (new format) - marks completion
+  // Result event — marks turn completion
   if (json.type === "result") {
     return { type: "end" }
   }
 
-  // Tool start
+  // ── Current Gemini format: tool_use + tool_result ──────────────────────────
+
+  // tool_use: the agent is invoking a tool.
+  // We emit tool_start immediately, and stash the tool_id so we can pair the output.
+  if (json.type === "tool_use") {
+    const name = normalizeToolName(json.tool_name.toLowerCase(), toolMappings)
+    // Track pending tool_id → tool event pairing in parse context
+    if (!context.state.pendingToolIds) {
+      context.state.pendingToolIds = {}
+    }
+    // Store the normalized name so tool_result can reference it (not strictly needed but aids debugging)
+    ;(context.state.pendingToolIds as Record<string, string>)[json.tool_id] = name
+    return createToolStartEvent(name, json.parameters, toolMappings)
+  }
+
+  // tool_result: the tool invocation completed, contains stdout/stderr in output.
+  // We pair it with the most recently started tool_use via tool_id.
+  if (json.type === "tool_result") {
+    // Clean up the tracked tool_id
+    if (context.state.pendingToolIds) {
+      delete (context.state.pendingToolIds as Record<string, string>)[json.tool_id]
+    }
+    const output = typeof json.output === "string" && json.output.trim()
+      ? json.output.trim()
+      : undefined
+    return { type: "tool_end", output }
+  }
+
+  // ── Legacy Gemini streaming format ────────────────────────────────────────
+
+  // Tool start (legacy)
   if (json.type === "tool.start") {
     context.state.toolOutputBuffer = ""
     const name = normalizeToolName(json.name.toLowerCase(), toolMappings)

--- a/packages/agents/src/agents/opencode/index.ts
+++ b/packages/agents/src/agents/opencode/index.ts
@@ -65,7 +65,7 @@ export const opencodeAgent: AgentDefinition = {
     }
   },
 
-  parse(line: string, context: ParseContext): Event | null {
+  parse(line: string, context: ParseContext): Event | Event[] | null {
     return parseOpencodeLine(line, this.toolMappings, context)
   },
 }

--- a/packages/agents/src/agents/opencode/parser.ts
+++ b/packages/agents/src/agents/opencode/parser.ts
@@ -105,7 +105,7 @@ export function parseOpencodeLine(
   line: string,
   toolMappings: Record<string, string>,
   context: ParseContext
-): Event | null {
+): Event | Event[] | null {
   const json = safeJsonParse<OpenCodeEvent>(line)
   if (!json) {
     return null
@@ -134,15 +134,23 @@ export function parseOpencodeLine(
     return createToolStartEvent(normalized, json.part?.args, toolMappings)
   }
 
-  // Tool use (stream-json: emitted when tool completes)
+  // Tool use (stream-json: emitted when tool completes with full state)
   if (json.type === "tool_use") {
     const toolName = (json.part?.tool || "unknown").toLowerCase()
     const normalized = normalizeToolName(toolName, toolMappings)
-    const raw = json.part as { state?: { input?: unknown } } | undefined
-    return createToolStartEvent(normalized, raw?.state?.input, toolMappings)
+    const raw = json.part as { state?: { status?: string; input?: unknown; output?: string } } | undefined
+    const startEvent = createToolStartEvent(normalized, raw?.state?.input, toolMappings)
+
+    // If the tool already completed (state.output is present), emit tool_end inline.
+    // This is the common case for OpenCode: tool_use carries the full result.
+    const rawOutput = raw?.state?.output
+    if (typeof rawOutput === "string" && rawOutput.trim()) {
+      return [startEvent, { type: "tool_end", output: rawOutput.trim() }]
+    }
+    return startEvent
   }
 
-  // Tool result - tool completed
+  // Tool result - tool completed (streaming / in-progress path, no output here)
   if (json.type === "tool_result") {
     return { type: "tool_end" }
   }

--- a/packages/agents/tests/parsers.test.ts
+++ b/packages/agents/tests/parsers.test.ts
@@ -241,6 +241,93 @@ describe("parseGeminiLine", () => {
     expect(event).toEqual({ type: "end" })
   })
 
+  it("parses message event (current format) for assistant text", () => {
+    const ctx = createContext()
+    const event = parseGeminiLine(
+      JSON.stringify({ type: "message", role: "assistant", content: "2 + 2 equals 4.", delta: true }),
+      mappings,
+      ctx
+    )
+    expect(event).toEqual({ type: "token", text: "2 + 2 equals 4." })
+  })
+
+  it("ignores message event for user role", () => {
+    const ctx = createContext()
+    const event = parseGeminiLine(
+      JSON.stringify({ type: "message", role: "user", content: "Please do X." }),
+      mappings,
+      ctx
+    )
+    expect(event).toBeNull()
+  })
+
+  it("parses result event (current format) as end", () => {
+    const ctx = createContext()
+    const event = parseGeminiLine(
+      JSON.stringify({ type: "result", status: "success", stats: {} }),
+      mappings,
+      ctx
+    )
+    expect(event).toEqual({ type: "end" })
+  })
+
+  it("parses tool_use event (current format) as tool_start", () => {
+    const ctx = createContext()
+    const event = parseGeminiLine(
+      JSON.stringify({
+        type: "tool_use",
+        tool_name: "run_shell_command",
+        tool_id: "abc123",
+        parameters: { command: "ls", description: "List files" },
+      }),
+      mappings,
+      ctx
+    )
+    // run_shell_command is not in GEMINI_TOOL_MAPPINGS, so it passes through normalized
+    expect(event).toMatchObject({ type: "tool_start", name: "run_shell_command" })
+  })
+
+  it("parses tool_use for known tool and normalizes name", () => {
+    const ctx = createContext()
+    const event = parseGeminiLine(
+      JSON.stringify({
+        type: "tool_use",
+        tool_name: "execute_code",
+        tool_id: "xyz789",
+        parameters: { command: "echo hi" },
+      }),
+      mappings,
+      ctx
+    )
+    expect(event).toEqual({ type: "tool_start", name: "shell", input: { command: "echo hi" } })
+  })
+
+  it("parses tool_result event (current format) with output", () => {
+    const ctx = createContext()
+    // First emit a tool_use to track the tool_id
+    parseGeminiLine(
+      JSON.stringify({ type: "tool_use", tool_name: "run_shell_command", tool_id: "abc123", parameters: {} }),
+      mappings,
+      ctx
+    )
+    const event = parseGeminiLine(
+      JSON.stringify({ type: "tool_result", tool_id: "abc123", status: "success", output: "hello.txt" }),
+      mappings,
+      ctx
+    )
+    expect(event).toEqual({ type: "tool_end", output: "hello.txt" })
+  })
+
+  it("parses tool_result with no output (empty string) as undefined output", () => {
+    const ctx = createContext()
+    const event = parseGeminiLine(
+      JSON.stringify({ type: "tool_result", tool_id: "noop", status: "success", output: "" }),
+      mappings,
+      ctx
+    )
+    expect(event).toEqual({ type: "tool_end", output: undefined })
+  })
+
   it("returns null for unknown event types", () => {
     const ctx = createContext()
     expect(parseGeminiLine('{"type": "unknown"}', mappings, ctx)).toBeNull()

--- a/packages/web/components/chat/message-bubble.tsx
+++ b/packages/web/components/chat/message-bubble.tsx
@@ -123,6 +123,9 @@ interface FilePreviewContent {
 
 const PREVIEW_LINES = 50
 
+/** Tool names whose output (stdout/stderr) should be shown in the timeline. */
+const TOOL_OUTPUT_TOOLS = ["Bash", "Shell", "Exec", "Run"] as const
+
 /**
  * Format file size for display
  */
@@ -372,9 +375,10 @@ function ToolCallTimeline({ toolCalls, sandboxId, repoPath }: { toolCalls: ToolC
           // Check if this is a file-related tool with a file path
           const isFileRelatedTool = ["Read", "Edit", "Write"].includes(tc.tool)
           const hasFilePath = isFileRelatedTool && tc.filePath
-          // Only show output dropdown for commands that produce stdout/stderr
-          const hasOutput = typeof tc.output === "string" && tc.output.length > 0
-
+          // Only show output chevron for shell commands that produce stdout/stderr
+          const hasOutput = TOOL_OUTPUT_TOOLS.includes(tc.tool as typeof TOOL_OUTPUT_TOOLS[number]) &&
+                            typeof tc.output === "string" && tc.output.length > 0
+                            
           return (
             <div key={tc.id} className="relative py-[5px] min-w-0">
               <div className="flex items-start gap-2.5 min-w-0">

--- a/packages/web/components/chat/message-bubble.tsx
+++ b/packages/web/components/chat/message-bubble.tsx
@@ -19,6 +19,7 @@ import {
   Loader2,
   AlertCircle,
   FileCode,
+  ChevronRight,
 } from "lucide-react"
 import { AgentIcon } from "@/components/icons/agent-icons"
 import { NoticeIcon, type NoticeIconType } from "@/components/icons/notice-icons"
@@ -61,6 +62,51 @@ function ToolCallIcon({ tool }: { tool: string }) {
     default:
       return <Terminal className={cls} />
   }
+}
+
+// ============================================================================
+// Shell Output Collapsible
+// ============================================================================
+
+/**
+ * Renders the captured stdout/stderr of a shell command.
+ * - Single-line output: always expanded (no toggle needed).
+ * - Multi-line output: collapsed by default, toggled with a chevron.
+ * Only rendered when output is a non-empty string — never produces an
+ * empty element, so old DB records (output === undefined) are safe.
+ */
+function ShellOutput({ output }: { output: string }) {
+  const isMultiLine = output.includes("\n")
+  const [expanded, setExpanded] = useState(!isMultiLine)
+
+  if (!isMultiLine) {
+    // Single line — always visible, no toggle
+    return (
+      <div className="ml-[12px] mt-0.5 rounded bg-muted/50 border border-border/50 px-2 py-1">
+        <pre className="font-mono text-[10px] text-muted-foreground whitespace-pre-wrap break-all leading-4">{output}</pre>
+      </div>
+    )
+  }
+
+  return (
+    <div className="ml-[12px] mt-0.5">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="flex items-center gap-1 text-[10px] text-muted-foreground/60 hover:text-muted-foreground transition-colors cursor-pointer"
+      >
+        <ChevronRight
+          className={cn("h-3 w-3 transition-transform duration-150", expanded && "rotate-90")}
+        />
+        <span>{expanded ? "Hide output" : "Show output"}</span>
+      </button>
+      {expanded && (
+        <div className="mt-1 rounded bg-muted/50 border border-border/50 px-2 py-1.5 max-h-[300px] overflow-y-auto">
+          <pre className="font-mono text-[10px] text-muted-foreground whitespace-pre-wrap break-all leading-4">{output}</pre>
+        </div>
+      )}
+    </div>
+  )
 }
 
 // ============================================================================
@@ -326,36 +372,41 @@ function ToolCallTimeline({ toolCalls, sandboxId, repoPath }: { toolCalls: ToolC
           // Check if this is a file-related tool with a file path
           const isFileRelatedTool = ["Read", "Edit", "Write"].includes(tc.tool)
           const hasFilePath = isFileRelatedTool && tc.filePath
+          // Only show output dropdown for commands that produce stdout/stderr
+          const hasOutput = typeof tc.output === "string" && tc.output.length > 0
 
           return (
-            <div key={tc.id} className="relative flex items-start gap-2.5 py-[5px] min-w-0">
-              <div className="relative z-10 flex h-[12px] w-[12px] shrink-0 items-center justify-center text-muted-foreground mt-0.5">
-                <ToolCallIcon tool={tc.tool} />
+            <div key={tc.id} className="relative py-[5px] min-w-0">
+              <div className="flex items-start gap-2.5 min-w-0">
+                <div className="relative z-10 flex h-[12px] w-[12px] shrink-0 items-center justify-center text-muted-foreground mt-0.5">
+                  <ToolCallIcon tool={tc.tool} />
+                </div>
+                {hasFilePath ? (
+                  <FilePathLink
+                    filePath={tc.filePath!}
+                    displayText={tc.summary}
+                    fullSummary={tc.fullSummary}
+                    sandboxId={sandboxId}
+                    repoPath={repoPath}
+                  />
+                ) : tc.fullSummary ? (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="text-xs text-muted-foreground break-words min-w-0">
+                        {tc.summary}
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent side="top" className="max-w-md font-mono text-[10px] whitespace-pre-wrap [overflow-wrap:anywhere]">
+                      {tc.fullSummary}
+                    </TooltipContent>
+                  </Tooltip>
+                ) : (
+                  <span className="text-xs text-muted-foreground break-words min-w-0">
+                    {tc.summary}
+                  </span>
+                )}
               </div>
-              {hasFilePath ? (
-                <FilePathLink
-                  filePath={tc.filePath!}
-                  displayText={tc.summary}
-                  fullSummary={tc.fullSummary}
-                  sandboxId={sandboxId}
-                  repoPath={repoPath}
-                />
-              ) : tc.fullSummary ? (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="text-xs text-muted-foreground break-words min-w-0">
-                      {tc.summary}
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent side="top" className="max-w-md font-mono text-[10px] whitespace-pre-wrap [overflow-wrap:anywhere]">
-                    {tc.fullSummary}
-                  </TooltipContent>
-                </Tooltip>
-              ) : (
-                <span className="text-xs text-muted-foreground break-words min-w-0">
-                  {tc.summary}
-                </span>
-              )}
+              {hasOutput && <ShellOutput output={tc.output!} />}
             </div>
           )
         })}

--- a/packages/web/lib/agents/agent-session.ts
+++ b/packages/web/lib/agents/agent-session.ts
@@ -59,7 +59,7 @@ export type ContentBlock = {
   text: string
 } | {
   type: "tool_calls"
-  toolCalls: Array<{ tool: string; summary: string; fullSummary?: string; filePath?: string }>
+  toolCalls: Array<{ tool: string; summary: string; fullSummary?: string; filePath?: string; output?: string }>
 }
 
 export interface AgentCrashedPayload {
@@ -70,7 +70,7 @@ export interface AgentCrashedPayload {
 export interface BackgroundPollResult {
   status: "running" | "completed" | "error"
   content: string
-  toolCalls: Array<{ tool: string; summary: string; fullSummary?: string }>
+  toolCalls: Array<{ tool: string; summary: string; fullSummary?: string; output?: string }>
   contentBlocks: ContentBlock[]
   error?: string
   agentCrashed?: AgentCrashedPayload
@@ -191,13 +191,16 @@ function getToolDetail(toolName: string, input: unknown): ToolDetailResult {
 // ContentBlocks Builder (for background execution results)
 // =============================================================================
 
+/** Maximum characters to store/display for a single multi-line tool output. */
+const TOOL_OUTPUT_MAX_CHARS = 4000
+
 export function buildContentBlocks(
   events: Event[]
-): { content: string; toolCalls: Array<{ tool: string; summary: string; fullSummary?: string; filePath?: string }>; contentBlocks: ContentBlock[] } {
+): { content: string; toolCalls: Array<{ tool: string; summary: string; fullSummary?: string; filePath?: string; output?: string }>; contentBlocks: ContentBlock[] } {
   const blocks: ContentBlock[] = []
   let pendingText = ""
-  let pendingToolCalls: Array<{ tool: string; summary: string; fullSummary?: string; filePath?: string }> = []
-  const allToolCalls: Array<{ tool: string; summary: string; fullSummary?: string; filePath?: string }> = []
+  let pendingToolCalls: Array<{ tool: string; summary: string; fullSummary?: string; filePath?: string; output?: string }> = []
+  const allToolCalls: Array<{ tool: string; summary: string; fullSummary?: string; filePath?: string; output?: string }> = []
   let allContent = ""
 
   for (const event of events) {
@@ -224,6 +227,20 @@ export function buildContentBlocks(
       const toolCall = { tool, summary, fullSummary, filePath }
       pendingToolCalls.push(toolCall)
       allToolCalls.push(toolCall)
+    } else if (event.type === "tool_end") {
+      const toolEndEvent = event as ToolEndEvent
+      const rawOutput = toolEndEvent.output
+      // Attach output to the last tool call if one exists and output is non-empty.
+      // Both pendingToolCalls and allToolCalls hold references to the same objects, so
+      // mutating via allToolCalls propagates to pendingToolCalls and any already-flushed
+      // blocks (which hold shallow-copied arrays of the same object references).
+      if (rawOutput && rawOutput.trim() && allToolCalls.length > 0) {
+        let output = rawOutput.trim()
+        if (output.length > TOOL_OUTPUT_MAX_CHARS) {
+          output = output.slice(0, TOOL_OUTPUT_MAX_CHARS) + "\n… (output truncated)"
+        }
+        allToolCalls[allToolCalls.length - 1].output = output
+      }
     }
   }
 

--- a/packages/web/lib/core/polling/polling-state.ts
+++ b/packages/web/lib/core/polling/polling-state.ts
@@ -37,6 +37,8 @@ export interface ToolCall {
   tool: string
   summary: string
   fullSummary?: string
+  filePath?: string
+  output?: string
 }
 
 export interface ContentBlock {
@@ -328,6 +330,8 @@ export function addToolCallIds(toolCalls: ToolCall[]): ToolCallWithId[] {
     tool: tc.tool,
     summary: tc.summary,
     fullSummary: tc.fullSummary,
+    filePath: tc.filePath,
+    output: tc.output,
     timestamp,
   }))
 }
@@ -349,6 +353,8 @@ export function addContentBlockIds(contentBlocks: ContentBlock[]): ContentBlockW
           tool: tc.tool,
           summary: tc.summary,
           fullSummary: tc.fullSummary,
+          filePath: tc.filePath,
+          output: tc.output,
           timestamp,
         })),
       }

--- a/packages/web/lib/shared/types.ts
+++ b/packages/web/lib/shared/types.ts
@@ -278,6 +278,8 @@ export interface ToolCall {
   summary: string
   fullSummary?: string // Full summary when truncated (for hover tooltip)
   filePath?: string // Full file path for file-related tools (Read, Edit, Write)
+  /** stdout/stderr captured from the command; only present when the agent emits it */
+  output?: string
   timestamp: string
 }
 


### PR DESCRIPTION
## Summary

Captures and surfaces stdout/stderr from tool executions (e.g. `Bash`, `npm test`) in the Tool Timeline. Adds collapsible output UI, implements Gemini CLI JSONL parsing, and fixes a data loss issue where tool output never reached the frontend.

## Problem

Tool outputs were present in provider JSONL streams (Claude, Codex, Gemini, OpenCode) but never rendered due to breaks across the pipeline:

1. Gemini and OpenCode parsers did not extract `output` from current schemas
2. `addToolCallIds()` in the web layer stripped `output` during transformation
3. UI components expected output but received none

## Changes

### Parser Fixes (SDK)

**Gemini (`parser.ts`)**

* Introduced `GeminiToolUse` and `GeminiToolResult` types aligned with current CLI schema
* Mapped:

  * `tool_use` → `tool_start`
  * `tool_result` → `tool_end` (with `output`)
* Preserved support for legacy schema (`tool.start` / `tool.delta` / `tool.end`)
* Added schema reference documentation

**OpenCode (`parser.ts`)**

* Extracted `state.output` from `tool_use` events
* Emits `[tool_start, tool_end]` when output exists

**Gemini / OpenCode (`index.ts`)**

* Corrected `parse` return type:
  `Event | null` → `Event | Event[] | null`

### Web Layer Fix

**`polling-state.ts`**

* `addToolCallIds()` now preserves:

  * `output`
  * `filePath`
* Same fix applied in `addContentBlockIds()`
* Updated `ToolCall` type to include both fields

### UI

**`message-bubble.tsx`**

* Output rendering enabled for shell-like tools (`Bash`, `Shell`, `Exec`, `Run`)
* Behavior:

  * Single-line output: inline display
  * Multi-line output: truncated at 4000 characters with indicator
  * Expand/collapse via chevron
* File operations (`Read`, `Write`, `Edit`) excluded from output UI

### Tests

**`parsers.test.ts`**

* Added coverage for:

  * Gemini: message/result events, tool lifecycle, output presence/absence
  * OpenCode: `tool_use` with `state.output`

## Validation

* TypeScript build passes
* Unit and integration tests pass (`@upstream/agents`)
* Manual verification confirms correct rendering and interaction of tool output in UI
