### PR TITLE
Switch workspace packages to compiled exports and enforce pre-build in scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,13 +5,13 @@
     "packages/*"
   ],
   "scripts": {
-    "postinstall": "cd packages/web && npx prisma generate",
+    "postinstall": "npm run build -w @upstream/common && npm run build -w @upstream/terminal && cd packages/web && npx prisma generate",
     "dev": "cd packages/web && prisma generate && next dev --webpack",
     "dev:simple-chat": "npm run dev -w @upstream/simple-chat",
-    "build": "npm run build -w @upstream/agents && npm run build -w @upstream/web && npm run build -w @upstream/simple-chat",
+    "build": "npm run build -w @upstream/common && npm run build -w @upstream/terminal && npm run build -w @upstream/agents && npm run build -w @upstream/web && npm run build -w @upstream/simple-chat",
     "build:sdk": "npm run build -w @upstream/agents",
-    "build:web": "npm run build -w @upstream/agents && npm run build -w @upstream/web",
-    "build:simple-chat": "npm run build -w @upstream/agents && npm run build -w @upstream/simple-chat",
+    "build:web": "npm run build -w @upstream/common && npm run build -w @upstream/terminal && npm run build -w @upstream/agents && npm run build -w @upstream/web",
+    "build:simple-chat": "npm run build -w @upstream/common && npm run build -w @upstream/agents && npm run build -w @upstream/simple-chat",
     "start": "cd packages/web && next start",
     "start:simple-chat": "npm run start -w @upstream/simple-chat",
     "lint": "npm run lint --workspaces --if-present",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -2,12 +2,20 @@
   "name": "@upstream/common",
   "version": "0.1.0",
   "description": "Shared utilities and types for upstream-agents packages",
-  "main": "src/index.ts",
-  "types": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts",
-    "./*": "./src/*"
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
   },
   "scripts": {
     "build": "tsc",

--- a/packages/simple-chat/package.json
+++ b/packages/simple-chat/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --port 4000",
+    "dev": "npm run build -w @upstream/common && npm run build -w @upstream/agents && next dev --port 4000",
     "build": "next build",
     "start": "next start --port 4000",
     "lint": "eslint .",

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -2,8 +2,8 @@
   "name": "@upstream/terminal",
   "version": "0.2.0",
   "description": "WebSocket-based PTY terminal for Daytona sandboxes",
-  "main": "src/index.ts",
-  "types": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "type": "module",
   "scripts": {
     "build": "tsc",
@@ -32,10 +32,46 @@
     }
   },
   "exports": {
-    ".": "./src/index.ts",
-    "./components": "./src/components/index.ts",
-    "./sandbox": "./src/sandbox/index.ts",
-    "./server": "./src/server/index.ts"
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    },
+    "./components": {
+      "import": {
+        "types": "./dist/components/index.d.ts",
+        "default": "./dist/components/index.js"
+      },
+      "require": {
+        "types": "./dist/components/index.d.ts",
+        "default": "./dist/components/index.js"
+      }
+    },
+    "./sandbox": {
+      "import": {
+        "types": "./dist/sandbox/index.d.ts",
+        "default": "./dist/sandbox/index.js"
+      },
+      "require": {
+        "types": "./dist/sandbox/index.d.ts",
+        "default": "./dist/sandbox/index.js"
+      }
+    },
+    "./server": {
+      "import": {
+        "types": "./dist/server/index.d.ts",
+        "default": "./dist/server/index.js"
+      },
+      "require": {
+        "types": "./dist/server/index.d.ts",
+        "default": "./dist/server/index.js"
+      }
+    }
   },
   "files": [
     "src",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "npm run build -w @upstream/agents && prisma generate && next dev --webpack",
+    "dev": "npm run build -w @upstream/common && npm run build -w @upstream/terminal && npm run build -w @upstream/agents && prisma generate && next dev --webpack",
     "build": "prisma generate && next build",
     "postinstall": "prisma generate",
     "start": "next start",


### PR DESCRIPTION
**Summary**
Moves `@upstream/common` and `@upstream/terminal` from source-based exports (`src/index.ts`) to compiled outputs (`dist/index.js`). Updates install, dev, and build flows so dependencies are compiled before any consumer attempts to import them.

**Problem**

1. **Workspace resolution failure**
   After a fresh install, `node_modules/@upstream/common` was not consistently symlinked, leading to `Module not found` errors. Root cause: exporting `.ts` sources caused unreliable resolution in npm workspaces.

2. **Webpack static analysis warnings**
   Re-exports from `.ts` sources prevented proper static analysis, triggering warnings like:
   `Attempted import error: 'agentLabels' is not exported from '@/lib/shared/types'`.
   These were non-blocking but noisy and misleading.

**Solution**

* Export compiled artifacts from both packages.
* Ensure build order guarantees: dependencies are built before any consumer runs.

**Changes**

* **Package exports**

  * `@upstream/common` → `dist/index.js`
  * `@upstream/terminal` → `dist/index.js`

* **Build pipeline**

  * Root `postinstall` builds `common` and `terminal`
  * `dev` scripts in `web` and `simple-chat` build dependencies first
  * All root `build:*` scripts include `common` (and `terminal` where applicable)

**Files Modified**

* `packages/common/package.json` — switch exports to `dist/`
* `packages/terminal/package.json` — switch exports to `dist/`
* `packages/web/package.json` — prepend dependency build in `dev`
* `packages/simple-chat/package.json` — prepend dependency build in `dev`
* `package.json` (root) — update `postinstall` and all `build:*` scripts

**Impact**

* Eliminates workspace symlink inconsistencies on fresh installs
* Removes webpack export warnings from source-based re-exports
* Standardizes dependency build order across all entry points

**Verification**

* Fresh `npm install` produces valid workspace symlinks
* No `Module not found` for `@upstream/common` or `@upstream/terminal`
* Webpack builds without export-related warnings
* `dev` and `build` scripts run without manual pre-build steps