### PR TITLE
Implement Plan Mode

### DIFF
--- a/packages/agents/src/agents/claude/index.ts
+++ b/packages/agents/src/agents/claude/index.ts
@@ -85,6 +85,11 @@ export const claudeAgent: AgentDefinition = {
       args.push("--resume", options.sessionId)
     }
 
+    // Enable extended thinking when plan mode is active
+    if (options.planMode) {
+      args.push("--settings", JSON.stringify({ alwaysThinkingEnabled: true }))
+    }
+
     // The "--" sentinel signals end-of-options to the Claude CLI's argument parser
     if (options.prompt) {
       args.push("--")

--- a/packages/agents/src/agents/opencode/index.ts
+++ b/packages/agents/src/agents/opencode/index.ts
@@ -47,6 +47,11 @@ export const opencodeAgent: AgentDefinition = {
       parts.push("-s", quote(options.sessionId))
     }
 
+    // Enable extended thinking when plan mode is active
+    if (options.planMode) {
+      parts.push("--thinking")
+    }
+
     // The "--" sentinel signals end-of-options to the OpenCode's argument parser
     if (options.prompt) {
       parts.push("--")

--- a/packages/agents/src/background/types.ts
+++ b/packages/agents/src/background/types.ts
@@ -68,4 +68,6 @@ export interface StartOptions {
   cwd?: string
   /** Previous conversation history to inject as context for this turn. */
   history?: readonly HistoryMessage[]
+  /** When true, agent should use extended thinking / plan mode */
+  planMode?: boolean
 }

--- a/packages/agents/src/core/agent.ts
+++ b/packages/agents/src/core/agent.ts
@@ -46,6 +46,8 @@ export interface RunOptions {
   env?: Record<string, string>
   /** Working directory for the agent process */
   cwd?: string
+  /** When true, agent should use extended thinking / plan mode */
+  planMode?: boolean
 }
 
 /**

--- a/packages/agents/src/session.ts
+++ b/packages/agents/src/session.ts
@@ -44,6 +44,8 @@ export interface SessionOptions {
   env?: Record<string, string>
   /** Working directory for the agent process */
   cwd?: string
+  /** When true, agent should use extended thinking / plan mode */
+  planMode?: boolean
 }
 
 /**
@@ -177,6 +179,7 @@ async function createSessionWithId(
     systemPrompt: options.systemPrompt,
     env: options.env,
     cwd: options.cwd,
+    planMode: options.planMode,
   })
 
   // Write initial meta for reattachment

--- a/packages/web/app/api/chats/[chatId]/messages/route.ts
+++ b/packages/web/app/api/chats/[chatId]/messages/route.ts
@@ -68,6 +68,8 @@ interface MessagePayload {
   assistantMessageId: string
   /** Branch name for the new sandbox if one is being created. Generated server-side if omitted. */
   newBranch?: string
+  /** When true, agent should plan before acting */
+  planMode?: boolean
 }
 
 interface SuccessResponse {
@@ -387,6 +389,7 @@ export async function POST(
       agent: payload.agent as Agent,
       model: payload.model,
       env: Object.keys(env).length > 0 ? env : undefined,
+      planMode: payload.planMode,
     })
 
     // ── Stage 5: persist messages + chat status (transactional) ────────────

--- a/packages/web/app/api/chats/[chatId]/messages/route.ts
+++ b/packages/web/app/api/chats/[chatId]/messages/route.ts
@@ -445,6 +445,7 @@ export async function POST(
           model: payload.model,
           toolCalls: [],
           contentBlocks: [],
+          metadata: payload.planMode ? { isPlan: true } : undefined,
         },
         update: {},
       })

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -169,6 +169,7 @@ export default function HomePage() {
       case "file": return `file:${item.filePath}`
       case "terminal": return `terminal:${item.id}`
       case "server": return `server:${item.port}`
+      case "plan": return `plan:${item.messageId}`
     }
   }, [])
 
