### PR TITLE
Migrate GitHub OAuth Tokens from JWT to Postgres

### DIFF
--- a/packages/web/app/api/chats/[chatId]/messages/route.ts
+++ b/packages/web/app/api/chats/[chatId]/messages/route.ts
@@ -1,16 +1,14 @@
 import { Daytona } from "@daytonaio/sdk"
 import { NextRequest } from "next/server"
 import { Prisma } from "@prisma/client"
-import { getServerSession } from "next-auth"
 import { randomUUID } from "crypto"
-
-import { authOptions } from "@/lib/auth"
 import { PATHS } from "@/lib/constants"
 import { NEW_REPOSITORY } from "@/lib/types"
 import { prisma } from "@/lib/db/prisma"
 import {
   badRequest,
   getChatWithAuth,
+  getGitHubToken,
   getUserCredentials,
   internalError,
   isAuthError,
@@ -117,8 +115,7 @@ export async function POST(
   const daytonaApiKey = process.env.DAYTONA_API_KEY
   if (!daytonaApiKey) return serverConfigError("DAYTONA_API_KEY")
 
-  const session = await getServerSession(authOptions)
-  const githubToken = session?.accessToken
+  const githubToken = await getGitHubToken(userId)
 
   let credentials = await getUserCredentials(userId)
 
@@ -171,7 +168,7 @@ export async function POST(
         repo: chat.repo,
         baseBranch: chat.baseBranch ?? "main",
         newBranch,
-        githubToken,
+        githubToken: githubToken ?? undefined,
         userId,
       })
       sandboxId = created.sandboxId

--- a/packages/web/app/api/git/push/route.ts
+++ b/packages/web/app/api/git/push/route.ts
@@ -1,8 +1,7 @@
 import { Daytona } from "@daytonaio/sdk"
-import { getServerSession } from "next-auth"
 import { createSandboxGit } from "@upstream/daytona-git"
-import { authOptions } from "@/lib/auth"
 import { PATHS } from "@/lib/constants"
+import { requireGitHubAuth, isGitHubAuthError } from "@/lib/db/api-helpers"
 
 export async function POST(req: Request) {
   // 1. Parse request body
@@ -14,14 +13,14 @@ export async function POST(req: Request) {
   }
 
   // 2. Get GitHub token from request body first (for API access)
-  // Fall back to session token (for browser access)
+  // Fall back to DB token (for browser access)
   let githubToken = body.githubToken
   if (!githubToken) {
-    const session = await getServerSession(authOptions)
-    if (!session?.accessToken) {
+    const ghAuth = await requireGitHubAuth()
+    if (isGitHubAuthError(ghAuth)) {
       return Response.json({ error: "Unauthorized - provide githubToken in body or sign in" }, { status: 401 })
     }
-    githubToken = session.accessToken
+    githubToken = ghAuth.token
   }
 
   // 3. Get Daytona API key

--- a/packages/web/app/api/git/setup-remote/route.ts
+++ b/packages/web/app/api/git/setup-remote/route.ts
@@ -1,7 +1,6 @@
 import { Daytona } from "@daytonaio/sdk"
-import { getServerSession } from "next-auth"
-import { authOptions } from "@/lib/auth"
 import { PATHS } from "@/lib/constants"
+import { requireGitHubAuth, isGitHubAuthError } from "@/lib/db/api-helpers"
 
 /**
  * Sets up a GitHub remote for an existing local repo in a sandbox and pushes to it.
@@ -19,15 +18,15 @@ export async function POST(req: Request) {
     )
   }
 
-  // 2. Get GitHub token from session
-  const session = await getServerSession(authOptions)
-  if (!session?.accessToken) {
+  // 2. Get GitHub token from DB
+  const ghAuth = await requireGitHubAuth()
+  if (isGitHubAuthError(ghAuth)) {
     return Response.json(
       { error: "Unauthorized - please sign in with GitHub" },
       { status: 401 }
     )
   }
-  const githubToken = session.accessToken
+  const githubToken = ghAuth.token
 
   // 3. Get Daytona API key
   const daytonaApiKey = process.env.DAYTONA_API_KEY

--- a/packages/web/app/api/github/compare/route.ts
+++ b/packages/web/app/api/github/compare/route.ts
@@ -1,12 +1,9 @@
-import { getServerSession } from "next-auth"
-import { authOptions } from "@/lib/auth"
 import { compareBranches, isGitHubApiError } from "@upstream/common"
+import { requireGitHubAuth, isGitHubAuthError } from "@/lib/db/api-helpers"
 
 export async function POST(req: Request) {
-  const session = await getServerSession(authOptions)
-  if (!session?.accessToken) {
-    return Response.json({ error: "Unauthorized" }, { status: 401 })
-  }
+  const ghAuth = await requireGitHubAuth()
+  if (isGitHubAuthError(ghAuth)) return ghAuth
 
   const body = await req.json()
   const { owner, repo, base, head } = body
@@ -16,7 +13,7 @@ export async function POST(req: Request) {
   }
 
   try {
-    const compareData = await compareBranches(session.accessToken, owner, repo, base, head)
+    const compareData = await compareBranches(ghAuth.token, owner, repo, base, head)
     return Response.json({
       ahead_by: compareData.ahead_by,
       behind_by: compareData.behind_by,

--- a/packages/web/app/api/github/create-repo/route.ts
+++ b/packages/web/app/api/github/create-repo/route.ts
@@ -1,16 +1,10 @@
-import { getServerSession } from "next-auth"
-import { authOptions } from "@/lib/auth"
 import { createRepo, createFileCommit, type GitHubRepo } from "@upstream/common"
+import { requireGitHubAuth, isGitHubAuthError } from "@/lib/db/api-helpers"
 
 export async function POST(req: Request) {
-  // 1. Get session and verify auth
-  const session = await getServerSession(authOptions)
-  if (!session?.accessToken) {
-    return Response.json(
-      { error: "Unauthorized - please sign in with GitHub" },
-      { status: 401 }
-    )
-  }
+  // 1. Get GitHub token from DB
+  const ghAuth = await requireGitHubAuth()
+  if (isGitHubAuthError(ghAuth)) return ghAuth
 
   // 2. Parse request body
   const body = await req.json()
@@ -34,7 +28,7 @@ export async function POST(req: Request) {
 
   try {
     // 3. Create the repository
-    const repo: GitHubRepo = await createRepo(session.accessToken, {
+    const repo: GitHubRepo = await createRepo(ghAuth.token, {
       name,
       description: description || undefined,
       isPrivate: isPrivate ?? false,
@@ -43,7 +37,7 @@ export async function POST(req: Request) {
     // 4. Create initial commit so the default branch exists
     // Without this, the repo is empty and cloning with a branch fails
     await createFileCommit(
-      session.accessToken,
+      ghAuth.token,
       repo.owner.login,
       repo.name,
       {

--- a/packages/web/app/api/github/pr/route.ts
+++ b/packages/web/app/api/github/pr/route.ts
@@ -1,5 +1,3 @@
-import { getServerSession } from "next-auth"
-import { authOptions } from "@/lib/auth"
 import {
   compareBranches,
   createPullRequest,
@@ -7,6 +5,7 @@ import {
   formatPRTitleFromBranch,
   formatPRBodyFromCommits,
 } from "@upstream/common"
+import { requireGitHubAuth, isGitHubAuthError } from "@/lib/db/api-helpers"
 import { createGitOperationMessage } from "@/lib/db/git-messages"
 
 /** PR description format options */
@@ -36,10 +35,9 @@ function generatePRBodyByType(commits: string[], descriptionType: PRDescriptionT
 }
 
 export async function POST(req: Request) {
-  const session = await getServerSession(authOptions)
-  if (!session?.accessToken) {
-    return Response.json({ error: "Unauthorized" }, { status: 401 })
-  }
+  const ghAuth = await requireGitHubAuth()
+  if (isGitHubAuthError(ghAuth)) return ghAuth
+  const githubToken = ghAuth.token
 
   const body = await req.json()
   const { owner, repo, head, base, descriptionType = "short", chatId } = body
@@ -52,7 +50,7 @@ export async function POST(req: Request) {
     // Get commits between base and head for PR body
     let commitMessages: string[] = []
     try {
-      const compareData = await compareBranches(session.accessToken, owner, repo, base, head)
+      const compareData = await compareBranches(githubToken, owner, repo, base, head)
       const commits = compareData.commits || []
       if (commits.length > 0) {
         commitMessages = commits.map((c) => c.commit.message)
@@ -66,7 +64,7 @@ export async function POST(req: Request) {
     const prBody = generatePRBodyByType(commitMessages, descriptionType as PRDescriptionType)
 
     // Create the PR
-    const prData = await createPullRequest(session.accessToken, owner, repo, {
+    const prData = await createPullRequest(githubToken, owner, repo, {
       title,
       body: prBody,
       head,

--- a/packages/web/app/api/github/repo/route.ts
+++ b/packages/web/app/api/github/repo/route.ts
@@ -1,5 +1,5 @@
-import { getRepoBranches } from "@upstream/common"
 import { requireGitHubAuth, isGitHubAuthError } from "@/lib/db/api-helpers"
+import { getRepo } from "@upstream/common"
 
 export async function GET(req: Request) {
   const ghAuth = await requireGitHubAuth()
@@ -14,10 +14,10 @@ export async function GET(req: Request) {
   }
 
   try {
-    const branches = await getRepoBranches(ghAuth.token, owner, repo)
-    return Response.json({ branches })
+    const repoData = await getRepo(ghAuth.token, owner, repo)
+    return Response.json({ repo: repoData })
   } catch (error: unknown) {
-    console.error("[github/branches] Error:", error)
+    console.error("[github/repo] Error:", error)
     const message = error instanceof Error ? error.message : "Unknown error"
     return Response.json({ error: message }, { status: 500 })
   }

--- a/packages/web/app/api/github/repos/route.ts
+++ b/packages/web/app/api/github/repos/route.ts
@@ -1,0 +1,20 @@
+import { requireGitHubAuth, isGitHubAuthError } from "@/lib/db/api-helpers"
+import { getUserRepos } from "@upstream/common"
+
+export async function GET() {
+  const ghAuth = await requireGitHubAuth()
+  if (isGitHubAuthError(ghAuth)) return ghAuth
+
+  try {
+    const repos = await getUserRepos(ghAuth.token, {
+      sort: "updated",
+      perPage: 100,
+      affiliation: "owner,collaborator,organization_member",
+    })
+    return Response.json({ repos })
+  } catch (error: unknown) {
+    console.error("[github/repos] Error:", error)
+    const message = error instanceof Error ? error.message : "Unknown error"
+    return Response.json({ error: message }, { status: 500 })
+  }
+}

--- a/packages/web/app/api/github/squash/route.ts
+++ b/packages/web/app/api/github/squash/route.ts
@@ -1,9 +1,8 @@
-import { getServerSession } from "next-auth"
-import { authOptions } from "@/lib/auth"
 import { compareBranches, githubFetch, isGitHubApiError } from "@upstream/common"
 import { Daytona } from "@daytonaio/sdk"
 import { PATHS } from "@/lib/constants"
 import { createGitOperationMessage } from "@/lib/db/git-messages"
+import { requireGitHubAuth, isGitHubAuthError } from "@/lib/db/api-helpers"
 
 // Squash operation timeout - 60 seconds
 export const maxDuration = 60
@@ -31,10 +30,9 @@ interface SquashRequestBody {
  * 5. Sync sandbox with git fetch + reset
  */
 export async function POST(req: Request) {
-  const session = await getServerSession(authOptions)
-  if (!session?.accessToken) {
-    return Response.json({ error: "Unauthorized" }, { status: 401 })
-  }
+  const ghAuth = await requireGitHubAuth()
+  if (isGitHubAuthError(ghAuth)) return ghAuth
+  const githubToken = ghAuth.token
 
   const body: SquashRequestBody = await req.json()
   const { owner, repo, head, base, sandboxId, chatId } = body
@@ -50,7 +48,7 @@ export async function POST(req: Request) {
 
   try {
     // First, verify there are commits to squash
-    const compareData = await compareBranches(session.accessToken, owner, repo, base, head)
+    const compareData = await compareBranches(githubToken, owner, repo, base, head)
     if (compareData.ahead_by < 2) {
       return Response.json({
         error: `Need at least 2 commits to squash. Branch "${head}" is only ${compareData.ahead_by} commit(s) ahead of "${base}".`
@@ -60,7 +58,7 @@ export async function POST(req: Request) {
     // Get the base branch SHA
     const baseRef = await githubFetch<{ object: { sha: string } }>(
       `/repos/${owner}/${repo}/git/refs/heads/${base}`,
-      session.accessToken
+      githubToken
     )
     const baseSha = baseRef.object.sha
 
@@ -68,7 +66,7 @@ export async function POST(req: Request) {
     const tempBranchName = `_squash-temp-${Date.now()}`
     await githubFetch(
       `/repos/${owner}/${repo}/git/refs`,
-      session.accessToken,
+      githubToken,
       {
         method: "POST",
         body: JSON.stringify({
@@ -82,7 +80,7 @@ export async function POST(req: Request) {
       // Step 2: Create a temporary PR and squash merge it
       const pr = await githubFetch<{ number: number; head: { sha: string } }>(
         `/repos/${owner}/${repo}/pulls`,
-        session.accessToken,
+        githubToken,
         {
           method: "POST",
           body: JSON.stringify({
@@ -108,7 +106,7 @@ export async function POST(req: Request) {
 
           mergeResult = await githubFetch<{ sha: string; merged: boolean }>(
             `/repos/${owner}/${repo}/pulls/${pr.number}/merge`,
-            session.accessToken,
+            githubToken,
             {
               method: "PUT",
               body: JSON.stringify({
@@ -139,14 +137,14 @@ export async function POST(req: Request) {
       // Get the new squashed commit SHA from the temp branch
       const tempRef = await githubFetch<{ object: { sha: string } }>(
         `/repos/${owner}/${repo}/git/refs/heads/${tempBranchName}`,
-        session.accessToken
+        githubToken
       )
       const squashedSha = tempRef.object.sha
 
       // Step 3: Update head branch to point to the squashed commit
       await githubFetch(
         `/repos/${owner}/${repo}/git/refs/heads/${head}`,
-        session.accessToken,
+        githubToken,
         {
           method: "PATCH",
           body: JSON.stringify({
@@ -160,7 +158,7 @@ export async function POST(req: Request) {
       try {
         await githubFetch(
           `/repos/${owner}/${repo}/git/refs/heads/${tempBranchName}`,
-          session.accessToken,
+          githubToken,
           { method: "DELETE" }
         )
       } catch {
@@ -219,7 +217,7 @@ export async function POST(req: Request) {
       try {
         await githubFetch(
           `/repos/${owner}/${repo}/git/refs/heads/${tempBranchName}`,
-          session.accessToken,
+          githubToken,
           { method: "DELETE" }
         )
       } catch {

--- a/packages/web/app/api/github/validate-token/route.ts
+++ b/packages/web/app/api/github/validate-token/route.ts
@@ -1,10 +1,9 @@
 import { NextResponse } from "next/server"
-import { getServerSession } from "next-auth"
-import { authOptions } from "@/lib/auth"
 import { getUser, isGitHubApiError } from "@upstream/common"
+import { requireGitHubAuth, isGitHubAuthError } from "@/lib/db/api-helpers"
 
 /**
- * Validates whether the GitHub access token stored in the JWT is still
+ * Validates whether the GitHub access token stored in the database is still
  * accepted by GitHub. Called once per page load by the client to detect
  * revoked / expired tokens early.
  *
@@ -14,13 +13,13 @@ import { getUser, isGitHubApiError } from "@upstream/common"
  * force re-auth during outages.
  */
 export async function GET() {
-  const session = await getServerSession(authOptions)
-  if (!session?.accessToken) {
+  const ghAuth = await requireGitHubAuth()
+  if (isGitHubAuthError(ghAuth)) {
     return NextResponse.json({ valid: false })
   }
 
   try {
-    await getUser(session.accessToken)
+    await getUser(ghAuth.token)
     return NextResponse.json({ valid: true })
   } catch (error: unknown) {
     if (isGitHubApiError(error) && error.status === 401) {

--- a/packages/web/app/api/sandbox/git/route.ts
+++ b/packages/web/app/api/sandbox/git/route.ts
@@ -1,15 +1,13 @@
 import { Daytona } from "@daytonaio/sdk"
-import { getServerSession } from "next-auth"
 import { createSandboxGit } from "@upstream/daytona-git"
-import { authOptions } from "@/lib/auth"
 import { PATHS } from "@/lib/constants"
 import { createGitOperationMessage } from "@/lib/db/git-messages"
+import { requireGitHubAuth, isGitHubAuthError } from "@/lib/db/api-helpers"
 
 export async function POST(req: Request) {
-  const session = await getServerSession(authOptions)
-  if (!session?.accessToken) {
-    return Response.json({ error: "Unauthorized" }, { status: 401 })
-  }
+  const ghAuth = await requireGitHubAuth()
+  if (isGitHubAuthError(ghAuth)) return ghAuth
+  const githubToken = ghAuth.token
 
   const body = await req.json()
   const { sandboxId, repoPath, action, targetBranch, currentBranch, repoOwner, repoApiName, squash, targetSandboxId, chatId, sourceName, targetName } = body
@@ -22,8 +20,6 @@ export async function POST(req: Request) {
   if (!daytonaApiKey) {
     return Response.json({ error: "Daytona API key not configured" }, { status: 500 })
   }
-
-  const githubToken = session.accessToken
 
   try {
     const daytona = new Daytona({ apiKey: daytonaApiKey })

--- a/packages/web/components/modals/BranchPickerModal.tsx
+++ b/packages/web/components/modals/BranchPickerModal.tsx
@@ -54,7 +54,7 @@ export function BranchPickerModal({
 
   // Reset state and fetch repo info + branches when modal opens or repo changes
   useEffect(() => {
-    if (open && session?.accessToken && repo && owner) {
+    if (open && session && repo && owner) {
       // Reset all state when opening with a new repo
       setSearch("")
       setError(null)
@@ -64,8 +64,8 @@ export function BranchPickerModal({
 
       // Fetch repo info (for default branch) and branches in parallel
       Promise.all([
-        fetchRepo(session.accessToken, owner, repo),
-        fetchBranches(session.accessToken, owner, repo)
+        fetchRepo(owner, repo),
+        fetchBranches(owner, repo)
       ])
         .then(([repoInfo, fetchedBranches]) => {
           setRepoDefaultBranch(repoInfo.default_branch)
@@ -78,7 +78,7 @@ export function BranchPickerModal({
         .catch((err) => setError(err instanceof Error ? err.message : "Failed to fetch branches"))
         .finally(() => setLoading(false))
     }
-  }, [open, session?.accessToken, repo, owner, selectedBranch])
+  }, [open, session, repo, owner, selectedBranch])
 
   // Focus search field when modal opens
   useEffect(() => {

--- a/packages/web/components/modals/RepoPickerModal.tsx
+++ b/packages/web/components/modals/RepoPickerModal.tsx
@@ -121,15 +121,15 @@ export function RepoPickerModal({ open, onClose, onSelect, isMobile = false, mod
   // Fetch repos on open — only when the select tab is available; otherwise we
   // never show the repo list and the loading spinner would flash for nothing.
   useEffect(() => {
-    if (open && session?.accessToken && allowSelect) {
+    if (open && session && allowSelect) {
       setLoading(true)
       setError(null)
-      fetchRepos(session.accessToken)
+      fetchRepos()
         .then(setRepos)
         .catch((err) => setError(err.message))
         .finally(() => setLoading(false))
     }
-  }, [open, session?.accessToken, allowSelect])
+  }, [open, session, allowSelect])
 
   // Reset state on close/open - set correct initial tab
   // Also reset when modal opens to ensure correct tab based on current allowSelect/allowCreate values
@@ -164,7 +164,7 @@ export function RepoPickerModal({ open, onClose, onSelect, isMobile = false, mod
 
   // Handle branch-only mode with preselected repo - skip to branch selection
   useEffect(() => {
-    if (open && isBranchOnly && preselectedRepo && session?.accessToken) {
+    if (open && isBranchOnly && preselectedRepo && session) {
       setSelectedRepo(preselectedRepo)
       setSelectedBranch(preselectedRepo.default_branch)
       setStep("branch")
@@ -172,12 +172,12 @@ export function RepoPickerModal({ open, onClose, onSelect, isMobile = false, mod
       setError(null)
       setShowBranchDropdown(true)
 
-      fetchBranches(session.accessToken, preselectedRepo.owner.login, preselectedRepo.name)
+      fetchBranches(preselectedRepo.owner.login, preselectedRepo.name)
         .then(setBranches)
         .catch((err) => setError(err instanceof Error ? err.message : "Failed to fetch branches"))
         .finally(() => setLoading(false))
     }
-  }, [open, isBranchOnly, preselectedRepo, session?.accessToken])
+  }, [open, isBranchOnly, preselectedRepo, session])
 
   // Handle repo selection - one-click: select repo with default branch immediately
   // User can change branch later via the branch button in the chat header

--- a/packages/web/lib/auth.ts
+++ b/packages/web/lib/auth.ts
@@ -27,18 +27,15 @@ export const authOptions: NextAuthOptions = {
   ],
   callbacks: {
     async jwt({ token, user, account }) {
-      // On initial sign in, persist user id and access token
+      // On initial sign in, persist user id
       if (user) {
         token.sub = user.id
       }
       if (account) {
-        token.accessToken = account.access_token
-
         // Sync the fresh token to the Account table. The PrismaAdapter only
         // writes Account rows on the very first link (create, not upsert), so
-        // on re-authorization the DB row keeps the old, revoked token. The
-        // agent stream route reads Account.access_token for auto-push, so we
-        // must keep it current.
+        // on re-authorization the DB row keeps the old, revoked token. All
+        // routes that need the GitHub token read it from the Account table.
         if (token.sub && account.access_token) {
           prisma.account
             .updateMany({
@@ -57,7 +54,7 @@ export const authOptions: NextAuthOptions = {
       return token
     },
     async session({ session, token }) {
-      // Send user id and access token to client
+      // Send user id to client
       if (session.user && token.sub) {
         session.user.id = token.sub
 
@@ -68,7 +65,6 @@ export const authOptions: NextAuthOptions = {
         })
         session.user.isAdmin = user?.isAdmin ?? false
       }
-      session.accessToken = token.accessToken as string
       return session
     },
   },

--- a/packages/web/lib/db/api-helpers.ts
+++ b/packages/web/lib/db/api-helpers.ts
@@ -159,6 +159,18 @@ export interface GitHubAuthResult {
 }
 
 /**
+ * Gets the GitHub access token for a user from the database.
+ * Returns null if no GitHub account is linked or no token is stored.
+ */
+export async function getGitHubToken(userId: string): Promise<string | null> {
+  const account = await prisma.account.findFirst({
+    where: { userId, provider: "github" },
+    select: { access_token: true },
+  })
+  return account?.access_token ?? null
+}
+
+/**
  * Gets the authenticated user's GitHub token
  * Returns userId and token or an error Response
  */

--- a/packages/web/lib/github.ts
+++ b/packages/web/lib/github.ts
@@ -1,59 +1,65 @@
 /**
  * GitHub API client for Simple Chat
- * Re-exports shared utilities from @upstream/common
+ *
+ * All functions call server-side proxy routes — the GitHub token never
+ * leaves the server. The proxy routes fetch the token from the DB.
  */
 
-import {
-  getUser,
-  getUserRepos,
-  getRepo,
-  getRepoBranches,
-  type GitHubUser,
-  type GitHubRepo,
-  type GitHubBranch,
+import type {
+  GitHubUser,
+  GitHubRepo,
+  GitHubBranch,
 } from "@upstream/common"
 
 // Re-export types for convenience
 export type { GitHubUser, GitHubRepo, GitHubBranch }
 
 /**
- * Fetch the authenticated user
+ * Fetch repositories for the authenticated user (100 most recent).
+ * Calls GET /api/github/repos which reads the token from DB server-side.
  */
-export async function fetchUser(token: string): Promise<GitHubUser> {
-  return getUser(token)
+export async function fetchRepos(): Promise<GitHubRepo[]> {
+  const res = await fetch("/api/github/repos")
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}))
+    throw new Error((data as { error?: string }).error || "Failed to fetch repos")
+  }
+  const data = await res.json()
+  return data.repos
 }
 
 /**
- * Fetch repositories for the authenticated user (100 most recent)
- */
-export async function fetchRepos(token: string): Promise<GitHubRepo[]> {
-  return getUserRepos(token, {
-    sort: "updated",
-    perPage: 100,
-    affiliation: "owner,collaborator,organization_member",
-  })
-}
-
-/**
- * Fetch a single repository
+ * Fetch a single repository.
+ * Calls GET /api/github/repo which reads the token from DB server-side.
  */
 export async function fetchRepo(
-  token: string,
   owner: string,
   repo: string
 ): Promise<GitHubRepo> {
-  return getRepo(token, owner, repo)
+  const res = await fetch(`/api/github/repo?owner=${encodeURIComponent(owner)}&repo=${encodeURIComponent(repo)}`)
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}))
+    throw new Error((data as { error?: string }).error || "Failed to fetch repo")
+  }
+  const data = await res.json()
+  return data.repo
 }
 
 /**
- * Fetch branches for a repository
+ * Fetch branches for a repository.
+ * Calls GET /api/github/branches which reads the token from DB server-side.
  */
 export async function fetchBranches(
-  token: string,
   owner: string,
   repo: string
 ): Promise<GitHubBranch[]> {
-  return getRepoBranches(token, owner, repo, { perPage: 100, paginate: true })
+  const res = await fetch(`/api/github/branches?owner=${encodeURIComponent(owner)}&repo=${encodeURIComponent(repo)}`)
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}))
+    throw new Error((data as { error?: string }).error || "Failed to fetch branches")
+  }
+  const data = await res.json()
+  return data.branches
 }
 
 /**

--- a/packages/web/lib/hooks/useChatWithSync.ts
+++ b/packages/web/lib/hooks/useChatWithSync.ts
@@ -693,7 +693,7 @@ export function useChatWithSync() {
     sendInFlight.current.add(chatId)
 
     try {
-      if (!session?.accessToken) return
+      if (!session) return
 
       const isFirstMessage = chat.messages.length === 0
       const selectedAgent = (agent ?? chat.agent ?? settings.defaultAgent ?? getDefaultAgent(credentialFlags)) as Agent
@@ -787,7 +787,7 @@ export function useChatWithSync() {
     } finally {
       sendInFlight.current.delete(chatId)
     }
-  }, [currentChatId, chats, session?.accessToken, settings, credentialFlags, updateChatsCache, startStreaming, suggestNameMutation, isDraftChatId, materializeDraft])
+  }, [currentChatId, chats, session, settings, credentialFlags, updateChatsCache, startStreaming, suggestNameMutation, isDraftChatId, materializeDraft])
 
   const dispatchNextQueuedMessage = useCallback((chatId: string, queueOverride?: QueuedMessage[]) => {
     const chat = chats.find((c) => c.id === chatId)

--- a/packages/web/lib/query/hooks/useBranchesQuery.ts
+++ b/packages/web/lib/query/hooks/useBranchesQuery.ts
@@ -12,17 +12,14 @@ import { fetchBranches, type GitHubBranch } from "@/lib/github"
  * @param repo - Repository name
  */
 export function useBranchesQuery(owner: string, repo: string) {
-  const { data: session } = useSession()
+  const { status } = useSession()
 
   return useQuery({
     queryKey: queryKeys.github.branches(owner, repo),
     queryFn: async (): Promise<GitHubBranch[]> => {
-      if (!session?.accessToken) {
-        throw new Error("No access token available")
-      }
-      return fetchBranches(session.accessToken, owner, repo)
+      return fetchBranches(owner, repo)
     },
-    enabled: !!session?.accessToken && !!owner && !!repo,
+    enabled: status === "authenticated" && !!owner && !!repo,
     staleTime: 30 * 1000, // 30 seconds
   })
 }

--- a/packages/web/lib/query/hooks/useReposQuery.ts
+++ b/packages/web/lib/query/hooks/useReposQuery.ts
@@ -10,17 +10,14 @@ import { fetchRepos, type GitHubRepo } from "@/lib/github"
  * Sorted by recently updated, includes owned, collaborator, and org repos.
  */
 export function useReposQuery() {
-  const { data: session } = useSession()
+  const { status } = useSession()
 
   return useQuery({
     queryKey: queryKeys.github.repos(),
     queryFn: async (): Promise<GitHubRepo[]> => {
-      if (!session?.accessToken) {
-        throw new Error("No access token available")
-      }
-      return fetchRepos(session.accessToken)
+      return fetchRepos()
     },
-    enabled: !!session?.accessToken,
+    enabled: status === "authenticated",
     staleTime: 60 * 1000, // 1 minute
     gcTime: 5 * 60 * 1000, // 5 minutes
   })

--- a/packages/web/types/next-auth.d.ts
+++ b/packages/web/types/next-auth.d.ts
@@ -2,7 +2,6 @@ import "next-auth"
 
 declare module "next-auth" {
   interface Session {
-    accessToken?: string
     user: {
       id: string
       name?: string | null
@@ -15,7 +14,6 @@ declare module "next-auth" {
 
 declare module "next-auth/jwt" {
   interface JWT {
-    accessToken?: string
     sub?: string
   }
 }


### PR DESCRIPTION
### Description

**Problem**
Previously, our GitHub OAuth tokens were stored both in the database (`Account.access_token`) and in the NextAuth JWT session (`session.accessToken`). This dual-storage approach caused several issues:
1. **Stale Tokens:** If a user's token was revoked or expired, the database would eventually update on re-authentication, but active frontend sessions could still hold onto stale tokens in their JWTs.
2. **Security Exposure:** The raw GitHub `access_token` was sent directly to the client browser via the session object so that client-side hooks could make direct API calls to GitHub. 
3. **Inconsistent State:** Server-side API routes were relying on the JWT session for git operations while background agent streams relied on the database, creating a fragmented architecture.

**Solution & Changes**
This PR unifies our GitHub token management to exclusively use the PostgreSQL database as the single source of truth, establishing a more secure and reliable token lifecycle.

- **Server-Side API Refactoring:** Migrated all 10 API routes (including Git pushes, PR creation, squashing, and Sandbox initialization) to fetch the token directly from the database using the `requireGitHubAuth()` / `getGitHubToken()` helpers.
- **Client-Side Proxying:** The client no longer holds the raw GitHub token. Client-side API calls to GitHub (fetching repos, branches, etc.) have been rerouted to new server-side proxies (`/api/github/repos` and `/api/github/repo`), keeping the token securely on the backend.
- **JWT Cleanup:** Stripped `accessToken` from the NextAuth JWT and Session types. The `jwt` callback in `auth.ts` now only performs a one-way sync of fresh tokens to the database upon login.
- **Hook & Component Updates:** Updated `useReposQuery`, `useBranchesQuery`, `RepoPickerModal`, and `BranchPickerModal` to execute requests without needing a session token. Cleaned up remaining token dependencies in the `useChatWithSync` hook.

**Testing**
To manually verify these changes:
1. Log out and log back in to trigger the DB token sync.
2. Verify that the "Select Repository" modal successfully loads your repositories and branches.
3. Start a chat and verify that the sandbox initializes successfully.
4. Execute a git operation (like push or squash) from the UI to confirm the server successfully pulls the token from the database.