### PR TITLE
Inject Conversation History When Forking a Chat

### DIFF
--- a/packages/web/app/api/chats/[chatId]/messages/route.ts
+++ b/packages/web/app/api/chats/[chatId]/messages/route.ts
@@ -271,6 +271,33 @@ export async function POST(
         )
     }
 
+    // ── Chat fork detection ───────────────────────────────────────────────
+    // When a chat is forked from a parent (via /branch, Option+Enter, etc.),
+    // the first message should include the parent's conversation history so
+    // the agent has context about what was previously discussed.
+    if (!history && chat.parentChatId && !lastAssistant) {
+      const parentMessages = await prisma.message.findMany({
+        where: { chatId: chat.parentChatId },
+        orderBy: { timestamp: "asc" },
+        select: { role: true, content: true },
+      })
+      history = parentMessages
+        .filter(
+          (
+            m
+          ): m is typeof m & { role: "user" | "assistant" } =>
+            (m.role === "user" || m.role === "assistant") &&
+            !!m.content.trim()
+        )
+        .map((m) => ({ role: m.role, content: m.content }))
+
+      if (history.length === 0) history = undefined
+      else
+        console.log(
+          `[chats/messages] Chat fork detected: injecting ${history.length} parent messages`
+        )
+    }
+
     // ── Stage 4: spin up the background session (does NOT start the agent yet) ──
     const env = getEnvForModel(payload.model, payload.agent as Agent, credentials)
     const bgSession = await createBackgroundAgentSession(sandbox, {


### PR DESCRIPTION
## Summary

When a user forks a chat (via `/branch`, `Option+Enter`, or branching a queued message), the new agent now receives the parent chat's conversation history as context. Previously, the new agent started completely blind without any knowledge of what was discussed in the parent chat.

## Changes

- Added a fork detection block in the `messages` route (`app/api/chats/[chatId]/messages/route.ts`).
- When a chat is forked (identified by the presence of `parentChatId`) and its first message is sent, the backend now loads the parent chat's messages from the database.
- These messages are passed as `history` to the agent's background session, injecting them into the prompt (the same mechanism used for agent switching).
- On subsequent messages in the forked chat, normal session resumption (`--resume`) takes over.