### PR TITLE
Update error message handling for branch creation

### DIFF
--- a/packages/web/app/api/sandbox/create/route.ts
+++ b/packages/web/app/api/sandbox/create/route.ts
@@ -265,10 +265,11 @@ export async function POST(req: Request) {
         // If starting from a specific commit (new branch only), fetch it and reset to it
         if (startCommit && !isRecreation) {
           sendProgress(controller, `Resetting to commit ${startCommit.slice(0, 7)}...`)
-          // Fetch the specific commit in case it's not part of the cloned branch history
-          // This handles the case where user branches from a commit that exists on a different branch
+          // Fetch all remote refs to ensure the commit is available locally.
+          // We can't fetch a specific SHA directly - git fetch requires a refspec (branch/tag).
+          // The commit may exist on a different branch than what was cloned.
           await sandbox.process.executeCommand(
-            `cd ${repoPath} && git fetch ${authedUrl} ${startCommit} 2>&1`
+            `cd ${repoPath} && git fetch ${authedUrl} '+refs/heads/*:refs/remotes/origin/*' 2>&1`
           )
           const resetResult = await sandbox.process.executeCommand(
             `cd ${repoPath} && git reset --hard ${startCommit} 2>&1`

--- a/packages/web/components/chat/message-bubble.tsx
+++ b/packages/web/components/chat/message-bubble.tsx
@@ -525,15 +525,16 @@ export function MessageBubble({ message, agent = "claude-code", agentLabel, sand
 
   // Commit row rendering
   if (message.commitHash) {
+    const shortHash = message.commitHash.slice(0, 7)
     return (
-      <div id={`commit-${message.commitHash}`} className="group/commitrow flex items-center gap-3 py-1">
+      <div id={`commit-${shortHash}`} className="group/commitrow flex items-center gap-3 py-1">
         <div className="h-px flex-1 bg-border" />
         <button
           onClick={() => onCommitClick?.(message.commitHash!, message.commitMessage || "")}
           className="flex cursor-pointer items-center gap-1.5 rounded-full border border-border bg-card px-3 py-1 text-xs text-muted-foreground hover:bg-accent/50 hover:border-primary/30 transition-colors"
         >
           <GitCommitHorizontal className="h-3 w-3" />
-          <code className="font-mono text-[10px] text-primary/70">{message.commitHash}</code>
+          <code className="font-mono text-[10px] text-primary/70">{shortHash}</code>
           <span className="max-w-[200px] truncate">{message.commitMessage}</span>
         </button>
         <div className="relative h-px flex-1 bg-border">

--- a/packages/web/lib/core/execution/detect-and-show-commits.ts
+++ b/packages/web/lib/core/execution/detect-and-show-commits.ts
@@ -165,7 +165,7 @@ export async function detectAndShowCommits(params: DetectAndShowCommitsParams): 
             hour: "2-digit",
             minute: "2-digit",
           }),
-          commitHash: c.shortHash,
+          commitHash: c.hash,  // Store full hash; truncate for display
           commitMessage: c.message,
         }
         await onAddMessage(branchId, commitMessage)

--- a/packages/web/lib/core/git/commit-detector.ts
+++ b/packages/web/lib/core/git/commit-detector.ts
@@ -12,7 +12,8 @@ import { ASSISTANT_SOURCE } from "@/lib/shared/constants"
 // =============================================================================
 
 export interface Commit {
-  shortHash: string
+  hash: string       // Full 40-char hash (used for storage and git operations)
+  shortHash: string  // 7-char hash (used for deduplication with existing messages)
   message: string
 }
 
@@ -55,8 +56,9 @@ export function filterNewCommits(
   existingHashes: Set<string>
 ): Commit[] {
   // Find the first commit that's already in chat
+  // Check both short and full hash to handle existing data (short) and new data (full)
   const firstSeenIdx = allCommits.findIndex((c) =>
-    existingHashes.has(c.shortHash)
+    existingHashes.has(c.shortHash) || existingHashes.has(c.hash)
   )
 
   // Get only commits before the first seen one
@@ -103,7 +105,7 @@ export function createCommitMessage(
       hour: '2-digit',
       minute: '2-digit',
     }),
-    commitHash: commit.shortHash,
+    commitHash: commit.hash,  // Store full hash; truncate for display
     commitMessage: commit.message,
   }
 }


### PR DESCRIPTION
This pull request fixes two issues related to working with Git commits:

## Changes
- Fixes an issue where `git fetch` was failing when trying to fetch a specific commit hash, by changing the command to fetch all remote refs instead
- Stores the full 40-character commit hash in the `commitHash` field instead of the 7-character short hash, ensuring Git operations like branching from a commit work reliably
- Truncates the hash to 7 characters for display in the message bubble
- Updates the deduplication logic to check both the short and full hashes for backward compatibility with existing data

No database migration is required, as the existing column can hold both hash formats.