### PR TITLE
Add support for history injection in simple-chat

### DIFF
--- a/packages/web/app/api/chats/[chatId]/messages/route.ts
+++ b/packages/web/app/api/chats/[chatId]/messages/route.ts
@@ -231,12 +231,53 @@ export async function POST(
         uploadedFilePaths.map((p) => `- ${p}`).join("\n")
     }
 
+    // ── Agent switch detection ────────────────────────────────────────────
+    // Detect by comparing the incoming agent against the agent that produced
+    // the most recent assistant message. Per-message agent fields are
+    // immutable, so this works even though chat.agent was already PATCHed
+    // by the dropdown change.
+    const lastAssistant = await prisma.message.findFirst({
+      where: { chatId, role: "assistant" },
+      orderBy: { timestamp: "desc" },
+      select: { agent: true },
+    })
+    const isAgentSwitch =
+      !!lastAssistant?.agent && lastAssistant.agent !== payload.agent
+
+    let history:
+      | { role: "user" | "assistant"; content: string }[]
+      | undefined
+
+    if (isAgentSwitch) {
+      const messages = await prisma.message.findMany({
+        where: { chatId },
+        orderBy: { timestamp: "asc" },
+        select: { role: true, content: true },
+      })
+      history = messages
+        .filter(
+          (
+            m
+          ): m is typeof m & { role: "user" | "assistant" } =>
+            (m.role === "user" || m.role === "assistant") &&
+            !!m.content.trim()
+        )
+        .map((m) => ({ role: m.role, content: m.content }))
+
+      if (history.length === 0) history = undefined
+      else
+        console.log(
+          `[chats/messages] Agent switch detected: injecting ${history.length} history messages`
+        )
+    }
+
     // ── Stage 4: spin up the background session (does NOT start the agent yet) ──
     const env = getEnvForModel(payload.model, payload.agent as Agent, credentials)
     const bgSession = await createBackgroundAgentSession(sandbox, {
       repoPath,
       previewUrlPattern: previewUrlPattern ?? undefined,
-      sessionId: chat.sessionId ?? undefined,
+      // On agent switch, don't pass the old agent's sessionId — it would crash the new CLI
+      sessionId: isAgentSwitch ? undefined : (chat.sessionId ?? undefined),
       agent: payload.agent as Agent,
       model: payload.model,
       env: Object.keys(env).length > 0 ? env : undefined,
@@ -265,6 +306,8 @@ export async function POST(
           role: "user",
           content: agentPrompt,
           timestamp: BigInt(now),
+          agent: payload.agent,
+          model: payload.model,
           uploadedFiles:
             uploadedFilePaths.length > 0
               ? (uploadedFilePaths as unknown as Prisma.InputJsonValue)
@@ -272,6 +315,8 @@ export async function POST(
         },
         update: {
           content: agentPrompt,
+          agent: payload.agent,
+          model: payload.model,
           uploadedFiles:
             uploadedFilePaths.length > 0
               ? (uploadedFilePaths as unknown as Prisma.InputJsonValue)
@@ -287,6 +332,8 @@ export async function POST(
           role: "assistant",
           content: "",
           timestamp: BigInt(now + 1),
+          agent: payload.agent,
+          model: payload.model,
           toolCalls: [],
           contentBlocks: [],
         },
@@ -302,12 +349,14 @@ export async function POST(
           // Persist agent/model so subsequent messages on this chat keep them
           agent: payload.agent,
           model: payload.model,
+          // Clear stale sessionId on agent switch — new agent will generate its own
+          ...(isAgentSwitch && { sessionId: null }),
         },
       })
     })
 
     // ── Stage 6: kick off the agent ────────────────────────────────────────
-    await bgSession.start(agentPrompt)
+    await bgSession.start(agentPrompt, history ? { history } : undefined)
 
     // Log message sent activity (fire and forget)
     logActivityAsync(userId, "message_sent", {

--- a/packages/web/app/api/chats/[chatId]/route.ts
+++ b/packages/web/app/api/chats/[chatId]/route.ts
@@ -26,6 +26,8 @@ interface MessageResponse {
   uploadedFiles: unknown
   linkBranch: string | null
   metadata: unknown
+  agent: string | null
+  model: string | null
 }
 
 interface ChatWithMessagesResponse {
@@ -124,6 +126,8 @@ export async function GET(
         uploadedFiles: m.uploadedFiles,
         linkBranch: m.linkBranch,
         metadata: m.metadata,
+        agent: m.agent,
+        model: m.model,
       })),
     }
 

