### PR TITLE
Add missing CLI tool name mappings for Gemini agent

### DIFF
--- a/packages/agents/src/agents/gemini/tools.ts
+++ b/packages/agents/src/agents/gemini/tools.ts
@@ -15,6 +15,7 @@ export const GEMINI_TOOL_MAPPINGS: Record<string, string> = {
   write_todos: "write",
   read_file: "read",
   apply_patch: "edit",
+  replace: "edit",
   // Search
   glob_file_search: "glob",
   list_directory: "glob",

--- a/packages/agents/src/agents/gemini/tools.ts
+++ b/packages/agents/src/agents/gemini/tools.ts
@@ -5,12 +5,18 @@
  */
 
 export const GEMINI_TOOL_MAPPINGS: Record<string, string> = {
+  // Shell / command execution
   execute_code: "shell",
   run_command: "shell",
+  run_shell_command: "shell",
   bash: "shell",
+  // File operations
   write_file: "write",
+  write_todos: "write",
   read_file: "read",
   apply_patch: "edit",
+  // Search
   glob_file_search: "glob",
+  list_directory: "glob",
   grep_search: "grep",
 }


### PR DESCRIPTION
## Summary

Adds missing tool name mappings for the Gemini CLI agent so its tool calls render with correct canonical names in the Tool Timeline UI.

## Problem

Gemini's CLI emits tool names that weren't mapped in `GEMINI_TOOL_MAPPINGS`, causing them to appear as raw lowercase strings instead of their canonical display names:

| Gemini emits | Was showing | Should show |
|---|---|---|
| `run_shell_command` | `run_shell_command` | `Bash` |
| `write_todos` | `write_todos` | `Write` |
| `list_directory` | `list_directory` | `Glob` |
| `replace` | `replace` | `Edit` |

## Changes

**`packages/agents/src/agents/gemini/tools.ts`**

Added 4 missing mappings:
- `run_shell_command` → `shell` (note: `bash` was present but the actual CLI emits `run_shell_command`)
- `write_todos` → `write`
- `list_directory` → `glob`
- `replace` → `edit`

Closes #39 