### PR TITLE
Stop injecting hardcoded default models for Goose CLI

### DIFF
--- a/packages/agents/README.md
+++ b/packages/agents/README.md
@@ -57,7 +57,7 @@ await sandbox.delete()
 |----------|-------------|
 | Claude | `claude -p --output-format stream-json --verbose --dangerously-skip-permissions -- "prompt"` |
 | Codex | `codex exec --json --skip-git-repo-check --yolo -- "prompt"` |
-| Goose | `goose run --output-format stream-json --provider openai --model gpt-4o --text "prompt"` |
+| Goose | `goose run --output-format stream-json --text "prompt"` |
 | OpenCode | `opencode run --format json --variant medium -- "prompt" 2>&1` |
 | Gemini | `gemini --output-format stream-json --yolo -p "prompt"` |
 | Pi | `pi --mode json -p "prompt"` |

--- a/packages/agents/src/agents/goose/index.ts
+++ b/packages/agents/src/agents/goose/index.ts
@@ -8,25 +8,17 @@ import { parseGooseLine } from "./parser"
 import { GOOSE_TOOL_MAPPINGS } from "./tools"
 
 /**
- * Determine the goose provider and model based on the model name and environment.
+ * Determine the goose provider based on the given model name.
  * Goose supports multiple providers: openai, anthropic, ollama, etc.
  */
-function getGooseProviderAndModel(
-  model: string | undefined,
-  env: Record<string, string> | undefined
-): { provider: string; model: string } {
+function getGooseProvider(model: string): string {
   // If model contains "claude", use anthropic provider
-  if (model?.toLowerCase().includes("claude")) {
-    return { provider: "anthropic", model: model }
-  }
-
-  // If ANTHROPIC_API_KEY is set but not OPENAI_API_KEY, use anthropic
-  if (env?.ANTHROPIC_API_KEY && !env?.OPENAI_API_KEY) {
-    return { provider: "anthropic", model: model || "claude-sonnet-4-5" }
+  if (model.toLowerCase().includes("claude")) {
+    return "anthropic"
   }
 
   // Default to OpenAI provider
-  return { provider: "openai", model: model || "gpt-4o" }
+  return "openai"
 }
 
 /**
@@ -53,10 +45,12 @@ export const gooseAgent: AgentDefinition = {
     // Enable JSON streaming output for machine-readable events
     gooseArgs.push("--output-format", "stream-json")
 
-    // Determine provider and model based on model name and environment
-    const { provider, model } = getGooseProviderAndModel(options.model, options.env)
-    gooseArgs.push("--provider", provider)
-    gooseArgs.push("--model", model)
+    // Only set provider and model flags if a model is explicitly requested
+    if (options.model) {
+      const provider = getGooseProvider(options.model)
+      gooseArgs.push("--provider", provider)
+      gooseArgs.push("--model", options.model)
+    }
 
     // Add prompt as text input
     if (options.prompt) {

--- a/packages/agents/tests/integration/providers.test.ts
+++ b/packages/agents/tests/integration/providers.test.ts
@@ -66,6 +66,7 @@ const agents = [
     apiKeyEnvVar: "OPENAI_API_KEY", // goose uses OpenAI provider by default
     apiKey: OPENAI_API_KEY,
     hasKey: !!OPENAI_API_KEY,
+    model: "gpt-4o",
   },
   {
     name: "opencode" as const,


### PR DESCRIPTION
## Description

**What changed:**
- Removed the logic in `gooseAgent` that forces `--provider openai --model gpt-4o` (or anthropic defaults) when no model is explicitly passed to `createSession`.
- Simplified the internal `getGooseProvider` helper to only infer the provider directly from the explicitly requested model string.
- Updated the integration tests (`tests/integration/providers.test.ts`) to explicitly pass `model: "gpt-4o"` so the test suite can successfully run Goose in clean Daytona sandboxes where no native configuration exists.
- Updated the README to reflect the implementation

Previously, the SDK was overriding the Goose CLI's native default configurations (those set in `~/.config/goose/config.yaml`) by forcing its own fallback defaults. This aligns Goose with the behavior of our other CLI integrations (like Claude and Gemini), which only append model flags if the user explicitly requests one, allowing the underlying CLI tools to govern their own defaults.