### PR TITLE
Env Variable Sdk

### DIFF
--- a/packages/agents/src/agents/claude/index.ts
+++ b/packages/agents/src/agents/claude/index.ts
@@ -3,9 +3,44 @@
  */
 
 import type { AgentDefinition, CommandSpec, ParseContext, RunOptions } from "../../core/agent"
+import type { CodeAgentSandbox } from "../../types/provider"
 import type { Event } from "../../types/events"
 import { parseClaudeLine } from "./parser"
 import { CLAUDE_TOOL_MAPPINGS } from "./tools"
+
+/** Claude credentials directory */
+const CLAUDE_CREDENTIALS_DIR = "/home/daytona/.claude"
+/** Claude credentials file */
+const CLAUDE_CREDENTIALS_FILE = "/home/daytona/.claude/.credentials.json"
+/** Environment variable name for Claude Code credentials */
+const CLAUDE_CODE_CREDENTIALS_ENV = "CLAUDE_CODE_CREDENTIALS"
+
+/**
+ * Claude agent-specific setup: write credentials from environment variable.
+ *
+ * When CLAUDE_CODE_CREDENTIALS environment variable is set, this function
+ * writes its contents to ~/.claude/.credentials.json. This allows credentials
+ * to be passed via environment variable instead of writing the file manually.
+ *
+ * The value should be the JSON content of the credentials file, e.g.:
+ * {"claudeAiOauth":{"accessToken":"sk-ant-oa..."}}
+ */
+async function claudeSetup(
+  sandbox: CodeAgentSandbox,
+  env: Record<string, string>
+): Promise<void> {
+  const credentialsJson = env[CLAUDE_CODE_CREDENTIALS_ENV]
+  if (!credentialsJson || !sandbox.executeCommand) return
+
+  // Escape single quotes for shell command
+  const safeCredentials = credentialsJson.replace(/'/g, "'\\''")
+
+  // Create directory and write credentials file with secure permissions
+  await sandbox.executeCommand(
+    `mkdir -p '${CLAUDE_CREDENTIALS_DIR}' && echo '${safeCredentials}' > '${CLAUDE_CREDENTIALS_FILE}' && chmod 600 '${CLAUDE_CREDENTIALS_FILE}'`,
+    30
+  )
+}
 
 /**
  * Claude Code CLI agent definition.
@@ -20,6 +55,7 @@ export const claudeAgent: AgentDefinition = {
   capabilities: {
     supportsSystemPrompt: true,
     supportsResume: true,
+    setup: claudeSetup,
   },
 
   buildCommand(options: RunOptions): CommandSpec {

--- a/packages/agents/tests/claude-setup.test.ts
+++ b/packages/agents/tests/claude-setup.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Claude agent setup tests - tests for the CLAUDE_CODE_CREDENTIALS environment variable handling.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { claudeAgent } from "../src/agents/index.js"
+import type { CodeAgentSandbox } from "../src/types/provider.js"
+
+describe("Claude agent setup", () => {
+  let mockSandbox: CodeAgentSandbox
+  let executedCommands: string[]
+
+  beforeEach(() => {
+    executedCommands = []
+    mockSandbox = {
+      ensureProvider: vi.fn().mockResolvedValue(undefined),
+      setEnvVars: vi.fn(),
+      executeCommand: vi.fn().mockImplementation(async (command: string) => {
+        executedCommands.push(command)
+        return { exitCode: 0, output: "" }
+      }),
+    }
+  })
+
+  it("should have a setup capability", () => {
+    expect(claudeAgent.capabilities?.setup).toBeDefined()
+    expect(typeof claudeAgent.capabilities?.setup).toBe("function")
+  })
+
+  it("should write credentials file when CLAUDE_CODE_CREDENTIALS is set", async () => {
+    const setup = claudeAgent.capabilities?.setup
+    if (!setup) throw new Error("Setup not defined")
+
+    const credentials = '{"claudeAiOauth":{"accessToken":"sk-ant-oa-test-token"}}'
+    await setup(mockSandbox, { CLAUDE_CODE_CREDENTIALS: credentials })
+
+    expect(executedCommands).toHaveLength(1)
+    expect(executedCommands[0]).toContain("mkdir -p")
+    expect(executedCommands[0]).toContain(".claude")
+    expect(executedCommands[0]).toContain("chmod 600")
+    expect(executedCommands[0]).toContain(credentials)
+  })
+
+  it("should escape single quotes in credentials", async () => {
+    const setup = claudeAgent.capabilities?.setup
+    if (!setup) throw new Error("Setup not defined")
+
+    const credentials = "{'key':'value's'}"
+    await setup(mockSandbox, { CLAUDE_CODE_CREDENTIALS: credentials })
+
+    expect(executedCommands).toHaveLength(1)
+    // Single quotes should be escaped as '\''
+    expect(executedCommands[0]).toContain("'\\''")
+  })
+
+  it("should not write credentials when CLAUDE_CODE_CREDENTIALS is not set", async () => {
+    const setup = claudeAgent.capabilities?.setup
+    if (!setup) throw new Error("Setup not defined")
+
+    await setup(mockSandbox, {})
+
+    expect(executedCommands).toHaveLength(0)
+  })
+
+  it("should not write credentials when CLAUDE_CODE_CREDENTIALS is empty", async () => {
+    const setup = claudeAgent.capabilities?.setup
+    if (!setup) throw new Error("Setup not defined")
+
+    await setup(mockSandbox, { CLAUDE_CODE_CREDENTIALS: "" })
+
+    expect(executedCommands).toHaveLength(0)
+  })
+
+  it("should not fail when executeCommand is not available", async () => {
+    const setup = claudeAgent.capabilities?.setup
+    if (!setup) throw new Error("Setup not defined")
+
+    const sandboxWithoutExecute: CodeAgentSandbox = {
+      ensureProvider: vi.fn().mockResolvedValue(undefined),
+      setEnvVars: vi.fn(),
+      // executeCommand is undefined
+    }
+
+    // Should not throw
+    await expect(
+      setup(sandboxWithoutExecute, { CLAUDE_CODE_CREDENTIALS: '{"token":"test"}' })
+    ).resolves.toBeUndefined()
+  })
+})

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -13,10 +13,6 @@ export const PATHS = {
   LOGS_DIR: "/tmp/logs",
   /** Marker file created after clone completes, used as baseline for modified file detection */
   CLONE_MARKER_FILE: "/tmp/.clone_complete",
-  /** Claude credentials directory */
-  CLAUDE_CREDENTIALS_DIR: "/home/daytona/.claude",
-  /** Claude credentials file */
-  CLAUDE_CREDENTIALS_FILE: "/home/daytona/.claude/.credentials.json",
   /** Claude hooks directory */
   CLAUDE_HOOKS_DIR: "/home/daytona/.claude/hooks",
   /** Claude settings file */

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -26,6 +26,19 @@ export const PATHS = {
 } as const
 
 // =============================================================================
+// Environment Variables
+// =============================================================================
+
+export const ENV_VARS = {
+  /**
+   * Environment variable for Claude Code credentials.
+   * When set, the Agent SDK will automatically write this to ~/.claude/.credentials.json
+   * Value should be the JSON content of the credentials file (e.g., {"claudeAiOauth":{"accessToken":"..."}})
+   */
+  CLAUDE_CODE_CREDENTIALS: "CLAUDE_CODE_CREDENTIALS",
+} as const
+
+// =============================================================================
 // Sandbox Configuration
 // =============================================================================
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -4,7 +4,7 @@
  */
 
 // Constants
-export { PATHS, SANDBOX_CONFIG, TIMEOUTS } from "./constants"
+export { PATHS, SANDBOX_CONFIG, TIMEOUTS, ENV_VARS } from "./constants"
 
 // Types
 export type {

--- a/packages/web/app/api/sandbox/create/route.ts
+++ b/packages/web/app/api/sandbox/create/route.ts
@@ -181,12 +181,10 @@ export async function POST(req: Request) {
         // Track sandbox ID for cleanup if subsequent steps fail
         daytonaSandboxId = sandbox.id
 
-        // Write Claude credentials so the Agent SDK picks them up
+        // Set Claude credentials as environment variable so the Agent SDK writes them automatically
+        // The SDK's claude agent setup() function detects CLAUDE_CODE_CREDENTIALS and writes to ~/.claude/.credentials.json
         if (anthropicAuthToken) {
-          const credentialsB64 = Buffer.from(anthropicAuthToken).toString("base64")
-          await sandbox.process.executeCommand(
-            `mkdir -p ${PATHS.CLAUDE_CREDENTIALS_DIR} && echo '${credentialsB64}' | base64 -d > ${PATHS.CLAUDE_CREDENTIALS_FILE} && chmod 600 ${PATHS.CLAUDE_CREDENTIALS_FILE}`
-          )
+          await sandbox.setEnvVar("CLAUDE_CODE_CREDENTIALS", anthropicAuthToken)
         }
 
         // Create the logs directory for agent output

--- a/packages/web/lib/sandbox/sandbox-resume.ts
+++ b/packages/web/lib/sandbox/sandbox-resume.ts
@@ -1,6 +1,6 @@
 import { Daytona, DaytonaNotFoundError } from "@daytonaio/sdk"
 import { readPersistedSessionId } from "@/lib/agents/agent-session"
-import { PATHS, SANDBOX_CONFIG } from "@/lib/shared/constants"
+import { SANDBOX_CONFIG } from "@/lib/shared/constants"
 import { prisma } from "@/lib/db/prisma"
 import { buildMcpConfig, getMcpConfigWriteCommand } from "@/lib/mcp/mcp-config"
 import { decrypt } from "@/lib/auth/encryption"
@@ -227,15 +227,13 @@ export async function ensureSandboxReady(
   const resumeSessionId =
     sameAgent ? (fileSessionId || databaseSessionId) : undefined
 
-  // Write Claude credentials file on every prompt execution
-  // This ensures fresh credentials are always available to the Claude Agent SDK
+  // Set Claude credentials as environment variable so the Agent SDK writes them automatically
+  // The SDK's claude agent setup() function detects CLAUDE_CODE_CREDENTIALS and writes to ~/.claude/.credentials.json
+  // We set this on every prompt execution to ensure fresh credentials are always available
   if (anthropicAuthToken) {
     t0 = Date.now()
-    const credentialsB64 = Buffer.from(anthropicAuthToken).toString("base64")
-    await sandbox.process.executeCommand(
-      `mkdir -p ${PATHS.CLAUDE_CREDENTIALS_DIR} && echo '${credentialsB64}' | base64 -d > ${PATHS.CLAUDE_CREDENTIALS_FILE} && chmod 600 ${PATHS.CLAUDE_CREDENTIALS_FILE}`
-    )
-    console.log(`[ensureSandboxReady] claude credentials written, took ${Date.now() - t0}ms`)
+    await sandbox.setEnvVar("CLAUDE_CODE_CREDENTIALS", anthropicAuthToken)
+    console.log(`[ensureSandboxReady] CLAUDE_CODE_CREDENTIALS env var set, took ${Date.now() - t0}ms`)
   }
 
   // Set up Claude Code hooks on every resume to ensure they're always present

--- a/packages/web/lib/shared/constants.ts
+++ b/packages/web/lib/shared/constants.ts
@@ -163,10 +163,6 @@ export const PATHS = {
   LOGS_DIR: "/tmp/logs",
   /** Marker file created after clone completes, used as baseline for modified file detection */
   CLONE_MARKER_FILE: "/tmp/.clone_complete",
-  /** Claude credentials directory */
-  CLAUDE_CREDENTIALS_DIR: "/home/daytona/.claude",
-  /** Claude credentials file */
-  CLAUDE_CREDENTIALS_FILE: "/home/daytona/.claude/.credentials.json",
   /** Claude hooks directory */
   CLAUDE_HOOKS_DIR: "/home/daytona/.claude/hooks",
   /** Claude settings file */


### PR DESCRIPTION
- feat(agents): add CLAUDE_CODE_CREDENTIALS environment variable support

The Agent SDK now detects the CLAUDE_CODE_CREDENTIALS environment variable
and automatically writes the credentials to ~/.claude/.credentials.json.

This allows credentials to be passed via environment variable instead of
writing the file manually, making it easier to:
- Configure credentials in sandbox environment variables
- Use Claude Code credentials in automated testing

Changes:
- Add CLAUDE_CODE_CREDENTIALS constant to @upstream/common
- Add setup() function to Claude agent that detects and writes credentials
- Update web package to use env var instead of direct file upload
- Add tests for the new credential handling

Closes #38

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>