### PR TITLE
History Injection in Prompt for Cross-Agent Session Continuity

### DIFF
--- a/packages/agents/src/background/index.ts
+++ b/packages/agents/src/background/index.ts
@@ -4,6 +4,7 @@
 
 export type {
   BackgroundRunPhase,
+  HistoryMessage,
   PollResult,
   SessionMeta,
   StartOptions,

--- a/packages/agents/src/background/session.ts
+++ b/packages/agents/src/background/session.ts
@@ -10,6 +10,7 @@ import type { AgentDefinition, ParseContext, RunOptions } from "../core/agent"
 import type { Event } from "../types/events"
 import type { CodeAgentSandbox } from "../types/provider"
 import type {
+  HistoryMessage,
   PollResult,
   SessionMeta,
   StartOptions,
@@ -115,6 +116,11 @@ class BackgroundSessionImpl implements BackgroundSession {
       ...this.defaults,
       ...options,
       prompt,
+    }
+
+    // Prepend conversation history to prompt when injecting context
+    if (options.history?.length) {
+      opts.prompt = this.formatHistory(options.history) + "\n\n" + (opts.prompt ?? "")
     }
 
     // Handle system prompt for agents without native support
@@ -621,6 +627,24 @@ class BackgroundSessionImpl implements BackgroundSession {
 
   private quoteArg(arg: string): string {
     return `'${arg.replace(/'/g, "'\\''")}'`
+  }
+
+  /**
+   * Format conversation history into a preamble for prompt injection.
+   *
+   * Produces a structured block that precedes the user's actual prompt,
+   * giving the agent context from a previous session.
+   */
+  private formatHistory(history: readonly HistoryMessage[]): string {
+    const lines = history.map(
+      (m) => `[${m.role === "user" ? "User" : "Assistant"}]: ${m.content}`
+    )
+    return (
+      "## Conversation History\n" +
+      "The following is the conversation history from a previous session. " +
+      "Use it as context for the current request.\n\n" +
+      lines.join("\n\n")
+    )
   }
 }
 

--- a/packages/agents/src/background/types.ts
+++ b/packages/agents/src/background/types.ts
@@ -46,6 +46,15 @@ export interface SessionMeta {
 }
 
 /**
+ * A single message from previous conversation history.
+ * Used to inject context when switching agents or forking chats.
+ */
+export interface HistoryMessage {
+  readonly role: "user" | "assistant"
+  readonly content: string
+}
+
+/**
  * Options for starting a turn
  */
 export interface StartOptions {
@@ -57,4 +66,6 @@ export interface StartOptions {
   env?: Record<string, string>
   /** Working directory for the agent process */
   cwd?: string
+  /** Previous conversation history to inject as context for this turn. */
+  history?: readonly HistoryMessage[]
 }

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -79,6 +79,7 @@ export type { CanonicalToolName } from "./core/tools"
 export type {
   BackgroundSession,
   BackgroundRunPhase,
+  HistoryMessage,
   PollResult,
   TurnHandle,
 } from "./background/index"

--- a/packages/agents/src/session.ts
+++ b/packages/agents/src/session.ts
@@ -197,4 +197,4 @@ async function createSessionWithId(
 
 // Re-export types
 export type { BackgroundSession } from "./background/index"
-export type { BackgroundRunPhase, PollResult, TurnHandle } from "./background/types"
+export type { BackgroundRunPhase, HistoryMessage, PollResult, TurnHandle } from "./background/types"

--- a/packages/web/app/api/agent/execute/route.ts
+++ b/packages/web/app/api/agent/execute/route.ts
@@ -165,8 +165,33 @@ export async function POST(req: Request) {
 
     // 8. Start the turn and write meta before returning (so client polling sees runId/outputFile)
     // Pass env at start() time for freshest credentials (run-level overrides session-level)
+
+    // Detect agent switch: load conversation history for context injection.
+    // When the user switches agents mid-conversation, the new CLI has no local
+    // session to resume from. We load the full chat history from the DB and
+    // inject it into the prompt so the new agent has context.
+    const previousAgent = sandboxRecord.sessionAgent
+    const isAgentSwitch = !!previousAgent && previousAgent !== agent && !!branchId
+    let history: { role: "user" | "assistant"; content: string }[] | undefined
+
+    if (isAgentSwitch) {
+      const messages = await prisma.message.findMany({
+        where: { branchId },
+        orderBy: { createdAt: "asc" },
+        select: { role: true, content: true },
+      })
+      history = messages
+        .filter((m): m is typeof m & { role: "user" | "assistant" } =>
+          (m.role === "user" || m.role === "assistant") && !!m.content.trim()
+        )
+        .map((m) => ({ role: m.role, content: m.content }))
+
+      if (history.length === 0) history = undefined
+      else console.log(`[agent/execute] Agent switch ${previousAgent} → ${agent}: injecting ${history.length} history messages`)
+    }
+
     try {
-      await bgSession.start(prompt, { env })
+      await bgSession.start(prompt, { env, ...(history && { history }) })
     } catch (error) {
       console.error("[agent/execute] bgSession.start failed", { messageId }, error)
       try {

--- a/packages/web/lib/agents/agent-session.ts
+++ b/packages/web/lib/agents/agent-session.ts
@@ -132,6 +132,8 @@ export async function readPersistedSessionId(
 export interface BackgroundStartOptions {
   /** Run-level env vars (override session-level for this run only, cleared after run completes). */
   env?: Record<string, string>
+  /** Previous conversation history to inject as context (e.g., agent switch). */
+  history?: readonly { role: "user" | "assistant"; content: string }[]
 }
 
 /** Background session handle returned by createBackgroundAgentSession. */
@@ -188,12 +190,10 @@ export async function createBackgroundAgentSession(
     backgroundSessionId: bgSession.id,
     async start(prompt: string, startOptions?: BackgroundStartOptions) {
       const t1 = Date.now()
-      // Pass run-level env if provided (overrides session-level for this run only)
-      if (startOptions?.env) {
-        await bgSession.start(prompt, { env: startOptions.env })
-      } else {
-        await bgSession.start(prompt)
-      }
+      await bgSession.start(prompt, {
+        ...(startOptions?.env && { env: startOptions.env }),
+        ...(startOptions?.history?.length && { history: startOptions.history }),
+      })
       console.log(`[createBackgroundAgentSession] bgSession.start took ${Date.now() - t1}ms`)
     },
   }


### PR DESCRIPTION
## Overview

This PR implements the History Injection feature, enabling agent switching mid-conversation without losing context.

Previously, switching agents (e.g., Claude -> Gemini) reset context because the new CLI process lacked session state and could not reuse agent specific resume mechanisms. This change resolves that by reconstructing conversation context from persisted storage and injecting it into the first prompt of the new agent.

## Changes

### SDK Layer (`packages/agents`)

* Added `HistoryMessage` interface (`role`, `content`)
* Extended `StartOptions` with `history` field
* Implemented `formatHistory()` in `BackgroundSessionImpl` to convert DB messages into structured prompt text
* Updated `start()` to inject history into prompt flow:

  * Order: `system prompt, then history, then user prompt`
* Re-exported `HistoryMessage` across public SDK barrels

### Web Backend (`packages/web`)

* Extended `BackgroundStartOptions` to support `history`
* Updated `/api/agent/execute` to detect agent switches via:

  * `requestedAgent !== sandboxRecord.sessionAgent`
* On agent switch:

  * Loads branch message history from PostgreSQL
  * Injects formatted history into SDK call
* Added observability logs for agent transitions:

  * Example: `Agent switch claude-code → gemini: injecting 6 history messages`

---

## Key Design Decisions

* Server-side-only detection and injection; frontend remains unchanged
* History is prepended to prompt (not system prompt) to preserve system-level instruction priority
* Sandbox reuse preserved:

  * Git state unchanged
  * Filesystem continuity maintained
  * Branch identity preserved

---

## Verification

* All tests pass
* Type safety confirmed:

  * `npx tsc --noEmit` in `packages/agents` → clean
  * `npx tsc --noEmit` in `packages/web` → clean
* Verified agent switch detection correctly triggers history hydration