### PR TITLE
Detect expired GitHub tokens and prompt re-authorization

### DIFF
--- a/packages/web/app/api/chats/[chatId]/messages/route.ts
+++ b/packages/web/app/api/chats/[chatId]/messages/route.ts
@@ -211,6 +211,23 @@ export async function POST(
 
     const repoPath = `${PATHS.SANDBOX_HOME}/project`
 
+    // ── Stage 2b: refresh git remote token if sandbox is pre-existing ──────
+    // The sandbox's git remote URL contains the GitHub token that was active
+    // at clone time. If the user has re-authenticated since then (e.g. token
+    // revoked and re-authorized via ReAuthModal), that stored token is stale
+    // and any agent-initiated git push will fail with a 401. We overwrite the
+    // remote URL with the current session token before the agent starts.
+    // Skipped for newly-created sandboxes (token is already current) and for
+    // NEW_REPOSITORY chats (no remote configured).
+    if (!createdSandbox && githubToken && chat.repo && chat.repo !== NEW_REPOSITORY) {
+      const [repoOwner, repoName] = chat.repo.split("/")
+      if (repoOwner && repoName) {
+        await sandbox.process.executeCommand(
+          `cd ${repoPath} && git remote set-url origin https://x-access-token:${githubToken}@github.com/${repoOwner}/${repoName}.git 2>&1 || true`
+        )
+      }
+    }
+
     // ── Stage 3: file upload ───────────────────────────────────────────────
     let uploadedFilePaths: string[] = []
     if (files.length > 0) {

--- a/packages/web/app/api/github/validate-token/route.ts
+++ b/packages/web/app/api/github/validate-token/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server"
+import { getServerSession } from "next-auth"
+import { authOptions } from "@/lib/auth"
+import { getUser, isGitHubApiError } from "@upstream/common"
+
+/**
+ * Validates whether the GitHub access token stored in the JWT is still
+ * accepted by GitHub. Called once per page load by the client to detect
+ * revoked / expired tokens early.
+ *
+ * Returns { valid: true } when the token works or when we can't
+ * determine validity (network errors, GitHub 5xx). Only returns
+ * { valid: false } on a definitive 401 from GitHub, so we don't
+ * force re-auth during outages.
+ */
+export async function GET() {
+  const session = await getServerSession(authOptions)
+  if (!session?.accessToken) {
+    return NextResponse.json({ valid: false })
+  }
+
+  try {
+    await getUser(session.accessToken)
+    return NextResponse.json({ valid: true })
+  } catch (error: unknown) {
+    if (isGitHubApiError(error) && error.status === 401) {
+      return NextResponse.json({ valid: false })
+    }
+
+    return NextResponse.json({ valid: true })
+  }
+}

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -10,6 +10,7 @@ import { PreviewView, type PreviewItem } from "@/components/PreviewView"
 import { RepoPickerModal } from "@/components/modals/RepoPickerModal"
 import { SettingsModal, type HighlightKey } from "@/components/modals/SettingsModal"
 import { SignInModal } from "@/components/modals/SignInModal"
+import { ReAuthModal } from "@/components/modals/ReAuthModal"
 import { HelpModal } from "@/components/modals/HelpModal"
 import { ConfirmDialog } from "@/components/modals/ConfirmDialog"
 import { BranchPickerModal } from "@/components/modals/BranchPickerModal"
@@ -20,6 +21,7 @@ import type { SlashCommandType } from "@/components/SlashCommandMenu"
 import { PaletteProvider } from "@/components/search-palette"
 import { useChatWithSync } from "@/lib/hooks/useChatWithSync"
 import { useMobile } from "@/lib/hooks/useMobile"
+import { useGitHubTokenCheck } from "@/lib/hooks/useGitHubTokenCheck"
 import { NEW_REPOSITORY, getDefaultAgent, getDefaultModelForAgent, type Agent, type Message, type Chat } from "@/lib/types"
 import { useReposQuery, useBranchesQuery, useServersQuery } from "@/lib/query"
 import { PATHS } from "@upstream/common"
@@ -59,6 +61,7 @@ function loadAndClearPendingMessage(): PendingMessage | null {
 
 export default function HomePage() {
   const { data: session } = useSession()
+  const { githubTokenInvalid } = useGitHubTokenCheck()
   const isMobile = useMobile()
 
   const {
@@ -1144,6 +1147,13 @@ export default function HomePage() {
       <SignInModal
         open={signInModalOpen}
         onClose={() => setSignInModalOpen(false)}
+        isMobile={isMobile}
+      />
+
+      {/* Re-auth Modal - shown when stored GitHub token has expired or been revoked */}
+      <ReAuthModal
+        open={githubTokenInvalid}
+        onClose={() => {}}
         isMobile={isMobile}
       />
 

--- a/packages/web/components/modals/ReAuthModal.tsx
+++ b/packages/web/components/modals/ReAuthModal.tsx
@@ -1,0 +1,97 @@
+"use client"
+
+import { signIn } from "next-auth/react"
+import * as Dialog from "@radix-ui/react-dialog"
+import { AlertTriangle, Github } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { ModalHeader, focusChatPrompt } from "@/components/ui/modal-header"
+
+interface ReAuthModalProps {
+  open: boolean
+  onClose: () => void
+  isMobile?: boolean
+}
+
+/**
+ * Shown when the GitHub access token stored in the session has expired
+ * or been revoked. The user must re-authorize via OAuth to continue
+ * using GitHub-dependent features (repos, branches, push, PRs, etc.).
+ *
+ * Mirrors the structure and styling of SignInModal but with re-auth
+ * specific copy and a warning icon.
+ */
+export function ReAuthModal({ open, onClose, isMobile = false }: ReAuthModalProps) {
+  const handleReAuth = () => {
+    signIn("github")
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+      <Dialog.Portal>
+        <Dialog.Overlay className={cn(
+          "fixed inset-0 z-50 transition-opacity duration-300 bg-black/15 backdrop-blur-[1px]",
+          open ? "opacity-100" : "opacity-0"
+        )} />
+        <Dialog.Content
+          onCloseAutoFocus={(e) => { e.preventDefault(); focusChatPrompt() }}
+          className={cn(
+            "fixed z-50 bg-popover overflow-hidden flex flex-col",
+            isMobile
+              ? "inset-x-4 top-1/2 -translate-y-1/2 rounded-xl"
+              : "top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-md border border-border rounded-lg shadow-xl"
+          )}
+        >
+          <ModalHeader
+            title={
+              <>
+                <AlertTriangle className="h-4 w-4 text-amber-500" />
+                GitHub authorization expired
+              </>
+            }
+          />
+
+          {/* Content */}
+          <div className={cn(
+            "flex flex-col items-center text-center",
+            isMobile ? "p-6 space-y-4" : "p-6 space-y-4"
+          )}>
+            <p className={cn(
+              "text-muted-foreground",
+              isMobile ? "text-base" : "text-sm"
+            )}>
+              Your GitHub access has expired or been revoked. Please authorize again to continue working with repositories, branches, and other GitHub features.
+            </p>
+
+            <button
+              autoFocus
+              onClick={handleReAuth}
+              className={cn(
+                "w-full flex items-center justify-center gap-2 rounded-md bg-[#24292f] text-white hover:bg-[#24292f]/90 active:bg-[#24292f]/80 transition-colors font-medium cursor-pointer",
+                isMobile ? "px-6 py-3 text-base" : "px-4 py-2.5 text-sm"
+              )}
+            >
+              <Github className={cn(isMobile ? "h-5 w-5" : "h-4 w-4")} />
+              Authorize with GitHub
+            </button>
+          </div>
+
+          {/* Footer */}
+          <div className={cn(
+            "flex justify-center border-t border-border bg-popover",
+            isMobile ? "px-4 py-3" : "px-4 py-3"
+          )}>
+            <button
+              onClick={onClose}
+              className={cn(
+                "text-muted-foreground hover:text-foreground transition-colors cursor-pointer",
+                isMobile ? "text-sm" : "text-xs"
+              )}
+            >
+              Dismiss
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/packages/web/lib/auth.ts
+++ b/packages/web/lib/auth.ts
@@ -33,6 +33,26 @@ export const authOptions: NextAuthOptions = {
       }
       if (account) {
         token.accessToken = account.access_token
+
+        // Sync the fresh token to the Account table. The PrismaAdapter only
+        // writes Account rows on the very first link (create, not upsert), so
+        // on re-authorization the DB row keeps the old, revoked token. The
+        // agent stream route reads Account.access_token for auto-push, so we
+        // must keep it current.
+        if (token.sub && account.access_token) {
+          prisma.account
+            .updateMany({
+              where: {
+                userId: token.sub,
+                provider: account.provider,
+                providerAccountId: account.providerAccountId,
+              },
+              data: { access_token: account.access_token },
+            })
+            .catch((err) => {
+              console.error("[auth] Failed to sync access_token to Account table:", err)
+            })
+        }
       }
       return token
     },

--- a/packages/web/lib/hooks/useGitHubTokenCheck.ts
+++ b/packages/web/lib/hooks/useGitHubTokenCheck.ts
@@ -1,0 +1,42 @@
+"use client"
+
+import { useState, useEffect, useRef } from "react"
+import { useSession } from "next-auth/react"
+
+/**
+ * Validates the GitHub access token stored in the JWT on page load.
+ *
+ * The JWT can outlive the GitHub token (revoked, expired, de-authorized
+ * from GitHub Settings, etc.). This hook makes a single lightweight
+ * check when the session first loads and exposes the result so the
+ * caller can show a re-auth prompt.
+ *
+ * Only runs once per page load, not on every re-render.
+ *
+ * @returns `githubTokenInvalid` — true when we've confirmed the stored
+ *          token is rejected by GitHub (401). False by default and while
+ *          the check is in flight, so the UI doesn't flash a dialog.
+ */
+export function useGitHubTokenCheck(): { githubTokenInvalid: boolean } {
+  const { status } = useSession()
+  const checked = useRef(false)
+  const [githubTokenInvalid, setGithubTokenInvalid] = useState(false)
+
+  useEffect(() => {
+    if (status !== "authenticated" || checked.current) return
+    checked.current = true
+
+    fetch("/api/github/validate-token")
+      .then((res) => res.json())
+      .then((data: { valid: boolean }) => {
+        if (!data.valid) {
+          setGithubTokenInvalid(true)
+        }
+      })
+      .catch(() => {
+        // Network error reaching our own API — don't force re-auth
+      })
+  }, [status])
+
+  return { githubTokenInvalid }
+}


### PR DESCRIPTION
## Problem

The JWT session strategy captures `account.access_token` at sign-in time and bakes it into the token. The JWT itself never expires (self-signed, no server-side revocation check), so `useSession()` continues returning a valid session. However, if the underlying GitHub token is revoked, either by the user de-authorizing the OAuth app, or by GitHub rotating the token, all GitHub API calls silently fail with a 401. The user sees a working app (can navigate, open settings, etc.) but repos won't load, pushes fail, and PR creation errors out with no indication of what's wrong.

## Solution

Add a lightweight token validation check on page load for returning sessions. When the stored GitHub token is invalid, show a dialog prompting the user to re-authorize.

### How it works

1. A new `GET /api/github/validate-token` endpoint takes the `accessToken` from the server-side session and makes a `GET /user` call to GitHub.
   - **200** → `{ valid: true }`
   - **401** → `{ valid: false }`
   - **Network error / 5xx** → `{ valid: true }` (avoids re-auth loops during GitHub outages)

2. A `useGitHubTokenCheck` hook fires once per page load when `status === "authenticated"`. If the token is invalid, it sets a flag.

3. A `ReAuthModal` dialog (matching existing `SignInModal` styling) is shown with an explicit message: *"Your GitHub access has expired or been revoked."* The user clicks "Authorize with GitHub" to go through OAuth again.

## Changes

| File | Change |
|------|--------|
| `app/api/github/validate-token/route.ts` | **New.** Server-side endpoint to validate the token against GitHub. |
| `lib/hooks/useGitHubTokenCheck.ts` | **New.** Client hook, fires once per page load, exposes `githubTokenInvalid`. |
| `components/modals/ReAuthModal.tsx` | **New.** Re-auth dialog with warning icon and contextual copy. |
| `app/page.tsx` | Import hook + modal, one-line integration. |