### PR TITLE
Feat/gemini 3.1 pro model fixes

### DIFF
--- a/packages/common/src/agents.ts
+++ b/packages/common/src/agents.ts
@@ -93,7 +93,7 @@ export const agentModels: Record<Agent, ModelOption[]> = {
     { value: "opencode/gpt-5-codex", label: "GPT-5 Codex", requiresKey: "opencode" },
     { value: "opencode/gpt-5-nano", label: "GPT-5 Nano", requiresKey: "opencode" },
     { value: "opencode/gemini-3-flash", label: "Gemini 3 Flash", requiresKey: "opencode" },
-    { value: "opencode/gemini-3.1-pro-preview", label: "Gemini 3.1 Pro", requiresKey: "opencode" },
+    { value: "opencode/gemini-3.1-pro", label: "Gemini 3.1 Pro", requiresKey: "opencode" },
     { value: "opencode/kimi-k2.5", label: "Kimi K2.5", requiresKey: "opencode" },
     // Anthropic direct models (requires Anthropic API key)
     { value: "anthropic/claude-sonnet-4-5", label: "Claude Sonnet 4.5", requiresKey: "anthropic" },

--- a/packages/common/src/agents.ts
+++ b/packages/common/src/agents.ts
@@ -93,7 +93,7 @@ export const agentModels: Record<Agent, ModelOption[]> = {
     { value: "opencode/gpt-5-codex", label: "GPT-5 Codex", requiresKey: "opencode" },
     { value: "opencode/gpt-5-nano", label: "GPT-5 Nano", requiresKey: "opencode" },
     { value: "opencode/gemini-3-flash", label: "Gemini 3 Flash", requiresKey: "opencode" },
-    { value: "opencode/gemini-3-pro", label: "Gemini 3 Pro", requiresKey: "opencode" },
+    { value: "opencode/gemini-3.1-pro-preview", label: "Gemini 3.1 Pro", requiresKey: "opencode" },
     { value: "opencode/kimi-k2.5", label: "Kimi K2.5", requiresKey: "opencode" },
     // Anthropic direct models (requires Anthropic API key)
     { value: "anthropic/claude-sonnet-4-5", label: "Claude Sonnet 4.5", requiresKey: "anthropic" },
@@ -137,6 +137,7 @@ export const agentModels: Record<Agent, ModelOption[]> = {
   "gemini": [
     { value: "gemini-2.5-flash", label: "Gemini 2.5 Flash (Recommended)", requiresKey: "gemini" },
     { value: "gemini-2.5-pro", label: "Gemini 2.5 Pro", requiresKey: "gemini" },
+    { value: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro", requiresKey: "gemini" },
     { value: "gemini-2.0-flash", label: "Gemini 2.0 Flash", requiresKey: "gemini" },
   ],
   "goose": [

--- a/packages/simple-chat/components/modals/SettingsModal.tsx
+++ b/packages/simple-chat/components/modals/SettingsModal.tsx
@@ -313,7 +313,7 @@ export function SettingsModal({ open, onClose, settings, onSave, highlightKey }:
                 placeholder="..."
                 highlight={highlightKey === "opencode"}
                 inputRef={opencodeInputRef}
-                helpUrl="https://opencode.ai"
+                helpUrl="https://opencode.ai/auth"
                 helpText="Get key"
               />
 

--- a/packages/web/components/chat/chat-input.tsx
+++ b/packages/web/components/chat/chat-input.tsx
@@ -78,12 +78,14 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
     // Group models by requirement for display
     const modelSections = useMemo(() => {
       const freeModels = availableModels.filter(m => m.requiresKey === "none")
+      const opencodeModels = availableModels.filter(m => m.requiresKey === "opencode")
       const anthropicModels = availableModels.filter(m => m.requiresKey === "anthropic")
       const openaiModels = availableModels.filter(m => m.requiresKey === "openai")
       const geminiModels = availableModels.filter(m => m.requiresKey === "gemini")
       const sections: { label: string; models: typeof availableModels }[] = []
 
       if (freeModels.length > 0) sections.push({ label: "Free", models: freeModels })
+      if (opencodeModels.length > 0) sections.push({ label: "OpenCode", models: opencodeModels })
       if (anthropicModels.length > 0) sections.push({ label: "Anthropic", models: anthropicModels })
       if (openaiModels.length > 0) sections.push({ label: "OpenAI", models: openaiModels })
       if (geminiModels.length > 0) sections.push({ label: "Gemini", models: geminiModels })
@@ -147,7 +149,14 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
       // Check if user has credentials for this model (pass current agent for proper credential checking)
       if (!hasCredentialsForModel(model, credentials, currentAgent)) {
         // Determine which field to highlight based on model requirement
-        const field = model.requiresKey === "openai" ? "openaiApiKey" : "anthropicApiKey"
+        const fieldMap: Record<string, string> = {
+          openai: "openaiApiKey",
+          anthropic: "anthropicApiKey",
+          opencode: "opencodeApiKey",
+          gemini: "geminiApiKey",
+          pi: "anthropicApiKey",
+        }
+        const field = fieldMap[model.requiresKey ?? ""] ?? "anthropicApiKey"
         onOpenSettingsWithHighlight?.(field)
       }
     }, [onModelChange, onOpenSettingsWithHighlight, credentials, currentAgent])

--- a/packages/web/components/modals/settings-modal.tsx
+++ b/packages/web/components/modals/settings-modal.tsx
@@ -561,7 +561,7 @@ export function SettingsModal({ open, onClose, credentials, onCredentialsUpdate,
                     {renderClearButton(credentials?.hasOpencodeApiKey ?? false, "opencodeApiKey")}
                     {renderUndoClearButton("opencodeApiKey")}
                     <a
-                      href="https://opencode.ai/keys"
+                      href="https://opencode.ai/auth"
                       target="_blank"
                       rel="noopener noreferrer"
                       className="flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground transition-colors"


### PR DESCRIPTION
## Summary
<img width="3439" height="1260" alt="image" src="https://github.com/user-attachments/assets/90e92cdf-c67f-4b6f-ba61-b21d0f45dd12" />

- Add Gemini 3.1 Pro model to both Gemini agent and OpenCode agent model lists
- Add missing "OpenCode" section to model dropdown (paid OpenCode models were silently hidden)
- Fix credential field routing — selecting a Gemini/OpenCode/Pi model no longer incorrectly prompts for Anthropic API key
- Fix OpenCode "Get key" links to point to `opencode.ai/auth` instead of dead URLs

## Changes
**`packages/common/src/agents.ts`**
- Replace deprecated `opencode/gemini-3-pro` with `opencode/gemini-3.1-pro`
- Add `gemini-3.1-pro-preview` to Gemini agent model list

**`packages/web/components/chat/chat-input.tsx`**
- Add `opencode` requiresKey filter so paid OpenCode models appear in dropdown
- Map model `requiresKey` to correct settings field (gemini → geminiApiKey, opencode → opencodeApiKey)

**`packages/web/components/modals/settings-modal.tsx`**
- Fix OpenCode "Get key" href: `opencode.ai/keys` → `opencode.ai/auth`

**`packages/simple-chat/components/modals/SettingsModal.tsx`**
- Fix OpenCode help URL: `opencode.ai` → `opencode.ai/auth`

## Test plan
- [ ] Select OpenCode agent → model dropdown shows "OpenCode" section with paid models
- [ ] Select Gemini agent → model dropdown shows Gemini 3.1 Pro
- [ ] Click Gemini 3.1 Pro without Gemini API key → settings opens highlighting Gemini field (not Anthropic)
- [ ] Click an OpenCode model without key → settings opens highlighting OpenCode field
- [ ] "Get key" link in settings for OpenCode navigates to `opencode.ai/auth`
