### PR TITLE
Add chat search, settings search, theme toggle to command palette and…

### DIFF
--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -19,7 +19,7 @@ import { EnvironmentVariablesModal } from "@/components/modals/EnvironmentVariab
 import { MobileCommandsMenu } from "@/components/MobileCommandsMenu"
 import { clearAllStorage } from "@/lib/storage"
 import type { SlashCommandType } from "@/components/SlashCommandMenu"
-import { PaletteProvider } from "@/components/search-palette"
+import { PaletteProvider, usePalette } from "@/components/search-palette"
 import { useChatWithSync } from "@/lib/hooks/useChatWithSync"
 import { useMobile } from "@/lib/hooks/useMobile"
 import { useGitHubTokenCheck } from "@/lib/hooks/useGitHubTokenCheck"
@@ -58,6 +58,11 @@ function loadAndClearPendingMessage(): PendingMessage | null {
     }
   }
   return null
+}
+
+function ChatPanelWithPalette(props: React.ComponentProps<typeof ChatPanel>) {
+  const { openCommand } = usePalette()
+  return <ChatPanel {...props} onOpenCommandPalette={openCommand} />
 }
 
 export default function HomePage() {
@@ -964,7 +969,7 @@ export default function HomePage() {
       onCreateRepo={currentChat?.repo === NEW_REPOSITORY ? handleCreateRepo : undefined}
       showGitCommands={!!currentChat && currentChat.repo !== NEW_REPOSITORY}
       onOpenInGitHub={githubBranchUrl ? handleOpenInGitHub : undefined}
-      onOpenSettings={() => handleOpenSettings()}
+      onOpenSettings={handleOpenSettings}
       onToggleSidebar={!isMobile ? () => setSidebarCollapsed((v) => !v) : undefined}
       onSignIn={!session ? () => signIn("github") : undefined}
       onSignOut={session ? () => {
@@ -1130,7 +1135,7 @@ export default function HomePage() {
 
         <div className="flex-1 flex min-h-0">
             <div className="flex-1 flex flex-col min-w-0">
-              <ChatPanel
+              <ChatPanelWithPalette
                 chat={displayCurrentChat}
                 settings={settings}
                 credentialFlags={credentialFlags}

--- a/packages/web/components/ChatPanel.tsx
+++ b/packages/web/components/ChatPanel.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useRef, useEffect, useLayoutEffect, useMemo, useCallback } from "react"
-import { ArrowUp, Square, ChevronDown, Github, GitBranch, Key, X, Paperclip, Trash2, HelpCircle, Pencil, AlertTriangle, Loader2, Plus, GitBranchPlus } from "lucide-react"
+import { ArrowUp, Square, ChevronDown, Github, GitBranch, Key, X, Paperclip, Trash2, HelpCircle, Pencil, AlertTriangle, Loader2, Plus, GitBranchPlus, Command } from "lucide-react"
 import { cn } from "@/lib/utils"
 import type { Chat, Settings, Agent, ModelOption, PendingFile, CredentialFlags } from "@/lib/types"
 import { nanoid } from "nanoid"
@@ -56,9 +56,11 @@ interface ChatPanelProps {
   draft?: string
   /** Callback when draft text changes */
   onDraftChange?: (draft: string) => void
+  /** Callback to open the command palette */
+  onOpenCommandPalette?: () => void
 }
 
-export function ChatPanel({ chat, settings, credentialFlags, onSendMessage, onEnqueueMessage, onRemoveQueuedMessage, onResumeQueue, onStopAgent, onChangeRepo, onChangeBranch, onUpdateChat, onOpenSettings, onSlashCommand, onRequireSignIn, onDeleteChat, onOpenHelp, onOpenFile, onForcePush, onOpenEnvVars, isMobile = false, rebaseConflict, onAbortConflict, conflictActionLoading = false, onBranchWithMessage, onBranchQueuedMessage, canBranch = false, isLoadingMessages = false, draft = "", onDraftChange }: ChatPanelProps) {
+export function ChatPanel({ chat, settings, credentialFlags, onSendMessage, onEnqueueMessage, onRemoveQueuedMessage, onResumeQueue, onStopAgent, onChangeRepo, onChangeBranch, onUpdateChat, onOpenSettings, onSlashCommand, onRequireSignIn, onDeleteChat, onOpenHelp, onOpenFile, onForcePush, onOpenEnvVars, isMobile = false, rebaseConflict, onAbortConflict, conflictActionLoading = false, onBranchWithMessage, onBranchQueuedMessage, canBranch = false, isLoadingMessages = false, draft = "", onDraftChange, onOpenCommandPalette }: ChatPanelProps) {
   // Use draft prop as input value (controlled component pattern for per-chat drafts)
   const input = draft
   const setInput = useCallback((value: string) => {
@@ -937,16 +939,28 @@ export function ChatPanel({ chat, settings, credentialFlags, onSendMessage, onEn
         "flex-1 flex flex-col items-center justify-center bg-background relative",
         isMobile ? "p-4 pb-safe" : "p-4"
       )}>
-        {onOpenHelp && (
-          <button
-            onClick={onOpenHelp}
-            className="absolute top-3 right-3 p-1.5 rounded-md hover:bg-accent text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
-            title="Help"
-            aria-label="Help"
-          >
-            <HelpCircle className="h-4 w-4" />
-          </button>
-        )}
+        <div className="absolute top-3 right-3 flex items-center gap-1">
+          {onOpenCommandPalette && (
+            <button
+              onClick={onOpenCommandPalette}
+              className="p-1.5 rounded-md hover:bg-accent text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+              title="Commands"
+              aria-label="Open commands"
+            >
+              <Command className="h-4 w-4" />
+            </button>
+          )}
+          {onOpenHelp && (
+            <button
+              onClick={onOpenHelp}
+              className="p-1.5 rounded-md hover:bg-accent text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+              title="Help"
+              aria-label="Help"
+            >
+              <HelpCircle className="h-4 w-4" />
+            </button>
+          )}
+        </div>
         <div className="text-center mb-6">
           <h2 className={cn("font-semibold", isMobile ? "text-xl" : "text-2xl")}>
             What would you like to build?
@@ -1151,6 +1165,18 @@ export function ChatPanel({ chat, settings, credentialFlags, onSendMessage, onEn
                 </div>
               )}
             </div>
+            )}
+          </div>
+          <div className="flex items-center gap-1">
+            {onOpenCommandPalette && (
+              <button
+                onClick={onOpenCommandPalette}
+                className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground transition-colors cursor-pointer"
+                title="Commands"
+                aria-label="Open commands"
+              >
+                <Command className="h-4 w-4" />
+              </button>
             )}
           </div>
         </div>

--- a/packages/web/components/modals/SettingsModal.tsx
+++ b/packages/web/components/modals/SettingsModal.tsx
@@ -25,6 +25,8 @@ import {
 
 /** Which provider's API key field to highlight */
 export type HighlightKey = ProviderId | null
+/** Settings modal section identifier */
+export type SectionKey = "general" | "api-keys" | "appearance"
 
 interface SettingsModalProps {
   open: boolean
@@ -37,6 +39,8 @@ interface SettingsModalProps {
   }) => Promise<{ ok: boolean; error?: string }>
   /** Which provider's first API key field to highlight with a red outline */
   highlightKey?: HighlightKey
+  /** Which section to show by default */
+  defaultSection?: SectionKey
   isMobile?: boolean
 }
 
@@ -46,8 +50,6 @@ const themeOptions: { value: Theme; label: string; icon: typeof Sun }[] = [
   { value: "dark", label: "Dark", icon: Moon },
 ]
 
-
-type SectionKey = "general" | "api-keys" | "appearance"
 
 const sections: { key: SectionKey; label: string; icon: typeof Bot }[] = [
   { key: "general", label: "General", icon: SettingsIcon },
@@ -168,7 +170,7 @@ function CopyCode({ text }: { text: string }) {
   )
 }
 
-export function SettingsModal({ open, onClose, settings, credentialFlags, onSave, highlightKey, isMobile = false }: SettingsModalProps) {
+export function SettingsModal({ open, onClose, settings, credentialFlags, onSave, highlightKey, defaultSection = "general", isMobile = false }: SettingsModalProps) {
   const { setTheme } = useTheme()
 
   // Refs for API key inputs, keyed by credential id.
@@ -202,7 +204,7 @@ export function SettingsModal({ open, onClose, settings, credentialFlags, onSave
   const [defaultAgent, setDefaultAgent] = useState<Agent>(initialDefaultAgent)
   const [defaultModel, setDefaultModel] = useState(initialDefaultModel)
   const [selectedTheme, setSelectedTheme] = useState<Theme>(settings.theme)
-  const [activeSection, setActiveSection] = useState<SectionKey>("general")
+  const [activeSection, setActiveSection] = useState<SectionKey>(defaultSection)
 
   // Swipe to dismiss state (mobile only)
   const [isDragging, setIsDragging] = useState(false)
@@ -232,9 +234,10 @@ export function SettingsModal({ open, onClose, settings, credentialFlags, onSave
       setDefaultAgent(initialDefaultAgent)
       setDefaultModel(initialDefaultModel)
       setSelectedTheme(settings.theme)
+      setActiveSection(defaultSection)
       setDragY(0)
     }
-  }, [open, settings, credentialFlags, initialDefaultAgent, initialDefaultModel])
+  }, [open, settings, credentialFlags, initialDefaultAgent, initialDefaultModel, defaultSection])
 
   // Switch to API Keys tab when a key is highlighted
   useEffect(() => {

--- a/packages/web/components/search-palette/CommandPalette.tsx
+++ b/packages/web/components/search-palette/CommandPalette.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { GitMerge, GitBranch, GitPullRequest, GitCommitVertical, Plus, GitBranchPlus, Settings, Github, PanelLeft, LogIn, LogOut, FolderGit2, Trash2, Code2, TerminalSquare, Globe, PanelRightClose, Download, Copy } from "lucide-react"
+import { useTheme } from "next-themes"
+import { GitMerge, GitBranch, GitPullRequest, GitCommitVertical, Plus, GitBranchPlus, Settings, Github, PanelLeft, LogIn, LogOut, FolderGit2, Trash2, Code2, TerminalSquare, Globe, PanelRightClose, Download, Copy, MessageSquare, Key, Sun, Moon, Monitor, Search } from "lucide-react"
 import {
   CommandDialog,
   CommandInput,
@@ -9,9 +10,12 @@ import {
   CommandGroup,
   CommandItem,
   CommandShortcut,
+  CommandSeparator,
 } from "@/components/ui/command"
 import { cn } from "@/lib/utils"
 import { SLASH_COMMANDS } from "@upstream/common"
+import type { SectionKey } from "@/components/modals/SettingsModal"
+import type { Theme } from "@/lib/types"
 
 /** Custom italic x icon for variables */
 function VariableIcon({ className }: { className?: string }) {
@@ -31,6 +35,11 @@ const iconMap: Record<string, React.ComponentType<{ className?: string }>> = {
   FolderGit2,
 }
 
+interface ChatItem {
+  id: string
+  displayName: string | null
+}
+
 interface CommandPaletteProps {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -44,7 +53,7 @@ interface CommandPaletteProps {
   showGitCommands?: boolean
   /** Omitted when the current chat has no pushed branch on GitHub. */
   onOpenInGitHub?: () => void
-  onOpenSettings: () => void
+  onOpenSettings: (section?: SectionKey) => void
   onToggleSidebar?: () => void
   onSignIn?: () => void
   onSignOut?: () => void
@@ -64,6 +73,14 @@ interface CommandPaletteProps {
   onCopyCheckoutCommand?: () => void
   /** Open environment variables modal. Omitted when no chat is active. */
   onOpenEnvVars?: () => void
+  /** Chats for search. */
+  chats?: ChatItem[]
+  /** Select a chat from search. */
+  onSelectChat?: (chatId: string) => void
+  /** Current theme value. */
+  currentTheme?: Theme
+  /** Change theme. */
+  onThemeChange?: (theme: Theme) => void
 }
 
 export function CommandPalette({
@@ -90,6 +107,10 @@ export function CommandPalette({
   onCopyCloneCommand,
   onCopyCheckoutCommand,
   onOpenEnvVars,
+  chats = [],
+  onSelectChat,
+  currentTheme = "system",
+  onThemeChange,
 }: CommandPaletteProps) {
   const handleSelect = (command: string) => {
     onRunCommand(command)
@@ -101,6 +122,26 @@ export function CommandPalette({
     onOpenChange(false)
   }
 
+  const themeIconMap: Record<Theme, typeof Sun> = {
+    system: Monitor,
+    light: Sun,
+    dark: Moon,
+  }
+
+  const themeLabels: Record<Theme, string> = {
+    system: "Auto",
+    light: "Light",
+    dark: "Dark",
+  }
+
+  const settingItems: { value: string; label: string; section: SectionKey; icon: typeof Settings }[] = [
+    { value: "settings general", label: "General settings", section: "general", icon: Settings },
+    { value: "settings api keys credentials", label: "API keys", section: "api-keys", icon: Key },
+    { value: "settings appearance theme", label: "Appearance", section: "appearance", icon: Sun },
+    { value: "settings default agent", label: "Default agent", section: "general", icon: Settings },
+    { value: "settings default model", label: "Default model", section: "general", icon: Settings },
+  ]
+
   return (
     <CommandDialog
       open={open}
@@ -111,6 +152,20 @@ export function CommandPalette({
       <CommandInput placeholder="Type a command..." />
       <CommandList>
         <CommandEmpty>No commands found.</CommandEmpty>
+        {chats.length > 0 && onSelectChat && (
+          <CommandGroup heading="Chats">
+            {chats.map((chat) => (
+              <CommandItem
+                key={chat.id}
+                value={`chat:${chat.displayName ?? "untitled"}:${chat.id}`}
+                onSelect={() => run(() => onSelectChat(chat.id))}
+              >
+                <MessageSquare className="mr-2 h-4 w-4 text-muted-foreground" />
+                <span>{chat.displayName ?? "Untitled Chat"}</span>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
         <CommandGroup heading="Chat">
           <CommandItem value="new chat" onSelect={() => run(onNewChat)}>
             <Plus className="mr-2 h-4 w-4 text-muted-foreground" />
@@ -214,6 +269,38 @@ export function CommandPalette({
             })}
           </CommandGroup>
         )}
+        <CommandGroup heading="Settings">
+          {settingItems.map((item) => (
+            <CommandItem
+              key={item.value}
+              value={item.value}
+              onSelect={() => run(() => onOpenSettings(item.section))}
+            >
+              <item.icon className="mr-2 h-4 w-4 text-muted-foreground" />
+              <span>{item.label}</span>
+            </CommandItem>
+          ))}
+        </CommandGroup>
+        {onThemeChange && (
+          <CommandGroup heading="Theme">
+            {(["system", "light", "dark"] as Theme[]).map((theme) => {
+              const Icon = themeIconMap[theme]
+              return (
+                <CommandItem
+                  key={theme}
+                  value={`theme ${theme} ${themeLabels[theme]}`}
+                  onSelect={() => run(() => onThemeChange(theme))}
+                >
+                  <Icon className="mr-2 h-4 w-4 text-muted-foreground" />
+                  <span>{themeLabels[theme]}</span>
+                  {currentTheme === theme && (
+                    <CommandShortcut>Active</CommandShortcut>
+                  )}
+                </CommandItem>
+              )
+            })}
+          </CommandGroup>
+        )}
         <CommandGroup heading="Application">
           {onToggleSidebar && (
             <CommandItem value="toggle sidebar" onSelect={() => run(onToggleSidebar)}>
@@ -221,7 +308,7 @@ export function CommandPalette({
               <span>Toggle sidebar</span>
             </CommandItem>
           )}
-          <CommandItem value="settings" onSelect={() => run(onOpenSettings)}>
+          <CommandItem value="settings" onSelect={() => run(() => onOpenSettings())}>
             <Settings className="mr-2 h-4 w-4 text-muted-foreground" />
             <span>Settings</span>
           </CommandItem>

--- a/packages/web/components/search-palette/PaletteProvider.tsx
+++ b/packages/web/components/search-palette/PaletteProvider.tsx
@@ -1,9 +1,12 @@
 "use client"
 
 import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from "react"
+import { useTheme } from "next-themes"
 import { SearchPalette } from "./SearchPalette"
 import { CommandPalette } from "./CommandPalette"
 import type { GitHubRepo, GitHubBranch } from "@/lib/github"
+import type { SectionKey } from "@/components/modals/SettingsModal"
+import type { Theme } from "@/lib/types"
 
 interface Chat {
   id: string
@@ -40,7 +43,7 @@ interface PaletteProviderProps {
   onCreateRepo?: () => void
   showGitCommands?: boolean
   onOpenInGitHub?: () => void
-  onOpenSettings: () => void
+  onOpenSettings: (section?: SectionKey) => void
   onToggleSidebar?: () => void
   onSignIn?: () => void
   onSignOut?: () => void
@@ -99,6 +102,7 @@ export function PaletteProvider({
   onSelectChat,
   onNavigateChat,
 }: PaletteProviderProps) {
+  const { theme, setTheme } = useTheme()
   const [searchOpen, setSearchOpenState] = useState(false)
   const [commandOpen, setCommandOpenState] = useState(false)
 
@@ -213,6 +217,10 @@ export function PaletteProvider({
         onCopyCloneCommand={onCopyCloneCommand}
         onCopyCheckoutCommand={onCopyCheckoutCommand}
         onOpenEnvVars={onOpenEnvVars}
+        chats={chats.map((c) => ({ id: c.id, displayName: c.displayName }))}
+        onSelectChat={onSelectChat}
+        currentTheme={(theme as Theme) ?? "system"}
+        onThemeChange={(newTheme: Theme) => setTheme(newTheme)}
       />
     </PaletteContext.Provider>
   )


### PR DESCRIPTION
… add open button to UI

- Add searchable chat items to the Cmd+K command palette
- Add settings search items (General, API Keys, Appearance, Default Agent/Model)
- Add theme toggle options (Auto, Light, Dark) with active indicator
- Add command palette button to home screen welcome area
- Add command palette button to individual chat headers
- Support opening settings to specific sections