### PR TITLE
Add skill management per repository

### DIFF
--- a/packages/web/app/api/chats/[chatId]/messages/route.ts
+++ b/packages/web/app/api/chats/[chatId]/messages/route.ts
@@ -26,6 +26,7 @@ import {
   createSandboxForChat,
   deleteSandboxQuietly,
   ensureSandboxStarted,
+  installSkillsForRepo,
   uploadFilesToSandbox,
 } from "@/lib/sandbox"
 
@@ -338,6 +339,14 @@ export async function POST(
     }
 
     await ensureSandboxStarted(sandbox)
+
+    // ── Stage 2a: restore repo-scoped skills ──────────────────────────────
+    // On newly created sandboxes (including recreation after deletion),
+    // install all skills associated with this user+repo so the agent has
+    // them available from the first prompt.
+    if (createdSandbox && chat.repo !== NEW_REPOSITORY) {
+      await installSkillsForRepo(sandbox, userId, chat.repo)
+    }
 
     const repoPath = `${PATHS.SANDBOX_HOME}/project`
 

--- a/packages/web/app/api/skills/[id]/route.ts
+++ b/packages/web/app/api/skills/[id]/route.ts
@@ -1,0 +1,39 @@
+import { prisma } from "@/lib/db/prisma"
+import {
+  requireAuth,
+  isAuthError,
+  notFound,
+  internalError,
+} from "@/lib/db/api-helpers"
+
+// =============================================================================
+// DELETE - Uninstall a skill by ID
+// =============================================================================
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<Response> {
+  const authResult = await requireAuth()
+  if (isAuthError(authResult)) return authResult
+  const { userId } = authResult
+  const { id } = await params
+
+  try {
+    // Verify ownership before deleting
+    const skill = await prisma.skill.findUnique({
+      where: { id },
+      select: { userId: true },
+    })
+
+    if (!skill || skill.userId !== userId) {
+      return notFound("Skill not found")
+    }
+
+    await prisma.skill.delete({ where: { id } })
+
+    return Response.json({ success: true })
+  } catch (error) {
+    return internalError(error)
+  }
+}

