### PR TITLE
feat: left align user message and render as markdown

### DIFF
--- a/packages/web/components/MessageBubble.tsx
+++ b/packages/web/components/MessageBubble.tsx
@@ -33,16 +33,15 @@ export function MessageBubble({ message, isStreaming, isMobile = false, repo, on
       {/* Content */}
       <div className={cn(
         !isUser && "w-full",
-        isUser && "text-right",
         isUser && (isMobile ? "max-w-[95%]" : "max-w-[90%]")
       )}>
         {isUser ? (
           <div>
             <div className={cn(
-              "inline-block rounded-lg bg-muted text-foreground",
+              "inline-block rounded-lg bg-muted text-foreground text-left",
               isMobile ? "px-3 py-2 text-base" : "px-4 py-2 text-[15px]"
             )}>
-              <p className="whitespace-pre-wrap">{message.content}</p>
+              <MarkdownContent text={message.content} isMobile={isMobile} />
             </div>
             {/* Uploaded files display */}
             {hasUploadedFiles && (
@@ -119,10 +118,6 @@ function CodeBlock({ children, isMobile = false }: { children: React.ReactNode; 
     </div>
   )
 }
-
-// =============================================================================
-// Assistant Content (with tool calls)
-// =============================================================================
 
 function MarkdownContent({ text, isMobile = false }: { text: string; isMobile?: boolean }) {
   return (
@@ -252,6 +247,10 @@ function MarkdownContent({ text, isMobile = false }: { text: string; isMobile?: 
     </div>
   )
 }
+
+// =============================================================================
+// Assistant Content (with tool calls)
+// =============================================================================
 
 function AssistantContent({ message, isStreaming, isMobile = false, repo, onOpenFile, onForcePush }: { message: Message; isStreaming?: boolean; isMobile?: boolean; repo?: string; onOpenFile?: (filePath: string) => void; onForcePush?: () => void }) {
   const hasContent = message.content && message.content.trim().length > 0


### PR DESCRIPTION

| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/2a4afb17-86bc-4f34-9a4c-8fc287cc28d2" width="400"/> | <img src="https://github.com/user-attachments/assets/4a19d6cc-d684-441f-a87c-097593071774" width="400"/> |

## Summary
- User messages now render markdown formatting
- Fixed text alignment: bubble stays right-aligned, content inside is left-aligned
- Reuses existing `MarkdownContent` component for consistency with assistant messages

## Changes
- Removed `text-right` from user message container (was causing content to right-align)
- Added `text-left` to the bubble div for proper text alignment inside
- Replaced plain `<p>` tag with `<MarkdownContent>` component for markdown rendering