--- a/packages/web/lib/agent-session.ts
+++ b/packages/web/lib/agent-session.ts
@@ -73,9 +73,14 @@ export interface AgentSessionOptions {
 // Background Session
 // =============================================================================
 
+export interface BackgroundStartOptions {
+  /** Previous conversation history to inject as context (e.g., on agent switch). */
+  history?: readonly { role: "user" | "assistant"; content: string }[]
+}
+
 export interface BackgroundAgentSession {
   backgroundSessionId: string
-  start: (prompt: string) => Promise<void>
+  start: (prompt: string, options?: BackgroundStartOptions) => Promise<void>
 }
 
 export async function createBackgroundAgentSession(
@@ -116,8 +121,10 @@ export async function createBackgroundAgentSession(
 
   return {
     backgroundSessionId: bgSession.id,
-    async start(prompt: string) {
-      await bgSession.start(prompt)
+    async start(prompt: string, options?: BackgroundStartOptions) {
+      await bgSession.start(prompt, {
+        ...(options?.history?.length && { history: options.history }),
+      })
     },
   }
 }

--- a/packages/web/lib/sync/api.ts
+++ b/packages/web/lib/sync/api.ts
@@ -47,6 +47,8 @@ export interface MessageResponse {
   uploadedFiles: unknown
   linkBranch: string | null
   metadata: unknown
+  agent: string | null
+  model: string | null
 }
 
 export interface ChatWithMessagesResponse extends ChatResponse {
@@ -236,6 +238,8 @@ export function toMessageType(serverMessage: MessageResponse): Message {
     role: serverMessage.role as Message["role"],
     content: serverMessage.content,
     timestamp: serverMessage.timestamp,
+    agent: serverMessage.agent || undefined,
+    model: serverMessage.model || undefined,
     messageType: serverMessage.messageType as Message["messageType"],
     isError: serverMessage.isError,
     toolCalls: serverMessage.toolCalls as Message["toolCalls"],

--- a/packages/web/lib/types.ts
+++ b/packages/web/lib/types.ts
@@ -47,6 +47,10 @@ export interface Message {
   role: "user" | "assistant"
   content: string
   timestamp: number
+  /** Which agent produced this message */
+  agent?: string
+  /** Which model produced this message */
+  model?: string
   /** Type of message - defaults to "chat" for regular messages */
   messageType?: MessageType
   /** For git-operation messages, whether this is an error */

--- a/packages/web/prisma/migrations/20260501132248_add_agent_model_to_message/migration.sql
+++ b/packages/web/prisma/migrations/20260501132248_add_agent_model_to_message/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Message" ADD COLUMN     "agent" TEXT,
+ADD COLUMN     "model" TEXT;

--- a/packages/web/prisma/schema.prisma
+++ b/packages/web/prisma/schema.prisma
@@ -137,6 +137,10 @@ model Message {
   content   String  @db.Text
   timestamp BigInt // Unix timestamp in milliseconds
 
+  // Which agent/model produced this message (nullable for old messages)
+  agent String?
+  model String?
+
   // Optional fields
   messageType String? // "chat" | "git-operation"
   isError     Boolean @default(false)


### PR DESCRIPTION
## Summary

When a user switches agents mid-conversation (e.g., Claude → Gemini), the new agent now receives the full conversation history as context. Previously, the new agent started completely blind and had no knowledge of what was discussed.

This PR also fixes the **Claude → Codex crash bug** as a side-effect where the old agent's session ID was passed to the new CLI, causing it to fail.

## Changes

### Per-message agent/model tracking
- Added `agent` and `model` columns to the `Message` model (nullable for backward compat with existing rows)
- Every user and assistant message now records which agent/model produced it
- These fields are returned in the GET API and mapped through to the frontend types

### History injection on agent switch
- **Detection:** When a message is sent, the backend compares `payload.agent` against the `agent` field on the most recent assistant message. If they differ, it's an agent switch.
- **Loading:** All messages for the chat are loaded from PostgreSQL and formatted as history.
- **Injection:** History is passed to the SDK's `bgSession.start(prompt, { history })`, which prepends it to the prompt in the format: `system prompt → conversation history → current prompt`.

### Session ID crash fix
- On agent switch, the old agent's `sessionId` is no longer passed to the new CLI (it's set to `undefined`).
- After the switch, the stale `sessionId` is cleared from the Chat row in the DB.
- The new agent generates its own session ID on its first turn.

## Files changed

| File | What |
|------|------|
| `prisma/schema.prisma` | Added `agent String?` and `model String?` to Message |
| `app/api/chats/[chatId]/messages/route.ts` | Agent switch detection, history loading, sessionId clearing, agent/model on messages |
| `lib/agent-session.ts` | `BackgroundStartOptions` interface, forwards `history` to SDK |
| `app/api/chats/[chatId]/route.ts` | Returns `agent`/`model` in message response |
| `lib/types.ts` | Added `agent?`/`model?` to client Message type |
| `lib/sync/api.ts` | Added `agent`/`model` to MessageResponse and toMessageType |