--- a/packages/web/app/api/skills/[id]/route.ts
+++ b/packages/web/app/api/skills/[id]/route.ts
@@ -1,3 +1,5 @@
+import { NextRequest } from "next/server"
+import { Daytona } from "@daytonaio/sdk"
 import { prisma } from "@/lib/db/prisma"
 import {
   requireAuth,
@@ -5,13 +7,14 @@ import {
   notFound,
   internalError,
 } from "@/lib/db/api-helpers"
+import { PATHS } from "@/lib/constants"
 
 // =============================================================================
-// DELETE - Uninstall a skill by ID
+// DELETE - Uninstall a skill by ID (DB + sandbox filesystem)
 // =============================================================================
 
 export async function DELETE(
-  _req: Request,
+  req: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ): Promise<Response> {
   const authResult = await requireAuth()
@@ -20,17 +23,49 @@ export async function DELETE(
   const { id } = await params
 
   try {
-    // Verify ownership before deleting
+    // Fetch the full skill record (need fullHandle for filesystem removal)
     const skill = await prisma.skill.findUnique({
       where: { id },
-      select: { userId: true },
     })
 
     if (!skill || skill.userId !== userId) {
       return notFound("Skill not found")
     }
 
+    // Delete from DB first
     await prisma.skill.delete({ where: { id } })
+
+    // Best-effort: remove from sandbox filesystem if chatId is provided
+    const chatId = new URL(req.url).searchParams.get("chatId")
+    if (chatId) {
+      const daytonaApiKey = process.env.DAYTONA_API_KEY
+      if (daytonaApiKey) {
+        try {
+          const chat = await prisma.chat.findUnique({
+            where: { id: chatId },
+            select: { sandboxId: true, userId: true },
+          })
+
+          if (chat?.sandboxId && chat.userId === userId) {
+            const daytona = new Daytona({ apiKey: daytonaApiKey })
+            const sandbox = await daytona.get(chat.sandboxId)
+            const repoPath = `${PATHS.SANDBOX_HOME}/project`
+
+            // Extract skillId from fullHandle (owner/repo/skillId)
+            const parts = skill.fullHandle.split("/")
+            const skillName = parts.length >= 3 ? parts.slice(2).join("/") : parts[parts.length - 1]
+
+            // Use `npx skills remove` with --all -y for non-interactive
+            await sandbox.process.executeCommand(
+              `cd ${repoPath} && npx -y skills remove ${skillName} --all -y 2>&1`
+            )
+          }
+        } catch (err) {
+          // Best-effort — log but don't fail the request
+          console.error("[skills/delete] Failed to remove from sandbox:", err)
+        }
+      }
+    }
 
     return Response.json({ success: true })
   } catch (error) {

--- a/packages/web/app/api/skills/install/route.ts
+++ b/packages/web/app/api/skills/install/route.ts
@@ -1,0 +1,108 @@
+import { NextRequest } from "next/server"
+import { Daytona } from "@daytonaio/sdk"
+import { prisma } from "@/lib/db/prisma"
+import {
+  requireAuth,
+  isAuthError,
+  badRequest,
+  notFound,
+  internalError,
+  serverConfigError,
+} from "@/lib/db/api-helpers"
+import { PATHS } from "@/lib/constants"
+
+// =============================================================================
+// POST - Install skills into a chat's sandbox
+// =============================================================================
+
+interface InstallBody {
+  chatId: string
+  skillIds?: string[] // If omitted, install ALL skills for the chat's repo
+}
+
+export async function POST(req: NextRequest): Promise<Response> {
+  const authResult = await requireAuth()
+  if (isAuthError(authResult)) return authResult
+  const { userId } = authResult
+
+  const daytonaApiKey = process.env.DAYTONA_API_KEY
+  if (!daytonaApiKey) return serverConfigError("DAYTONA_API_KEY")
+
+  try {
+    const body: InstallBody = await req.json()
+
+    if (!body.chatId) {
+      return badRequest("chatId is required")
+    }
+
+    // Verify chat ownership and get sandbox info
+    const chat = await prisma.chat.findUnique({
+      where: { id: body.chatId },
+      select: { userId: true, sandboxId: true, repo: true },
+    })
+
+    if (!chat || chat.userId !== userId) {
+      return notFound("Chat not found")
+    }
+
+    if (!chat.sandboxId) {
+      return badRequest("Chat has no sandbox — send a message first")
+    }
+
+    // Fetch skills to install
+    const whereClause: { userId: string; repo: string; id?: { in: string[] } } = {
+      userId,
+      repo: chat.repo,
+    }
+    if (body.skillIds && body.skillIds.length > 0) {
+      whereClause.id = { in: body.skillIds }
+    }
+
+    const skills = await prisma.skill.findMany({
+      where: whereClause,
+      orderBy: { createdAt: "asc" },
+    })
+
+    if (skills.length === 0) {
+      return Response.json({ installed: 0, total: 0, results: [] })
+    }
+
+    // Connect to sandbox
+    const daytona = new Daytona({ apiKey: daytonaApiKey })
+    const sandbox = await daytona.get(chat.sandboxId)
+
+    const repoPath = `${PATHS.SANDBOX_HOME}/project`
+    const results: { fullHandle: string; success: boolean; error?: string }[] = []
+
+    for (const skill of skills) {
+      try {
+        // fullHandle is "owner/repo/skillId" — extract parts for install command
+        // Must use --agent '*' -y for non-interactive sandbox environments
+        const parts = skill.fullHandle.split("/")
+        const source = parts.length >= 2 ? `${parts[0]}/${parts[1]}` : skill.fullHandle
+        const skillFlag = parts.length >= 3 ? ` --skill ${parts.slice(2).join("/")}` : ""
+        const installCmd = `npx -y skills add ${source}${skillFlag} --agent '*' -y`
+        const cmd = await sandbox.process.executeCommand(
+          `cd ${repoPath} && ${installCmd} 2>&1`
+        )
+        const success = cmd.exitCode === 0
+        results.push({
+          fullHandle: skill.fullHandle,
+          success,
+          error: success ? undefined : cmd.result?.trim(),
+        })
+      } catch (error) {
+        results.push({
+          fullHandle: skill.fullHandle,
+          success: false,
+          error: error instanceof Error ? error.message : "Unknown error",
+        })
+      }
+    }
+
+    const installed = results.filter((r) => r.success).length
+    return Response.json({ installed, total: skills.length, results })
+  } catch (error) {
+    return internalError(error)
+  }
+}

--- a/packages/web/app/api/skills/install/route.ts
+++ b/packages/web/app/api/skills/install/route.ts
@@ -20,6 +20,76 @@ interface InstallBody {
   skillIds?: string[] // If omitted, install ALL skills for the chat's repo
 }
 
+/** Strip ANSI escape codes, cursor controls, and terminal noise from CLI output */
+function stripAnsi(str: string): string {
+  return str
+    // eslint-disable-next-line no-control-regex
+    .replace(/\x1B\[[0-9;?]*[A-Za-z]/g, "")   // CSI sequences (colors, cursor)
+    // eslint-disable-next-line no-control-regex
+    .replace(/\x1B\][^\x07]*\x07/g, "")         // OSC sequences
+    // eslint-disable-next-line no-control-regex
+    .replace(/\x1B[@-Z\\-_]/g, "")              // Two-byte escape sequences
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\x00-\x09\x0B\x0C\x0E-\x1F]/g, "") // Control chars (keep \n)
+    .replace(/\r/g, "")                          // Carriage returns
+}
+
+/**
+ * Extract a clean, human-readable error from CLI output.
+ * Looks for known error patterns instead of dumping the full banner.
+ */
+function extractCleanError(raw: string): string {
+  const cleaned = stripAnsi(raw)
+  const noMatch = cleaned.match(/No matching skills found for:\s*(.+)/i)
+  if (noMatch) return `Skill "${noMatch[1].trim()}" not found in this repository`
+  if (cleaned.includes("Authentication failed")) return "Repository authentication failed"
+  if (cleaned.includes("Installation failed")) return "Installation failed"
+  return "Install failed"
+}
+
+/**
+ * Parse the output of `npx skills add <source> --list` to extract valid
+ * skill names. Output format includes lines like:
+ *   │    - skill-name
+ */
+function parseSkillList(output: string): string[] {
+  const cleaned = stripAnsi(output)
+  const skills: string[] = []
+  for (const line of cleaned.split("\n")) {
+    const match = line.match(/[-–]\s+(\S+)\s*$/)
+    if (match && match[1]) {
+      skills.push(match[1])
+    }
+  }
+  return skills
+}
+
+/**
+ * Run `npx skills add <source> --list` in the sandbox to discover which
+ * skills are actually available in the repo. Returns a Set of valid skill
+ * names, or null if the list command itself failed.
+ */
+async function listAvailableSkills(
+  sandbox: Awaited<ReturnType<Daytona["get"]>>,
+  repoPath: string,
+  source: string
+): Promise<Set<string> | null> {
+  try {
+    const cmd = await sandbox.process.executeCommand(
+      `cd ${repoPath} && npx -y skills add ${source} --list 2>&1`
+    )
+    if (cmd.exitCode !== 0 && !cmd.result?.includes("Found")) {
+      console.error(`[skills/install] --list failed for ${source}:`, cmd.result?.trim())
+      return null
+    }
+    const names = parseSkillList(cmd.result ?? "")
+    return names.length > 0 ? new Set(names) : null
+  } catch (err) {
+    console.error(`[skills/install] --list error for ${source}:`, err)
+    return null
+  }
+}
+
 export async function POST(req: NextRequest): Promise<Response> {
   const authResult = await requireAuth()
   if (isAuthError(authResult)) return authResult
@@ -74,22 +144,52 @@ export async function POST(req: NextRequest): Promise<Response> {
     const repoPath = `${PATHS.SANDBOX_HOME}/project`
     const results: { fullHandle: string; success: boolean; error?: string }[] = []
 
+    // ── Pre-validate: group skills by source repo, run --list for each ────
+    // Cache available skills per source repo so we only clone once per repo
+    const availableSkillsCache = new Map<string, Set<string> | null>()
+
     for (const skill of skills) {
+      const parts = skill.fullHandle.split("/")
+      const source = parts.length >= 2 ? `${parts[0]}/${parts[1]}` : skill.fullHandle
+      const skillId = parts.length >= 3 ? parts.slice(2).join("/") : null
+
+      // If there's a specific skillId, validate it exists in the repo
+      if (skillId) {
+        if (!availableSkillsCache.has(source)) {
+          const available = await listAvailableSkills(sandbox, repoPath, source)
+          availableSkillsCache.set(source, available)
+        }
+
+        const available = availableSkillsCache.get(source)
+        if (available && !available.has(skillId)) {
+          // Skill doesn't exist in the repo — skip install, remove from DB
+          results.push({
+            fullHandle: skill.fullHandle,
+            success: false,
+            error: `Skill "${skillId}" not found in ${source}. Available: ${[...available].slice(0, 5).join(", ")}${available.size > 5 ? "..." : ""}`,
+          })
+          // Clean up the invalid DB record
+          await prisma.skill.delete({ where: { id: skill.id } }).catch(() => {})
+          continue
+        }
+      }
+
+      // Validated — proceed with install
       try {
-        // fullHandle is "owner/repo/skillId" — extract parts for install command
-        // Must use --agent '*' -y for non-interactive sandbox environments
-        const parts = skill.fullHandle.split("/")
-        const source = parts.length >= 2 ? `${parts[0]}/${parts[1]}` : skill.fullHandle
-        const skillFlag = parts.length >= 3 ? ` --skill ${parts.slice(2).join("/")}` : ""
+        const skillFlag = skillId ? ` --skill ${skillId}` : ""
         const installCmd = `npx -y skills add ${source}${skillFlag} --agent '*' -y`
         const cmd = await sandbox.process.executeCommand(
           `cd ${repoPath} && ${installCmd} 2>&1`
         )
         const success = cmd.exitCode === 0
+        if (!success) {
+          // Install failed — clean up the DB record
+          await prisma.skill.delete({ where: { id: skill.id } }).catch(() => {})
+        }
         results.push({
           fullHandle: skill.fullHandle,
           success,
-          error: success ? undefined : cmd.result?.trim(),
+          error: success ? undefined : extractCleanError(cmd.result ?? ""),
         })
       } catch (error) {
         results.push({

--- a/packages/web/app/api/skills/route.ts
+++ b/packages/web/app/api/skills/route.ts
@@ -1,0 +1,133 @@
+import { NextRequest } from "next/server"
+import { prisma } from "@/lib/db/prisma"
+import {
+  requireAuth,
+  isAuthError,
+  badRequest,
+  internalError,
+} from "@/lib/db/api-helpers"
+import { NEW_REPOSITORY } from "@/lib/types"
+
+// =============================================================================
+// GET - List installed skills for a repo
+// =============================================================================
+
+export async function GET(req: NextRequest): Promise<Response> {
+  const authResult = await requireAuth()
+  if (isAuthError(authResult)) return authResult
+  const { userId } = authResult
+
+  const { searchParams } = new URL(req.url)
+  const repo = searchParams.get("repo")
+
+  if (!repo || repo === NEW_REPOSITORY) {
+    return badRequest("repo is required and must be a valid owner/repo")
+  }
+
+  try {
+    const skills = await prisma.skill.findMany({
+      where: { userId, repo },
+      orderBy: { createdAt: "desc" },
+    })
+
+    return Response.json({
+      skills: skills.map((s) => ({
+        id: s.id,
+        repo: s.repo,
+        publisher: s.publisher,
+        name: s.name,
+        fullHandle: s.fullHandle,
+        url: s.url,
+        createdAt: s.createdAt.getTime(),
+        updatedAt: s.updatedAt.getTime(),
+      })),
+    })
+  } catch (error) {
+    return internalError(error)
+  }
+}
+
+// =============================================================================
+// POST - Bulk install skills for a repo
+// =============================================================================
+
+interface SkillInput {
+  publisher: string
+  name: string
+  fullHandle: string
+  url?: string
+}
+
+interface InstallSkillsBody {
+  repo: string
+  skills: SkillInput[]
+}
+
+export async function POST(req: NextRequest): Promise<Response> {
+  const authResult = await requireAuth()
+  if (isAuthError(authResult)) return authResult
+  const { userId } = authResult
+
+  try {
+    const body: InstallSkillsBody = await req.json()
+
+    if (!body.repo || body.repo === NEW_REPOSITORY) {
+      return badRequest("repo is required and must be a valid owner/repo")
+    }
+
+    if (!body.skills || !Array.isArray(body.skills) || body.skills.length === 0) {
+      return badRequest("skills array is required and must not be empty")
+    }
+
+    // Validate each skill
+    for (const skill of body.skills) {
+      if (!skill.publisher?.trim() || !skill.name?.trim() || !skill.fullHandle?.trim()) {
+        return badRequest("Each skill must have publisher, name, and fullHandle")
+      }
+    }
+
+    // Upsert each skill (idempotent — re-installing the same skill is a no-op)
+    const created = await prisma.$transaction(
+      body.skills.map((skill) =>
+        prisma.skill.upsert({
+          where: {
+            userId_repo_fullHandle: {
+              userId,
+              repo: body.repo,
+              fullHandle: skill.fullHandle,
+            },
+          },
+          create: {
+            userId,
+            repo: body.repo,
+            publisher: skill.publisher.trim(),
+            name: skill.name.trim(),
+            fullHandle: skill.fullHandle.trim(),
+            url: skill.url ?? null,
+          },
+          update: {
+            url: skill.url ?? undefined,
+          },
+        })
+      )
+    )
+
+    return Response.json(
+      {
+        skills: created.map((s) => ({
+          id: s.id,
+          repo: s.repo,
+          publisher: s.publisher,
+          name: s.name,
+          fullHandle: s.fullHandle,
+          url: s.url,
+          createdAt: s.createdAt.getTime(),
+          updatedAt: s.updatedAt.getTime(),
+        })),
+      },
+      { status: 201 }
+    )
+  } catch (error) {
+    return internalError(error)
+  }
+}

--- a/packages/web/app/api/skills/search/route.ts
+++ b/packages/web/app/api/skills/search/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest } from "next/server"
+import {
+  requireAuth,
+  isAuthError,
+  badRequest,
+  internalError,
+} from "@/lib/db/api-helpers"
+
+// =============================================================================
+// GET - Search skills from Skills.sh registry
+// =============================================================================
+
+const SKILLS_API_BASE = "https://skills.sh"
+
+// Actual Skills.sh API response shape
+interface SkillsApiResult {
+  id: string        // e.g. "vercel-labs/agent-skills/vercel-react-best-practices"
+  skillId: string   // e.g. "vercel-react-best-practices"
+  name: string      // e.g. "vercel-react-best-practices"
+  installs: number  // e.g. 378800
+  source: string    // e.g. "vercel-labs/agent-skills" (owner/repo)
+}
+
+export async function GET(req: NextRequest): Promise<Response> {
+  const authResult = await requireAuth()
+  if (isAuthError(authResult)) return authResult
+
+  const { searchParams } = new URL(req.url)
+  const query = searchParams.get("q")
+
+  if (!query?.trim()) {
+    return badRequest("q (search query) is required")
+  }
+
+  try {
+    const apiUrl = new URL("/api/search", SKILLS_API_BASE)
+    apiUrl.searchParams.set("q", query.trim())
+
+    const response = await fetch(apiUrl.toString(), {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(10000),
+    })
+
+    if (!response.ok) {
+      console.error(
+        `[skills/search] Skills.sh API error: ${response.status} ${response.statusText}`
+      )
+      return Response.json(
+        { error: "Skills registry unavailable", results: [] },
+        { status: 502 }
+      )
+    }
+
+    const data = await response.json()
+
+    // Normalize the response into our SkillSearchResult shape
+    // source = "owner/repo", skillId = skill name within that repo
+    // fullHandle = "owner/repo/skillId" — unique per skill
+    // install via: npx skills add owner/repo --skill skillId
+    const results = (data.skills ?? []).map((item: SkillsApiResult) => {
+      const source = item.source ?? ""
+      const skillId = item.skillId ?? item.name ?? ""
+      return {
+        publisher: source.split("/")[0] ?? "",
+        name: item.name ?? skillId,
+        fullHandle: `${source}/${skillId}`, // unique key: "owner/repo/skillId"
+        source,                              // "owner/repo" for install command
+        skillId,                             // individual skill within the repo
+        description: "",
+        url: `https://skills.sh/skills/${source}/${skillId}`,
+        installs: item.installs ?? 0,
+      }
+    })
+
+    return Response.json({ results })
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      return Response.json(
+        { error: "Skills registry timed out", results: [] },
+        { status: 504 }
+      )
+    }
+    return internalError(error)
+  }
+}

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -21,6 +21,7 @@ import { MobileCommandsMenu } from "@/components/MobileCommandsMenu"
 import { MobileRenameModal } from "@/components/ui/MobileBottomSheet"
 import { ScheduledJobForm } from "@/components/scheduled-jobs/ScheduledJobForm"
 import { ScheduledJobsView } from "@/components/scheduled-jobs/ScheduledJobsView"
+import { SkillSearchView } from "@/components/skills/SkillSearchView"
 import { clearAllStorage } from "@/lib/storage"
 import type { SlashCommandType } from "@/components/SlashCommandMenu"
 import { PaletteProvider, usePalette } from "@/components/search-palette"
@@ -169,6 +170,7 @@ function HomePageContent({ isMobile }: HomePageContentProps) {
   // Track when a message send is initiated (for instant UI feedback before server responds)
   const [isSendingMessage, setIsSendingMessage] = useState(false)
   const [isDownloading, setIsDownloading] = useState(false)
+  const [skillsModalOpen, setSkillsModalOpen] = useState(false)
 
   // Preview state from hook
   const preview = usePreview({
@@ -1057,6 +1059,11 @@ function HomePageContent({ isMobile }: HomePageContentProps) {
       onCopyCloneCommand={currentChat?.repo && currentChat.repo !== NEW_REPOSITORY ? handleCopyCloneCommand : undefined}
       onCopyCheckoutCommand={currentChat?.branch ? handleCopyCheckoutCommand : undefined}
       onOpenEnvVars={currentChat ? handleOpenEnvVars : undefined}
+      onOpenSkills={
+        currentChat?.sandboxId && currentChat.repo !== NEW_REPOSITORY
+          ? () => setSkillsModalOpen(true)
+          : undefined
+      }
       chatIds={displayChats.map((c) => c.id)}
       onNavigateChat={handleNavigateChat}
       currentChatId={displayCurrentChatId}
@@ -1285,6 +1292,16 @@ function HomePageContent({ isMobile }: HomePageContentProps) {
           initialRepoEnvVars={envVarsRepoEnvVars}
           isMobile={isMobile}
         />
+
+      {/* Skills Search Modal */}
+      {currentChat?.sandboxId && currentChat.repo !== NEW_REPOSITORY && (
+        <SkillSearchView
+          open={skillsModalOpen}
+          onOpenChange={setSkillsModalOpen}
+          chatId={currentChat.id}
+          repo={currentChat.repo}
+        />
+      )}
 
       {/* Git Dialogs - now use API calls instead of pasting git commands */}
       <MergeDialog

--- a/packages/web/components/search-palette/CommandPalette.tsx
+++ b/packages/web/components/search-palette/CommandPalette.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { GitMerge, GitBranch, GitPullRequest, GitCommitVertical, Plus, GitBranchPlus, Settings, Github, PanelLeft, LogIn, LogOut, FolderGit2, Trash2, Code2, TerminalSquare, Globe, PanelRightClose, PanelRightOpen, Download, Copy, MessageSquare, Key, Sun, Moon, Monitor } from "lucide-react"
+import { GitMerge, GitBranch, GitPullRequest, GitCommitVertical, Plus, GitBranchPlus, Settings, Github, PanelLeft, LogIn, LogOut, FolderGit2, Trash2, Code2, TerminalSquare, Globe, PanelRightClose, PanelRightOpen, Download, Copy, MessageSquare, Key, Sun, Moon, Monitor, Zap } from "lucide-react"
 import {
   CommandDialog,
   CommandInput,
@@ -74,6 +74,8 @@ interface CommandPaletteProps {
   onCopyCheckoutCommand?: () => void
   /** Open environment variables modal. Omitted when no chat is active. */
   onOpenEnvVars?: () => void
+  /** Open skills manager. Omitted when no sandbox exists. */
+  onOpenSkills?: () => void
   /** Chats for search. */
   chats?: ChatItem[]
   /** Select a chat from search. */
@@ -109,6 +111,7 @@ export function CommandPalette({
   onCopyCloneCommand,
   onCopyCheckoutCommand,
   onOpenEnvVars,
+  onOpenSkills,
   chats = [],
   onSelectChat,
   currentTheme = "system",
@@ -236,6 +239,12 @@ export function CommandPalette({
             <CommandItem value="environment variables" onSelect={() => run(onOpenEnvVars)}>
               <VariableIcon className="mr-2 h-4 w-4 text-muted-foreground" />
               <span>Environment variables</span>
+            </CommandItem>
+          )}
+          {onOpenSkills && (
+            <CommandItem value="manage skills agent" onSelect={() => run(onOpenSkills)}>
+              <Zap className="mr-2 h-4 w-4 text-muted-foreground" />
+              <span>Manage skills</span>
             </CommandItem>
           )}
           {onDeleteChat && (

--- a/packages/web/components/search-palette/PaletteProvider.tsx
+++ b/packages/web/components/search-palette/PaletteProvider.tsx
@@ -54,6 +54,7 @@ interface PaletteProviderProps {
   onCopyCloneCommand?: () => void
   onCopyCheckoutCommand?: () => void
   onOpenEnvVars?: () => void
+  onOpenSkills?: () => void
   // For Alt+Up/Down chat navigation
   chatIds: string[]
   currentChatId: string | null
@@ -94,6 +95,7 @@ export function PaletteProvider({
   onCopyCloneCommand,
   onCopyCheckoutCommand,
   onOpenEnvVars,
+  onOpenSkills,
   chatIds,
   currentChatId,
   onSelectChat,
@@ -215,6 +217,7 @@ export function PaletteProvider({
         onCopyCloneCommand={onCopyCloneCommand}
         onCopyCheckoutCommand={onCopyCheckoutCommand}
         onOpenEnvVars={onOpenEnvVars}
+        onOpenSkills={onOpenSkills}
         chats={chats.map((c) => ({ id: c.id, displayName: c.displayName }))}
         onSelectChat={onSelectChat}
         currentTheme={(theme as Theme) ?? "system"}

--- a/packages/web/components/skills/SkillSearchView.tsx
+++ b/packages/web/components/skills/SkillSearchView.tsx
@@ -1,0 +1,458 @@
+"use client"
+
+import { useState, useEffect, useCallback, useRef } from "react"
+import { Search, X, Check, Loader2, Zap, Trash2, ExternalLink } from "lucide-react"
+import { cn } from "@/lib/utils"
+import type { Skill, SkillSearchResult } from "@/lib/types"
+
+interface SkillSearchViewProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  chatId: string
+  repo: string
+}
+
+export function SkillSearchView({ open, onOpenChange, chatId, repo }: SkillSearchViewProps) {
+  const [query, setQuery] = useState("")
+  const [searchResults, setSearchResults] = useState<(SkillSearchResult & { installs?: number })[]>([])
+  const [installedSkills, setInstalledSkills] = useState<Skill[]>([])
+  const [selectedHandles, setSelectedHandles] = useState<Set<string>>(new Set())
+  const [isSearching, setIsSearching] = useState(false)
+  const [isInstalling, setIsInstalling] = useState(false)
+  const [installProgress, setInstallProgress] = useState<{ installed: number; total: number } | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [activeTab, setActiveTab] = useState<"search" | "installed">("search")
+  const inputRef = useRef<HTMLInputElement>(null)
+  const searchTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+
+  // Fetch installed skills on open
+  useEffect(() => {
+    if (!open) return
+    fetchInstalledSkills()
+    // Focus input on open
+    setTimeout(() => inputRef.current?.focus(), 100)
+  }, [open, repo])
+
+  // Reset state on close
+  useEffect(() => {
+    if (!open) {
+      setQuery("")
+      setSearchResults([])
+      setSelectedHandles(new Set())
+      setError(null)
+      setInstallProgress(null)
+      setActiveTab("search")
+    }
+  }, [open])
+
+  const fetchInstalledSkills = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/skills?repo=${encodeURIComponent(repo)}`)
+      if (res.ok) {
+        const data = await res.json()
+        setInstalledSkills(data.skills ?? [])
+      }
+    } catch {
+      // Silent fail — non-critical
+    }
+  }, [repo])
+
+  // Debounced search
+  useEffect(() => {
+    if (searchTimeoutRef.current) {
+      clearTimeout(searchTimeoutRef.current)
+    }
+
+    if (!query.trim()) {
+      setSearchResults([])
+      setIsSearching(false)
+      return
+    }
+
+    setIsSearching(true)
+    searchTimeoutRef.current = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/skills/search?q=${encodeURIComponent(query.trim())}`)
+        if (res.ok) {
+          const data = await res.json()
+          setSearchResults(data.results ?? [])
+        } else {
+          setError("Search failed — registry may be unavailable")
+          setSearchResults([])
+        }
+      } catch {
+        setError("Search failed — check your connection")
+        setSearchResults([])
+      } finally {
+        setIsSearching(false)
+      }
+    }, 300)
+
+    return () => {
+      if (searchTimeoutRef.current) {
+        clearTimeout(searchTimeoutRef.current)
+      }
+    }
+  }, [query])
+
+  const toggleSelection = (fullHandle: string) => {
+    setSelectedHandles((prev) => {
+      const next = new Set(prev)
+      if (next.has(fullHandle)) next.delete(fullHandle)
+      else next.add(fullHandle)
+      return next
+    })
+  }
+
+  const isAlreadyInstalled = (fullHandle: string) => {
+    return installedSkills.some((s) => s.fullHandle === fullHandle)
+  }
+
+  const handleInstallSelected = async () => {
+    if (selectedHandles.size === 0) return
+    setIsInstalling(true)
+    setError(null)
+    setInstallProgress({ installed: 0, total: selectedHandles.size })
+
+    try {
+      // Build skill objects from search results
+      const skillsToInstall = searchResults
+        .filter((r) => selectedHandles.has(r.fullHandle))
+        .map((r) => ({
+          publisher: r.publisher,
+          name: r.name,
+          fullHandle: r.fullHandle,
+          url: r.url,
+        }))
+
+      // Step 1: Save to DB
+      const saveRes = await fetch("/api/skills", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ repo, skills: skillsToInstall }),
+      })
+
+      if (!saveRes.ok) {
+        throw new Error("Failed to save skills")
+      }
+
+      // Step 2: Install in sandbox
+      const installRes = await fetch("/api/skills/install", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ chatId }),
+      })
+
+      if (installRes.ok) {
+        const result = await installRes.json()
+        setInstallProgress({ installed: result.installed, total: result.total })
+      }
+
+      // Refresh installed list and clear selection
+      await fetchInstalledSkills()
+      setSelectedHandles(new Set())
+
+      // Show installed tab after successful install
+      setTimeout(() => {
+        setActiveTab("installed")
+        setInstallProgress(null)
+      }, 1500)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Installation failed")
+      setInstallProgress(null)
+    } finally {
+      setIsInstalling(false)
+    }
+  }
+
+  const handleUninstall = async (skillId: string) => {
+    try {
+      const res = await fetch(`/api/skills/${skillId}`, { method: "DELETE" })
+      if (res.ok) {
+        setInstalledSkills((prev) => prev.filter((s) => s.id !== skillId))
+      }
+    } catch {
+      setError("Failed to uninstall skill")
+    }
+  }
+
+  if (!open) return null
+
+  const selectableResults = searchResults.filter((r) => !isAlreadyInstalled(r.fullHandle))
+  const selectedCount = selectedHandles.size
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm animate-in fade-in-0"
+        onClick={() => onOpenChange(false)}
+      />
+
+      {/* Modal */}
+      <div className="fixed inset-x-0 top-[15vh] z-50 mx-auto w-full max-w-xl animate-in fade-in-0 zoom-in-95 slide-in-from-bottom-2 duration-200">
+        <div className="rounded-xl border border-border bg-popover shadow-2xl overflow-hidden">
+          {/* Header */}
+          <div className="flex items-center gap-3 px-4 py-3 border-b border-border">
+            <Zap className="h-4 w-4 text-amber-500" />
+            <span className="text-sm font-medium text-foreground">Skills</span>
+            <span className="text-xs text-muted-foreground">
+              {repo}
+            </span>
+            <div className="flex-1" />
+            {installedSkills.length > 0 && (
+              <span className="text-xs px-2 py-0.5 rounded-full bg-primary/10 text-primary">
+                {installedSkills.length} installed
+              </span>
+            )}
+            <button
+              onClick={() => onOpenChange(false)}
+              className="p-1 rounded-md hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+
+          {/* Tabs */}
+          <div className="flex border-b border-border">
+            <button
+              onClick={() => setActiveTab("search")}
+              className={cn(
+                "flex-1 px-4 py-2 text-sm font-medium transition-colors",
+                activeTab === "search"
+                  ? "text-foreground border-b-2 border-primary"
+                  : "text-muted-foreground hover:text-foreground"
+              )}
+            >
+              Search
+            </button>
+            <button
+              onClick={() => setActiveTab("installed")}
+              className={cn(
+                "flex-1 px-4 py-2 text-sm font-medium transition-colors relative",
+                activeTab === "installed"
+                  ? "text-foreground border-b-2 border-primary"
+                  : "text-muted-foreground hover:text-foreground"
+              )}
+            >
+              Installed
+              {installedSkills.length > 0 && (
+                <span className="ml-1.5 text-xs text-muted-foreground">
+                  ({installedSkills.length})
+                </span>
+              )}
+            </button>
+          </div>
+
+          {activeTab === "search" && (
+            <>
+              {/* Search Input */}
+              <div className="relative px-4 py-3 border-b border-border">
+                <Search className="absolute left-7 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                <input
+                  ref={inputRef}
+                  type="text"
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  placeholder="Search skills..."
+                  className="w-full pl-8 pr-3 py-1.5 text-sm bg-transparent border-none outline-none placeholder:text-muted-foreground"
+                  autoFocus
+                />
+                {isSearching && (
+                  <Loader2 className="absolute right-7 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground animate-spin" />
+                )}
+              </div>
+
+              {/* Search Results */}
+              <div className="max-h-[40vh] overflow-y-auto scrollbar-auto-hide">
+                {error && (
+                  <div className="px-4 py-3 text-sm text-destructive bg-destructive/10">
+                    {error}
+                  </div>
+                )}
+
+                {!query.trim() && !isSearching && searchResults.length === 0 && (
+                  <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+                    Search the Skills.sh registry to find skills for your agent
+                  </div>
+                )}
+
+                {query.trim() && !isSearching && searchResults.length === 0 && (
+                  <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+                    No skills found for &ldquo;{query}&rdquo;
+                  </div>
+                )}
+
+                {searchResults.map((result) => {
+                  const installed = isAlreadyInstalled(result.fullHandle)
+                  const selected = selectedHandles.has(result.fullHandle)
+                  return (
+                    <button
+                      key={result.fullHandle}
+                      onClick={() => !installed && toggleSelection(result.fullHandle)}
+                      disabled={installed || isInstalling}
+                      className={cn(
+                        "flex items-start gap-3 w-full px-4 py-3 text-left transition-colors",
+                        installed
+                          ? "opacity-50 cursor-default"
+                          : selected
+                            ? "bg-primary/5"
+                            : "hover:bg-accent/50 cursor-pointer"
+                      )}
+                    >
+                      {/* Checkbox */}
+                      <div
+                        className={cn(
+                          "mt-0.5 flex-shrink-0 h-4 w-4 rounded border transition-colors",
+                          installed
+                            ? "border-muted-foreground/30 bg-muted"
+                            : selected
+                              ? "border-primary bg-primary"
+                              : "border-border"
+                        )}
+                      >
+                        {(installed || selected) && (
+                          <Check className="h-4 w-4 text-primary-foreground" />
+                        )}
+                      </div>
+
+                      {/* Content */}
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span className="text-sm font-medium text-foreground truncate">
+                            {result.fullHandle}
+                          </span>
+                          {installed && (
+                            <span className="text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
+                              Installed
+                            </span>
+                          )}
+                          {result.installs != null && result.installs > 0 && (
+                            <span className="text-xs text-muted-foreground">
+                              {result.installs.toLocaleString()} installs
+                            </span>
+                          )}
+                        </div>
+                        {result.description && (
+                          <p className="text-xs text-muted-foreground mt-0.5 line-clamp-2">
+                            {result.description}
+                          </p>
+                        )}
+                      </div>
+
+                      {/* External link */}
+                      {result.url && (
+                        <a
+                          href={result.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          onClick={(e) => e.stopPropagation()}
+                          className="mt-0.5 flex-shrink-0 p-1 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
+                        >
+                          <ExternalLink className="h-3.5 w-3.5" />
+                        </a>
+                      )}
+                    </button>
+                  )
+                })}
+              </div>
+
+              {/* Install Bar */}
+              {(selectedCount > 0 || installProgress) && (
+                <div className="flex items-center gap-3 px-4 py-3 border-t border-border bg-accent/30">
+                  {installProgress ? (
+                    <div className="flex items-center gap-2 flex-1">
+                      <Loader2 className="h-4 w-4 animate-spin text-primary" />
+                      <span className="text-sm text-foreground">
+                        Installing {installProgress.installed}/{installProgress.total} skills…
+                      </span>
+                      <div className="flex-1 h-1.5 rounded-full bg-muted overflow-hidden">
+                        <div
+                          className="h-full rounded-full bg-primary transition-all duration-300"
+                          style={{
+                            width: `${installProgress.total > 0 ? (installProgress.installed / installProgress.total) * 100 : 0}%`,
+                          }}
+                        />
+                      </div>
+                    </div>
+                  ) : (
+                    <>
+                      <span className="text-sm text-muted-foreground">
+                        {selectedCount} skill{selectedCount !== 1 ? "s" : ""} selected
+                      </span>
+                      <div className="flex-1" />
+                      <button
+                        onClick={() => setSelectedHandles(new Set())}
+                        className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                      >
+                        Clear
+                      </button>
+                      <button
+                        onClick={handleInstallSelected}
+                        disabled={isInstalling}
+                        className="px-3 py-1.5 text-sm font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
+                      >
+                        Install selected
+                      </button>
+                    </>
+                  )}
+                </div>
+              )}
+            </>
+          )}
+
+          {activeTab === "installed" && (
+            <div className="max-h-[50vh] overflow-y-auto scrollbar-auto-hide">
+              {installedSkills.length === 0 ? (
+                <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+                  No skills installed for this repo.
+                  <br />
+                  <button
+                    onClick={() => setActiveTab("search")}
+                    className="mt-2 text-primary hover:underline"
+                  >
+                    Search for skills →
+                  </button>
+                </div>
+              ) : (
+                installedSkills.map((skill) => (
+                  <div
+                    key={skill.id}
+                    className="flex items-center gap-3 px-4 py-3 hover:bg-accent/30 transition-colors group"
+                  >
+                    <Zap className="h-4 w-4 text-amber-500 flex-shrink-0" />
+                    <div className="flex-1 min-w-0">
+                      <div className="text-sm font-medium text-foreground truncate">
+                        {skill.fullHandle}
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        Installed {new Date(skill.createdAt).toLocaleDateString()}
+                      </div>
+                    </div>
+                    {skill.url && (
+                      <a
+                        href={skill.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex-shrink-0 p-1 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors opacity-0 group-hover:opacity-100"
+                      >
+                        <ExternalLink className="h-3.5 w-3.5" />
+                      </a>
+                    )}
+                    <button
+                      onClick={() => handleUninstall(skill.id)}
+                      className="flex-shrink-0 p-1 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors opacity-0 group-hover:opacity-100"
+                      title="Uninstall skill"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                ))
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/packages/web/components/skills/SkillSearchView.tsx
+++ b/packages/web/components/skills/SkillSearchView.tsx
@@ -70,12 +70,14 @@ export function SkillSearchView({ open, onOpenChange, chatId, repo }: SkillSearc
     }
 
     setIsSearching(true)
+    setError(null) // Clear any stale install/search errors
     searchTimeoutRef.current = setTimeout(async () => {
       try {
         const res = await fetch(`/api/skills/search?q=${encodeURIComponent(query.trim())}`)
         if (res.ok) {
           const data = await res.json()
           setSearchResults(data.results ?? [])
+          setError(null) // Clear errors on successful search
         } else {
           setError("Search failed — registry may be unavailable")
           setSearchResults([])
@@ -136,7 +138,7 @@ export function SkillSearchView({ open, onOpenChange, chatId, repo }: SkillSearc
         throw new Error("Failed to save skills")
       }
 
-      // Step 2: Install in sandbox
+      // Step 2: Install in sandbox (includes --list pre-validation)
       const installRes = await fetch("/api/skills/install", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -145,18 +147,35 @@ export function SkillSearchView({ open, onOpenChange, chatId, repo }: SkillSearc
 
       if (installRes.ok) {
         const result = await installRes.json()
-        setInstallProgress({ installed: result.installed, total: result.total })
+        const installedCount = result.installed ?? 0
+        setInstallProgress({ installed: installedCount, total: result.total })
+
+        // Surface per-skill failures
+        const failures = (result.results ?? []).filter(
+          (r: { success: boolean; error?: string }) => !r.success
+        )
+        if (failures.length > 0) {
+          const failMsgs = failures.map(
+            (f: { fullHandle: string; error?: string }) =>
+              `${f.fullHandle}: ${f.error ?? "unknown error"}`
+          )
+          setError(`${failures.length} skill(s) failed:\n${failMsgs.join("\n")}`)
+        }
+
+        // Refresh installed list and clear selection
+        await fetchInstalledSkills()
+        setSelectedHandles(new Set())
+
+        // Show installed tab only if at least one skill succeeded
+        setTimeout(() => {
+          if (installedCount > 0) {
+            setActiveTab("installed")
+          }
+          setInstallProgress(null)
+        }, 2000)
+      } else {
+        throw new Error("Install request failed")
       }
-
-      // Refresh installed list and clear selection
-      await fetchInstalledSkills()
-      setSelectedHandles(new Set())
-
-      // Show installed tab after successful install
-      setTimeout(() => {
-        setActiveTab("installed")
-        setInstallProgress(null)
-      }, 1500)
     } catch (err) {
       setError(err instanceof Error ? err.message : "Installation failed")
       setInstallProgress(null)

--- a/packages/web/components/skills/SkillSearchView.tsx
+++ b/packages/web/components/skills/SkillSearchView.tsx
@@ -186,7 +186,9 @@ export function SkillSearchView({ open, onOpenChange, chatId, repo }: SkillSearc
 
   const handleUninstall = async (skillId: string) => {
     try {
-      const res = await fetch(`/api/skills/${skillId}`, { method: "DELETE" })
+      const res = await fetch(`/api/skills/${skillId}?chatId=${encodeURIComponent(chatId)}`, {
+        method: "DELETE",
+      })
       if (res.ok) {
         setInstalledSkills((prev) => prev.filter((s) => s.id !== skillId))
       }

--- a/packages/web/lib/sandbox.ts
+++ b/packages/web/lib/sandbox.ts
@@ -286,8 +286,9 @@ export async function deleteSandboxQuietly(
  * Install all repo-scoped skills into a sandbox.
  *
  * Called during sandbox creation/restoration to ensure skills are present
- * before the agent starts. Best-effort — individual skill install failures
- * are logged but don't abort the overall sandbox setup.
+ * before the agent starts. Pre-validates each skill via --list to avoid
+ * installing stale/renamed skills. Best-effort — individual failures are
+ * logged but don't abort the overall sandbox setup.
  */
 export async function installSkillsForRepo(
   sandbox: Awaited<ReturnType<Daytona["get"]>>,
@@ -304,13 +305,42 @@ export async function installSkillsForRepo(
   const repoPath = `${PATHS.SANDBOX_HOME}/project`
   let installed = 0
 
+  // Cache --list results per source repo so we only clone once per repo
+  const availableSkillsCache = new Map<string, Set<string> | null>()
+
   for (const skill of skills) {
     try {
       // fullHandle is "owner/repo/skillId" — extract parts for install command
       // Must use --agent '*' -y for non-interactive sandbox environments
       const parts = skill.fullHandle.split("/")
       const source = parts.length >= 2 ? `${parts[0]}/${parts[1]}` : skill.fullHandle
-      const skillFlag = parts.length >= 3 ? ` --skill ${parts.slice(2).join("/")}` : ""
+      const skillId = parts.length >= 3 ? parts.slice(2).join("/") : null
+
+      // Pre-validate: check the skill actually exists in the repo
+      if (skillId) {
+        if (!availableSkillsCache.has(source)) {
+          try {
+            const listCmd = await sandbox.process.executeCommand(
+              `cd ${repoPath} && npx -y skills add ${source} --list 2>&1`
+            )
+            const names = parseSkillList(listCmd.result ?? "")
+            availableSkillsCache.set(source, names.length > 0 ? new Set(names) : null)
+          } catch {
+            availableSkillsCache.set(source, null)
+          }
+        }
+
+        const available = availableSkillsCache.get(source)
+        if (available && !available.has(skillId)) {
+          console.warn(
+            `[sandbox] Skill "${skillId}" not found in ${source}, removing stale DB record`
+          )
+          await prisma.skill.delete({ where: { id: skill.id } }).catch(() => {})
+          continue
+        }
+      }
+
+      const skillFlag = skillId ? ` --skill ${skillId}` : ""
       const installCmd = `npx -y skills add ${source}${skillFlag} --agent '*' -y`
       const cmd = await sandbox.process.executeCommand(
         `cd ${repoPath} && ${installCmd} 2>&1`
@@ -340,3 +370,33 @@ export async function installSkillsForRepo(
   return { installed, total: skills.length }
 }
 
+/** Strip ANSI escape codes, cursor controls, and terminal noise from CLI output */
+function stripAnsi(str: string): string {
+  return str
+    // eslint-disable-next-line no-control-regex
+    .replace(/\x1B\[[0-9;?]*[A-Za-z]/g, "")   // CSI sequences (colors, cursor)
+    // eslint-disable-next-line no-control-regex
+    .replace(/\x1B\][^\x07]*\x07/g, "")         // OSC sequences
+    // eslint-disable-next-line no-control-regex
+    .replace(/\x1B[@-Z\\-_]/g, "")              // Two-byte escape sequences
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\x00-\x09\x0B\x0C\x0E-\x1F]/g, "") // Control chars (keep \n)
+    .replace(/\r/g, "")                          // Carriage returns
+}
+
+/**
+ * Parse the output of `npx skills add <source> --list` to extract valid
+ * skill names. Output includes lines like:
+ *   │    - skill-name
+ */
+function parseSkillList(output: string): string[] {
+  const cleaned = stripAnsi(output)
+  const skills: string[] = []
+  for (const line of cleaned.split("\n")) {
+    const match = line.match(/[-–]\s+(\S+)\s*$/)
+    if (match && match[1]) {
+      skills.push(match[1])
+    }
+  }
+  return skills
+}

--- a/packages/web/lib/sandbox.ts
+++ b/packages/web/lib/sandbox.ts
@@ -11,6 +11,7 @@ import { randomUUID } from "crypto"
 import { createSandboxGit } from "@upstream/daytona-git"
 import { PATHS, SANDBOX_CONFIG } from "@/lib/constants"
 import { NEW_REPOSITORY } from "@/lib/types"
+import { prisma } from "@/lib/db/prisma"
 
 /**
  * Ensure a sandbox is in the "started" state, handling the race condition
@@ -280,3 +281,62 @@ export async function deleteSandboxQuietly(
     console.error("[sandbox] Failed to delete sandbox:", sandboxId, err)
   }
 }
+
+/**
+ * Install all repo-scoped skills into a sandbox.
+ *
+ * Called during sandbox creation/restoration to ensure skills are present
+ * before the agent starts. Best-effort — individual skill install failures
+ * are logged but don't abort the overall sandbox setup.
+ */
+export async function installSkillsForRepo(
+  sandbox: Awaited<ReturnType<Daytona["get"]>>,
+  userId: string,
+  repo: string
+): Promise<{ installed: number; total: number }> {
+  const skills = await prisma.skill.findMany({
+    where: { userId, repo },
+    orderBy: { createdAt: "asc" },
+  })
+
+  if (skills.length === 0) return { installed: 0, total: 0 }
+
+  const repoPath = `${PATHS.SANDBOX_HOME}/project`
+  let installed = 0
+
+  for (const skill of skills) {
+    try {
+      // fullHandle is "owner/repo/skillId" — extract parts for install command
+      // Must use --agent '*' -y for non-interactive sandbox environments
+      const parts = skill.fullHandle.split("/")
+      const source = parts.length >= 2 ? `${parts[0]}/${parts[1]}` : skill.fullHandle
+      const skillFlag = parts.length >= 3 ? ` --skill ${parts.slice(2).join("/")}` : ""
+      const installCmd = `npx -y skills add ${source}${skillFlag} --agent '*' -y`
+      const cmd = await sandbox.process.executeCommand(
+        `cd ${repoPath} && ${installCmd} 2>&1`
+      )
+      if (cmd.exitCode === 0) {
+        installed++
+      } else {
+        console.error(
+          `[sandbox] Failed to install skill ${skill.fullHandle}:`,
+          cmd.result?.trim()
+        )
+      }
+    } catch (err) {
+      console.error(
+        `[sandbox] Error installing skill ${skill.fullHandle}:`,
+        err
+      )
+    }
+  }
+
+  if (installed > 0) {
+    console.log(
+      `[sandbox] Installed ${installed}/${skills.length} skills for ${repo}`
+    )
+  }
+
+  return { installed, total: skills.length }
+}
+

--- a/packages/web/lib/types.ts
+++ b/packages/web/lib/types.ts
@@ -98,6 +98,30 @@ export interface Message {
 // Special value for new repository (local git repo, no GitHub)
 export const NEW_REPOSITORY = "__new__"
 
+// =============================================================================
+// Skills
+// =============================================================================
+
+export interface Skill {
+  id: string
+  repo: string
+  publisher: string
+  name: string
+  fullHandle: string
+  url: string | null
+  createdAt: number
+  updatedAt: number
+}
+
+export interface SkillSearchResult {
+  publisher: string
+  name: string
+  fullHandle: string
+  description: string
+  url: string
+}
+
+
 export interface Chat {
   id: string
 

--- a/packages/web/prisma/migrations/20260507220956_add_skill_model/migration.sql
+++ b/packages/web/prisma/migrations/20260507220956_add_skill_model/migration.sql
@@ -1,0 +1,23 @@
+-- CreateTable
+CREATE TABLE "Skill" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "repo" TEXT NOT NULL,
+    "publisher" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "fullHandle" TEXT NOT NULL,
+    "url" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Skill_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Skill_userId_repo_idx" ON "Skill"("userId", "repo");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Skill_userId_repo_fullHandle_key" ON "Skill"("userId", "repo", "fullHandle");
+
+-- AddForeignKey
+ALTER TABLE "Skill" ADD CONSTRAINT "Skill_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/web/prisma/schema.prisma
+++ b/packages/web/prisma/schema.prisma
@@ -43,6 +43,7 @@ model User {
   sessions      Session[]
   activityLogs  ActivityLog[]
   scheduledJobs ScheduledJob[]
+  skills        Skill[]
 }
 
 // =============================================================================
@@ -294,4 +295,31 @@ model ScheduledJobRun {
 
   @@index([jobId, startedAt])
   @@index([status])
+}
+
+// =============================================================================
+// Skill - repo-scoped skill manifests
+// =============================================================================
+
+model Skill {
+  id        String   @id @default(cuid())
+  userId    String
+  repo      String   // "owner/repo" — which repo this skill belongs to
+
+  // Skill identity
+  publisher  String  // e.g. "anthropic", "vercel"
+  name       String  // e.g. "code-review"
+  fullHandle String  // "publisher/name" — the install handle
+
+  // Source
+  url        String? // Source URL (skills.sh link)
+
+  // Timestamps
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, repo, fullHandle])
+  @@index([userId, repo])
 }


### PR DESCRIPTION
## Summary

Adds a full skill management system that lets users search, install, and uninstall agent skills from the [Skills.sh](https://skills.sh) registry. Skills are repo-scoped — each skill is tied to a specific user + repo combination and automatically restored when a sandbox is recreated.

## Changes

### Database
- Added `Skill` model to Prisma schema with `(userId, repo, fullHandle)` unique constraint
- Migration: `20260507220956_add_skill_model`

### API Routes (5 new)
| Route | Method | Purpose |
|---|---|---|
| `/api/skills` | `GET` | List installed skills for a repo |
| `/api/skills` | `POST` | Bulk upsert skills to DB (idempotent) |
| `/api/skills/search` | `GET` | Proxy search to Skills.sh (`/api/search?q=`) |
| `/api/skills/install` | `POST` | Pre-validate via `--list`, then install into sandbox |
| `/api/skills/[id]` | `DELETE` | Remove from DB + sandbox filesystem |

### Sandbox Integration (`lib/sandbox.ts`)
- `installSkillsForRepo()` — restores all skills on sandbox init/recreation
- Pre-validates each skill via `npx skills add <source> --list` before install
- Auto-deletes stale DB records when skills are renamed/removed upstream
- Integrated into `chats/[chatId]/messages/route.ts` post-sandbox-creation

### UI (`SkillSearchView` + Command Palette)
- **Command Palette**: Conditional "Manage skills" entry (visible only with active sandbox)
- **SkillSearchView modal**: Debounced search, multi-select checkboxes, progress bar, installed tab with uninstall
- Per-skill install failure reporting with clean error messages

## Key Design Decisions

- **Pre-validation with `--list`**: Before installing, we run `npx skills add <source> --list` to discover actual skill names in the repo. The Skills.sh search index can be stale (returning skill names that no longer exist), so this prevents silent install failures. (see `openai/frontend-design` skill for reference)
- **ANSI stripping**: CLI output contains escape codes, cursor controls, and spinner artifacts. All CLI output is sanitized before parsing or returning to the UI.
- **Non-interactive flags**: Sandbox has no TTY, so all CLI commands use `--agent '*' -y` to skip prompts.
- **Best-effort filesystem ops**: Sandbox install/uninstall failures are logged but never block the request — DB state is the source of truth.
- **`fullHandle` = `source/skillId`**: A single repo can contain many skills. Using `owner/repo/skillId` as the unique handle prevents key collisions.