### PR TITLE
Create repository after starting chat

### DIFF
--- a/packages/simple-chat/app/api/git/setup-remote/route.ts
+++ b/packages/simple-chat/app/api/git/setup-remote/route.ts
@@ -1,0 +1,74 @@
+import { Daytona } from "@daytonaio/sdk"
+import { getServerSession } from "next-auth"
+import { authOptions } from "@/lib/auth"
+import { PATHS } from "@/lib/constants"
+
+/**
+ * Sets up a GitHub remote for an existing local repo in a sandbox and pushes to it.
+ * Used when a user creates a new GitHub repo after already starting a chat.
+ */
+export async function POST(req: Request) {
+  // 1. Parse request body
+  const body = await req.json()
+  const { sandboxId, repoFullName, branch } = body
+
+  if (!sandboxId || !repoFullName || !branch) {
+    return Response.json(
+      { error: "Missing required fields: sandboxId, repoFullName, branch" },
+      { status: 400 }
+    )
+  }
+
+  // 2. Get GitHub token from session
+  const session = await getServerSession(authOptions)
+  if (!session?.accessToken) {
+    return Response.json(
+      { error: "Unauthorized - please sign in with GitHub" },
+      { status: 401 }
+    )
+  }
+  const githubToken = session.accessToken
+
+  // 3. Get Daytona API key
+  const daytonaApiKey = process.env.DAYTONA_API_KEY
+  if (!daytonaApiKey) {
+    return Response.json(
+      { error: "Daytona API key not configured" },
+      { status: 500 }
+    )
+  }
+
+  try {
+    // 4. Get sandbox from Daytona
+    const daytona = new Daytona({ apiKey: daytonaApiKey })
+    const sandbox = await daytona.get(sandboxId)
+
+    // 5. The repo name in the sandbox is just the repo part (not owner/repo)
+    const repoName = repoFullName.split("/")[1]
+    const repoPath = `${PATHS.SANDBOX_HOME}/${repoName}`
+
+    // 6. Set up the remote URL with auth token
+    const remoteUrl = `https://x-access-token:${githubToken}@github.com/${repoFullName}.git`
+
+    // Remove existing origin if any, then add the new one
+    // Using || true to ignore errors if remote doesn't exist
+    await sandbox.process.executeCommand(
+      `cd ${repoPath} && git remote remove origin 2>/dev/null || true`
+    )
+    await sandbox.process.executeCommand(
+      `cd ${repoPath} && git remote add origin "${remoteUrl}"`
+    )
+
+    // 7. Push to the remote (force push since it's a new repo)
+    // The new repo from GitHub has auto_init which creates a README, so we need to force push
+    await sandbox.process.executeCommand(
+      `cd ${repoPath} && git push -u origin ${branch} --force`
+    )
+
+    return Response.json({ success: true })
+  } catch (error) {
+    console.error("[git/setup-remote] Error:", error)
+    const message = error instanceof Error ? error.message : "Unknown error"
+    return Response.json({ error: message }, { status: 500 })
+  }
+}

--- a/packages/simple-chat/app/page.tsx
+++ b/packages/simple-chat/app/page.tsx
@@ -112,10 +112,36 @@ export default function HomePage() {
   }
 
   // Handler for repo selection - updates the current chat's repo
-  const handleRepoSelect = (repo: string, branch: string) => {
-    if (currentChatId) {
-      updateChatRepo(currentChatId, repo, branch)
+  // If sandbox already exists (chat started without repo), also set up remote and push
+  const handleRepoSelect = async (repo: string, branch: string) => {
+    if (!currentChatId || !currentChat) return
+
+    // If sandbox exists, we need to set up the remote and push
+    if (currentChat.sandboxId && currentChat.repo === NEW_REPOSITORY) {
+      try {
+        const response = await fetch("/api/git/setup-remote", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            sandboxId: currentChat.sandboxId,
+            repoFullName: repo,
+            branch: currentChat.branch,
+          }),
+        })
+
+        if (!response.ok) {
+          const error = await response.json()
+          console.error("Failed to set up remote:", error)
+          // TODO: Show error to user
+          return
+        }
+      } catch (error) {
+        console.error("Failed to set up remote:", error)
+        return
+      }
     }
+
+    updateChatRepo(currentChatId, repo, branch)
   }
 
   // Handler for sending message


### PR DESCRIPTION
This pull request adds the ability to push existing chat sandbox content to a newly created GitHub repository.

## Changes
- Introduces a new API endpoint `POST /api/git/setup-remote` that takes the sandbox ID, repository full name, and branch name
- Sets up the `origin` remote to point to the new GitHub repository
- Force pushes the existing commits to the new repository, handling the auto-initialized README

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>