### PR TITLE
Update system prompt to make the agent aware of skills

### DIFF
--- a/packages/common/src/session.ts
+++ b/packages/common/src/session.ts
@@ -48,6 +48,7 @@ The repository is cloned at ${repoPath}.
 - Always create NEW commits. Never rewrite git history (no git commit --amend, git rebase, or git reset --hard).
 - Do not push — pushing is handled automatically.
 - Use "git restore" to discard file changes (not "git checkout").
+- NEVER commit the \`.agents\` directory or \`skills-lock.json\`. These are local configuration files and must remain uncommitted.
 
 ## File Operations
 - Use ${repoPath} for all file operations.

--- a/packages/common/src/session.ts
+++ b/packages/common/src/session.ts
@@ -53,6 +53,11 @@ The repository is cloned at ${repoPath}.
 - Use ${repoPath} for all file operations.
 - Always check the current state of files before editing them.
 
+## Agent Skills
+- You may have "skills" (custom instructions, guidelines, and rules) installed in the repository.
+- To check what skills are installed and what they do, look inside the ${repoPath}/.agents/skills/ directory.
+- Always adhere to any instructions defined in these skills.
+
 ## Logs Directory
 - Write any log files to ${PATHS.LOGS_DIR}.
 - Examples: ${PATHS.LOGS_DIR}/build.log, ${PATHS.LOGS_DIR}/test-results.log


### PR DESCRIPTION
**What changed?**
Updated the shared system prompt (`buildSystemPrompt`) in `@upstream/common` to properly support the open `skills` ecosystem across all wrapped agents.

Specifically:
1. **Universal Skill Awareness**: Added an `## Agent Skills` section explicitly telling the LLMs what skills are and directing them to look inside the `.agents/skills/` directory. This allows agents to correctly list installed skills when asked, and ensures experimental/non-native agents strictly adhere to the installed rules.
2. **Prevent Dirty Commits**: Added a strict rule to the `## Git Rules` section explicitly forbidding agents from committing the `.agents/` directory or `skills-lock.json`. This ensures that repository-scoped skill configurations remain local and uncommitted.

**Why?**
- Previously, if a user asked "what skills do I have?", the agent would hallucinate "none" because it lacked the meta-knowledge to map the injected instructions to the `.agents/` directory. 
- Prevents agents from accidentally littering upstream repositories with local skill configuration files during auto-commits.