@@ -1378,6 +1379,7 @@ export default function HomePage() {
                   allItems={previewItems}
                   onSelectItem={selectPreviewItem}
                   onCloseItem={closePreviewItem}
+                  messages={currentChat?.messages}
                 />
               </>
             )}

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -702,7 +702,7 @@ export default function HomePage() {
   }
 
   // Handler for sending message
-  const handleSendMessage = (message: string, agent: string, model: string, files?: File[]) => {
+  const handleSendMessage = (message: string, agent: string, model: string, files?: File[], planMode?: boolean) => {
     // Always require sign-in to send messages
     if (!session) {
       // Store the pending message in sessionStorage (persists across OAuth redirect)
@@ -727,7 +727,7 @@ export default function HomePage() {
 
     // Set sending state immediately for instant UI feedback
     setIsSendingMessage(true)
-    sendMessage(message, agent, model, files)
+    sendMessage(message, agent, model, files, undefined, planMode)
   }
 
   // After sign-in, replay any pending message saved before the OAuth

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -1355,6 +1355,7 @@ export default function HomePage() {
                   onDraftChange={handleDraftChange}
                   onCreateScheduledJob={() => setScheduledJobFormOpen(true)}
                   isSending={isSendingMessage}
+                  onOpenPlan={(messageId) => openPreview({ type: "plan", messageId, content: "" })}
                 />
               )}
             </div>

--- a/packages/web/components/ChatPanel.tsx
+++ b/packages/web/components/ChatPanel.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useRef, useEffect, useLayoutEffect, useMemo, useCallback } from "react"
-import { ArrowUp, Square, ChevronDown, Github, GitBranch, Key, X, Paperclip, Trash2, HelpCircle, Pencil, AlertTriangle, Loader2, GitBranchPlus, FileText, FileCode, FileImage, File as FileIcon, Clock, Command } from "lucide-react"
+import { ArrowUp, Square, ChevronDown, Github, GitBranch, Key, X, Paperclip, Trash2, HelpCircle, Pencil, AlertTriangle, Loader2, GitBranchPlus, FileText, FileCode, FileImage, File as FileIcon, Clock, Command, Brain } from "lucide-react"
 import {
   getFileType,
   formatFileSize,
@@ -30,7 +30,7 @@ interface ChatPanelProps {
   chat: Chat | null
   settings: Settings
   credentialFlags: CredentialFlags
-  onSendMessage: (message: string, agent: string, model: string, files?: File[]) => void
+  onSendMessage: (message: string, agent: string, model: string, files?: File[], planMode?: boolean) => void
   onEnqueueMessage?: (message: string, agent?: string, model?: string) => void
   onRemoveQueuedMessage?: (id: string) => void
   onResumeQueue?: () => void
@@ -98,6 +98,8 @@ export function ChatPanel({ chat, settings, credentialFlags, onSendMessage, onEn
   // Conflict menu state
   const [conflictMenuOpen, setConflictMenuOpen] = useState(false)
   const conflictMenuRef = useRef<HTMLDivElement>(null)
+  // Plan mode state
+  const [planModeEnabled, setPlanModeEnabled] = useState(false)
   // File upload state
   const [pendingFiles, setPendingFiles] = useState<PendingFile[]>([])
   const [isDraggingOver, setIsDraggingOver] = useState(false)
@@ -344,7 +346,7 @@ export function ChatPanel({ chat, settings, credentialFlags, onSendMessage, onEn
 
     // Pass files to sendMessage - upload will happen after sandbox is ready
     const files = pendingFiles.length > 0 ? pendingFiles.map(pf => pf.file) : undefined
-    onSendMessage(input.trim(), currentAgent, currentModel, files)
+    onSendMessage(input.trim(), currentAgent, currentModel, files, planModeEnabled || undefined)
     setInput("")
     setPendingFiles([])
     setFileError(null)
@@ -955,6 +957,25 @@ export function ChatPanel({ chat, settings, credentialFlags, onSendMessage, onEn
             aria-label="Attach files"
           >
             <Paperclip className={cn(isMobile ? "h-4 w-4" : "h-3.5 w-3.5")} />
+          </button>
+
+          {/* Plan mode toggle */}
+          <button
+            type="button"
+            onClick={() => setPlanModeEnabled((v) => !v)}
+            className={cn(
+              "shrink-0 flex items-center gap-1 rounded-md transition-colors cursor-pointer",
+              planModeEnabled
+                ? "bg-primary/15 text-primary hover:bg-primary/20"
+                : "text-muted-foreground hover:text-foreground hover:bg-accent",
+              isMobile ? "h-7 px-2 text-sm" : "h-6 px-1.5 text-sm"
+            )}
+            title={planModeEnabled ? "Plan mode on — agent will plan before acting" : "Plan mode off"}
+            aria-label="Toggle plan mode"
+            aria-pressed={planModeEnabled}
+          >
+            <Brain className={cn(isMobile ? "h-4 w-4" : "h-3.5 w-3.5")} />
+            <span className={cn(isMobile ? "text-xs" : "text-xs")}>Plan</span>
           </button>
 
           {/* Repo display/selector */}

--- a/packages/web/components/ChatPanel.tsx
+++ b/packages/web/components/ChatPanel.tsx
@@ -73,9 +73,11 @@ interface ChatPanelProps {
   isSending?: boolean
   /** Callback to open the command palette */
   onOpenCommandPalette?: () => void
+  /** Callback to open a plan in the preview pane */
+  onOpenPlan?: (messageId: string) => void
 }
 
-export function ChatPanel({ chat, settings, credentialFlags, onSendMessage, onEnqueueMessage, onRemoveQueuedMessage, onResumeQueue, onStopAgent, onChangeRepo, onChangeBranch, onUpdateChat, onOpenSettings, onSlashCommand, onRequireSignIn, onDeleteChat, onOpenHelp, onOpenFile, onForcePush, onOpenEnvVars, isMobile = false, rebaseConflict, onAbortConflict, conflictActionLoading = false, onBranchWithMessage, onBranchQueuedMessage, canBranch = false, isLoadingMessages = false, draft = "", onDraftChange, onCreateScheduledJob, isSending = false, onOpenCommandPalette }: ChatPanelProps) {
+export function ChatPanel({ chat, settings, credentialFlags, onSendMessage, onEnqueueMessage, onRemoveQueuedMessage, onResumeQueue, onStopAgent, onChangeRepo, onChangeBranch, onUpdateChat, onOpenSettings, onSlashCommand, onRequireSignIn, onDeleteChat, onOpenHelp, onOpenFile, onForcePush, onOpenEnvVars, isMobile = false, rebaseConflict, onAbortConflict, conflictActionLoading = false, onBranchWithMessage, onBranchQueuedMessage, canBranch = false, isLoadingMessages = false, draft = "", onDraftChange, onCreateScheduledJob, isSending = false, onOpenCommandPalette, onOpenPlan }: ChatPanelProps) {
   // Use draft prop as input value (controlled component pattern for per-chat drafts)
   const input = draft
   const setInput = useCallback((value: string) => {
@@ -1538,6 +1540,7 @@ export function ChatPanel({ chat, settings, credentialFlags, onSendMessage, onEn
                 repo={isNewRepo ? undefined : chat.repo}
                 onOpenFile={onOpenFile}
                 onForcePush={onForcePush}
+                onOpenPlan={onOpenPlan}
               />
             )
           })}

--- a/packages/web/components/MessageBubble.tsx
+++ b/packages/web/components/MessageBubble.tsx
@@ -307,7 +307,7 @@ function AssistantContent({ message, isStreaming, isMobile = false, repo, onOpen
   if (message.metadata?.isPlan) {
     return (
       <div className={cn("w-full py-1", isMobile ? "text-base" : "text-[14px]")}>
-        <div className="flex items-center gap-3 p-3 border border-border rounded-lg bg-card shadow-sm max-w-sm">
+        <div className="flex items-center gap-3 p-3 border border-border rounded-lg bg-card shadow-sm w-full max-w-2xl">
           <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
             <Brain className="h-4 w-4" />
           </div>

--- a/packages/web/components/MessageBubble.tsx
+++ b/packages/web/components/MessageBubble.tsx
@@ -17,11 +17,13 @@ interface MessageBubbleProps {
   onOpenFile?: (filePath: string) => void
   /** Called when the user clicks the "force push" link in a push-failure message. */
   onForcePush?: () => void
+  /** Called when the user clicks "View Plan" for a plan message. */
+  onOpenPlan?: (messageId: string) => void
 }
 
 // Memoized MessageBubble to prevent re-renders when parent (ChatPanel) re-renders
 // due to input changes. Only re-render when message content actually changes.
-export const MessageBubble = memo(function MessageBubble({ message, isStreaming, isMobile = false, repo, onOpenFile, onForcePush }: MessageBubbleProps) {
+export const MessageBubble = memo(function MessageBubble({ message, isStreaming, isMobile = false, repo, onOpenFile, onForcePush, onOpenPlan }: MessageBubbleProps) {
   const isUser = message.role === "user"
   const hasUploadedFiles = isUser && message.uploadedFiles && message.uploadedFiles.length > 0
 
@@ -64,7 +66,7 @@ export const MessageBubble = memo(function MessageBubble({ message, isStreaming,
             )}
           </div>
         ) : (
-          <AssistantContent message={message} isStreaming={isStreaming} isMobile={isMobile} repo={repo} onOpenFile={onOpenFile} onForcePush={onForcePush} />
+          <AssistantContent message={message} isStreaming={isStreaming} isMobile={isMobile} repo={repo} onOpenFile={onOpenFile} onForcePush={onForcePush} onOpenPlan={onOpenPlan} />
         )}
       </div>
     </div>
@@ -267,7 +269,9 @@ function MarkdownContent({ text, isMobile = false, constrainWidth = true }: { te
 // Assistant Content (with tool calls)
 // =============================================================================
 
-function AssistantContent({ message, isStreaming, isMobile = false, repo, onOpenFile, onForcePush }: { message: Message; isStreaming?: boolean; isMobile?: boolean; repo?: string; onOpenFile?: (filePath: string) => void; onForcePush?: () => void }) {
+import { Brain } from "lucide-react"
+
+function AssistantContent({ message, isStreaming, isMobile = false, repo, onOpenFile, onForcePush, onOpenPlan }: { message: Message; isStreaming?: boolean; isMobile?: boolean; repo?: string; onOpenFile?: (filePath: string) => void; onForcePush?: () => void; onOpenPlan?: (messageId: string) => void }) {
   const hasContent = message.content && message.content.trim().length > 0
   const hasToolCalls = message.toolCalls && message.toolCalls.length > 0
   const hasBlocks = message.contentBlocks && message.contentBlocks.length > 0
@@ -296,6 +300,38 @@ function AssistantContent({ message, isStreaming, isMobile = false, repo, onOpen
         metadata={message.metadata}
         onForcePush={onForcePush}
       />
+    )
+  }
+
+  // Plan mode messages get a special stub
+  if (message.metadata?.isPlan) {
+    return (
+      <div className={cn("w-full py-1", isMobile ? "text-base" : "text-[14px]")}>
+        <div className="flex items-center gap-3 p-3 border border-border rounded-lg bg-card shadow-sm max-w-sm">
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+            <Brain className="h-4 w-4" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="font-medium truncate">Execution plan</p>
+            <p className="text-muted-foreground text-xs truncate">
+              {isStreaming ? "Agent is generating a plan..." : "Ready for review"}
+            </p>
+          </div>
+          <button
+            onClick={() => onOpenPlan?.(message.id)}
+            className="shrink-0 px-3 py-1.5 text-xs font-medium border border-border bg-background hover:bg-accent text-foreground rounded-md transition-colors cursor-pointer"
+          >
+            View plan
+          </button>
+        </div>
+        
+        {/* Streaming indicator for the rest of the plan generation */}
+        {isStreaming && (
+          <div className="text-2xl text-muted-foreground animate-pulse mt-2 ml-1">
+            ...
+          </div>
+        )}
+      </div>
     )
   }
 

--- a/packages/web/components/PreviewView.tsx
+++ b/packages/web/components/PreviewView.tsx
@@ -39,6 +39,8 @@ export interface PreviewViewProps {
   onSelectItem?: (item: PreviewItem) => void
   /** Called when user closes a specific item from the dropdown */
   onCloseItem?: (item: PreviewItem) => void
+  /** All messages in the current chat, for plugins that need live content */
+  messages?: import("@/lib/types").Message[]
 }
 
 /** Get a unique key for a preview item */
@@ -50,6 +52,8 @@ function getItemKey(item: PreviewItem): string {
       return `terminal:${item.id}`
     case "server":
       return `server:${item.port}`
+    case "plan":
+      return `plan:${item.messageId}`
   }
 }
 
@@ -79,6 +83,7 @@ export function PreviewView({
   allItems,
   onSelectItem,
   onCloseItem,
+  messages,
 }: PreviewViewProps) {
   const [refreshKey, setRefreshKey] = useState(0)
   const [scale, setScale] = useState(1)
@@ -290,6 +295,7 @@ export function PreviewView({
             item={item}
             sandboxId={sandboxId}
             scale={scale}
+            messages={messages}
           />
         </div>
       </div>

--- a/packages/web/lib/agent-session.ts
+++ b/packages/web/lib/agent-session.ts
@@ -67,6 +67,8 @@ export interface AgentSessionOptions {
   agent?: Agent
   model?: string
   env?: Record<string, string>
+  /** When true, agent should plan before acting */
+  planMode?: boolean
 }
 
 // =============================================================================
@@ -87,10 +89,33 @@ export async function createBackgroundAgentSession(
   sandbox: DaytonaSandbox,
   options: AgentSessionOptions
 ): Promise<BackgroundAgentSession> {
-  const systemPrompt = buildSystemPrompt(
+  let systemPrompt = buildSystemPrompt(
     options.repoPath,
     options.previewUrlPattern
   )
+
+  // When plan mode is enabled, append planning instructions to the system
+  // prompt. This is the universal mechanism — works for every agent because
+  // it's just text the model sees. Agent-specific CLI flags (e.g. Claude's
+  // thinking mode) are injected separately at the SDK layer.
+  if (options.planMode) {
+    systemPrompt += `
+
+## Plan Mode
+
+You are in PLAN MODE. Before taking any actions:
+1. Analyze the request thoroughly
+2. Create a detailed implementation plan in markdown format
+3. Present the plan to the user
+4. Do NOT execute any file writes, edits, or shell commands
+5. Wait for the user to review and approve the plan
+
+Your plan should include:
+- Summary of what needs to be done
+- Files to be created or modified (with brief descriptions)
+- Step-by-step implementation order
+- Any risks or trade-offs to consider`
+  }
 
   // Map agent type to SDK provider name
   const agent = options.agent || "opencode"

--- a/packages/web/lib/hooks/useChatWithSync.ts
+++ b/packages/web/lib/hooks/useChatWithSync.ts
@@ -662,7 +662,7 @@ export function useChatWithSync() {
   }, [updateChatsCache])
 
   // Send message
-  const sendMessage = useCallback(async (content: string, agent?: string, model?: string, files?: File[], targetChatId?: string) => {
+  const sendMessage = useCallback(async (content: string, agent?: string, model?: string, files?: File[], targetChatId?: string, planMode?: boolean) => {
     let chatId = targetChatId || currentChatId
     if (!chatId) return
 
@@ -724,6 +724,7 @@ export function useChatWithSync() {
           userMessageId: userMessage.id,
           assistantMessageId: assistantMessage.id,
           newBranch: chat.sandboxId ? undefined : `agent/${generateBranchName()}`,
+          planMode: planMode || undefined,
         }
 
         let response: Response

--- a/packages/web/lib/hooks/useChatWithSync.ts
+++ b/packages/web/lib/hooks/useChatWithSync.ts
@@ -703,7 +703,7 @@ export function useChatWithSync() {
       const selectedModel = model ?? chat.model ?? settings.defaultModel ?? getDefaultModelForAgent(selectedAgent, credentialFlags)
 
       const userMessage: Message = { id: nanoid(), role: "user", content, timestamp: Date.now() }
-      const assistantMessage: Message = { id: nanoid(), role: "assistant", content: "", timestamp: Date.now() + 1, toolCalls: [], contentBlocks: [] }
+      const assistantMessage: Message = { id: nanoid(), role: "assistant", content: "", timestamp: Date.now() + 1, toolCalls: [], contentBlocks: [], metadata: planMode ? { isPlan: true } : undefined }
 
       // Optimistic update
       updateChatsCache((old) => old.map((c) =>

--- a/packages/web/lib/hooks/useChatWithSync.ts
+++ b/packages/web/lib/hooks/useChatWithSync.ts
@@ -716,6 +716,19 @@ export function useChatWithSync() {
         } : c
       ))
 
+      // Auto-open plan preview if planMode is true
+      if (planMode) {
+        const chatPreviewItems = localChatState.previewStates[chatId]?.items ?? []
+        // Avoid duplicates if user rapidly sends plan mode messages
+        if (!chatPreviewItems.find((i) => i.type === "plan" && i.messageId === assistantMessage.id)) {
+          updateChatById(chatId, {
+            previewItems: [...chatPreviewItems, { type: "plan", messageId: assistantMessage.id, content: "" } as import("@/lib/plugins/types").PreviewItem],
+            activePreviewIndex: chatPreviewItems.length,
+            previewPaneHidden: false,
+          })
+        }
+      }
+
       try {
         const payload = {
           message: content,
@@ -791,7 +804,7 @@ export function useChatWithSync() {
     } finally {
       sendInFlight.current.delete(chatId)
     }
-  }, [currentChatId, chats, session, settings, credentialFlags, updateChatsCache, startStreaming, suggestNameMutation, isDraftChatId, materializeDraft])
+  }, [currentChatId, chats, session, settings, credentialFlags, updateChatsCache, startStreaming, suggestNameMutation, isDraftChatId, materializeDraft, localChatState.previewStates, updateChatById])
 
   const dispatchNextQueuedMessage = useCallback((chatId: string, queueOverride?: QueuedMessage[]) => {
     const chat = chats.find((c) => c.id === chatId)

--- a/packages/web/lib/plugins/panels/plan.tsx
+++ b/packages/web/lib/plugins/panels/plan.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import { Brain } from "lucide-react"
+import type { PanelPlugin, PanelProps, PreviewItem } from "../types"
+import { MarkdownPreview } from "@/lib/file-preview"
+
+function PlanViewerComponent({ item, messages }: PanelProps) {
+  if (item.type !== "plan") return null
+
+  // Find the message containing the plan. The stream updates messages automatically.
+  const message = messages?.find((m) => m.id === item.messageId)
+  const content = message?.content || item.content
+
+  return (
+    <MarkdownPreview
+      content={content}
+      className="h-full"
+    />
+  )
+}
+
+export const PlanViewerPlugin: PanelPlugin = {
+  id: "plan-viewer",
+
+  canHandle: (item: PreviewItem) => item.type === "plan",
+
+  getLabel: () => "Plan",
+
+  getIcon: () => Brain,
+
+  Component: PlanViewerComponent,
+}

--- a/packages/web/lib/plugins/registry.ts
+++ b/packages/web/lib/plugins/registry.ts
@@ -2,6 +2,7 @@ import type { PreviewItem, PanelPlugin } from "./types"
 import { FileViewerPlugin } from "./panels/file-viewer"
 import { TerminalPlugin } from "./panels/terminal"
 import { ServerPreviewPlugin } from "./panels/server-preview"
+import { PlanViewerPlugin } from "./panels/plan"
 
 /**
  * All registered panel plugins.
@@ -11,6 +12,7 @@ const panelPlugins: PanelPlugin[] = [
   FileViewerPlugin,
   TerminalPlugin,
   ServerPreviewPlugin,
+  PlanViewerPlugin,
 ]
 
 /**

--- a/packages/web/lib/plugins/types.ts
+++ b/packages/web/lib/plugins/types.ts
@@ -8,6 +8,7 @@ export type PreviewItem =
   | { type: "file"; filePath: string; filename: string }
   | { type: "terminal"; id: string }
   | { type: "server"; port: number; url: string }
+  | { type: "plan"; content: string; messageId: string }
 
 /**
  * Props passed to every panel plugin component.
@@ -17,6 +18,8 @@ export interface PanelProps {
   sandboxId: string | null
   /** Optional scale factor for preview (e.g., 0.5, 0.75, 1) */
   scale?: number
+  /** All messages in the current chat, for plugins that need live content */
+  messages?: import("@/lib/types").Message[]
 }
 
 /**

--- a/packages/web/lib/types.ts
+++ b/packages/web/lib/types.ts
@@ -61,6 +61,8 @@ export interface MessageMetadata {
   prUrl?: string
   /** PR number for view-pr action */
   prNumber?: number
+  /** Whether this message contains an agent's plan generated in Plan Mode */
+  isPlan?: boolean
 }
 
 export interface Message {

--- a/packages/web/lib/types.ts
+++ b/packages/web/lib/types.ts
@@ -142,6 +142,7 @@ export interface Chat {
     | { type: "file"; filePath: string; filename: string }
     | { type: "terminal"; id: string }
     | { type: "server"; port: number; url: string }
+    | { type: "plan"; content: string; messageId: string }
   >
 
   /** Index of the currently active preview item in previewItems array */


### PR DESCRIPTION
**Overview**
This PR implements "Plan Mode," allowing users to force AI agents to generate a structured implementation plan prior to executing code changes. To ensure a clean chat experience, plans are rendered in a dedicated tab within the right-hand preview pane rather than cluttering the main chat feed.

**Key Changes**

**1. SDK & Agent Integration**
- Added `planMode` boolean to `RunOptions`, `SessionOptions`, and `StartOptions` in the SDK.
- **Claude**: Injects `--settings '{"alwaysThinkingEnabled": true}'` when plan mode is active to enable deep reasoning.
- **OpenCode**: Injects the `--thinking` flag to force reasoning steps.
- **Universal**: Augments the base system prompt with a strict "PLAN MODE" directive for all agents to halt execution until the user reviews the generated Markdown plan.

**2. Backend & Persistence**
- Updated `MessagePayload` in the chat messaging route (`/api/chats/[id]/messages`) to receive the `planMode` toggle state.
- Added an `isPlan: true` flag to the `MessageMetadata` schema. This is persisted in the PostgreSQL database alongside the assistant's response, ensuring the UI knows how to render historical plan messages.

**3. Frontend UI (Chat & Preview Pane)**
- **Toolbar Toggle**: Added a new "Plan" toggle button (Brain icon) to the `ChatPanel` toolbar to activate the mode per request.
- **Clean Chat Bubbles**: Updated `MessageBubble` to intercept messages with `isPlan: true`. Instead of rendering massive Markdown blocks in the chat feed, it now renders a sleek "Execution plan" UI card with a streaming indicator and a "View plan" button.
- **Plan Viewer Plugin**: Created `PlanViewerPlugin` for the preview pane. It leverages `MarkdownPreview` to render the plan with full syntax highlighting.
- **Real-Time Streaming**: Refactored `PreviewView` props to pass live message data down to the plugins. This allows the Plan Viewer to stream the Markdown text in real-time as the agent types.
- **Auto-Open Logic**: Sending a plan-mode message instantly opens the preview pane and seamlessly focuses the new Plan tab.