### PR TITLE
feat: add rapid fire mode for sending background tasks without switching chats

### DIFF
--- a/packages/web/app/api/user/settings/route.ts
+++ b/packages/web/app/api/user/settings/route.ts
@@ -33,6 +33,7 @@ function readSettings(raw: unknown): Settings {
     defaultAgent: s.defaultAgent ?? null,
     defaultModel: s.defaultModel ?? null,
     theme: s.theme ?? DEFAULT_SETTINGS.theme,
+    rapidFireMode: s.rapidFireMode ?? DEFAULT_SETTINGS.rapidFireMode,
   }
 }
 

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -169,6 +169,8 @@ function HomePageContent({ isMobile }: HomePageContentProps) {
   const [scheduledJobsRefreshKey, setScheduledJobsRefreshKey] = useState(0)
   // Track when a message send is initiated (for instant UI feedback before server responds)
   const [isSendingMessage, setIsSendingMessage] = useState(false)
+  // Rapid fire notification: timestamp of last background task creation, 0 means no notification
+  const [rapidFireNotification, setRapidFireNotification] = useState(0)
   const [isDownloading, setIsDownloading] = useState(false)
   const [skillsModalOpen, setSkillsModalOpen] = useState(false)
 
@@ -585,6 +587,12 @@ function HomePageContent({ isMobile }: HomePageContentProps) {
       return
     }
 
+    // Rapid fire mode: send as background task without switching
+    if (settings.rapidFireMode) {
+      handleRapidFireSend(message, agent, model, files, planMode)
+      return
+    }
+
     // Update filter to match the chat's repo if this is the first message and repo differs from filter
     // This ensures the filter follows the user's choice when starting a chat
     if (displayCurrentChat && displayCurrentChat.messages.length === 0 &&
@@ -602,6 +610,24 @@ function HomePageContent({ isMobile }: HomePageContentProps) {
     setIsSendingMessage(true)
     sendMessage(message, agent, model, files, undefined, planMode)
   }
+
+  // Rapid fire: send as a new background chat without switching
+  const handleRapidFireSend = useCallback(async (message: string, agent: string, model: string, files?: File[], planMode?: boolean) => {
+    if (!session) {
+      savePendingMessage({ message, agent, model })
+      modals.setSignInModalOpen(true)
+      return
+    }
+
+    const repo = displayCurrentChat?.repo ?? NEW_REPOSITORY
+    const baseBranch = displayCurrentChat?.baseBranch ?? "main"
+
+    const chatId = await startNewChat(repo, baseBranch, undefined, false, "pending")
+    if (!chatId) return
+
+    sendMessage(message, agent, model, files, chatId, planMode)
+    setRapidFireNotification(Date.now())
+  }, [session, displayCurrentChat, startNewChat, sendMessage, modals, setRapidFireNotification])
 
   // After sign-in, replay any pending message saved before the OAuth
   // redirect. Two effects work together to avoid a stale-closure race:
@@ -1068,6 +1094,8 @@ function HomePageContent({ isMobile }: HomePageContentProps) {
       onNavigateChat={handleNavigateChat}
       currentChatId={displayCurrentChatId}
       onSelectChat={handleSelectChat}
+      rapidFireMode={settings.rapidFireMode}
+      onToggleRapidFire={() => updateSettings({ settings: { rapidFireMode: !settings.rapidFireMode } })}
     >
     <ChatProvider value={chatContextValue}>
     <GitProvider value={gitContextValue}>
@@ -1190,6 +1218,8 @@ function HomePageContent({ isMobile }: HomePageContentProps) {
                   isSending={isSendingMessage}
                   onOpenPlan={(messageId) => preview.openPreview({ type: "plan", messageId, content: "" })}
                   isAuthenticated={!!session}
+                  rapidFireMode={settings.rapidFireMode}
+                  rapidFireNotification={rapidFireNotification}
                 />
               )}
             </div>

--- a/packages/web/components/ChatPanel.tsx
+++ b/packages/web/components/ChatPanel.tsx
@@ -44,6 +44,10 @@ interface ChatPanelProps {
   onOpenPlan?: (messageId: string) => void
   /** Whether the user is authenticated */
   isAuthenticated?: boolean
+  /** Whether rapid fire mode is enabled */
+  rapidFireMode?: boolean
+  /** Timestamp of last rapid fire task creation (0 = no notification) */
+  rapidFireNotification?: number
 }
 
 export function ChatPanel({ chat, settings, credentialFlags, showClaudeLimitDialog, onSendMessage, onEnqueueMessage, onRemoveQueuedMessage, onResumeQueue, onStopAgent, onChangeRepo, onChangeBranch, onUpdateChat, onSlashCommand, onOpenFile, onOpenEnvVars, isMobile = false, isLoadingMessages = false, draft = "", onDraftChange, isSending = false, onOpenCommandPalette, onOpenPlan, isAuthenticated = false }: ChatPanelProps) {
@@ -362,6 +366,9 @@ export function ChatPanel({ chat, settings, credentialFlags, showClaudeLimitDial
   // Only show welcome screen if no messages AND not loading messages AND not a child chat
   const isNewChat = chat.messages.length === 0 && !chat.parentChatId && !isLoadingMessages
 
+  // Rapid fire notification
+  const showRapidFireNotification = rapidFireMode && rapidFireNotification && rapidFireNotification > 0
+
   // Chat input component
   const chatInput = (
     <ChatInput
@@ -508,6 +515,12 @@ export function ChatPanel({ chat, settings, credentialFlags, showClaudeLimitDial
               What would you like to build?
             </h2>
           </div>
+          {showRapidFireNotification && (
+            <div className="mt-2 flex items-center justify-center gap-1.5 text-sm text-emerald-600 dark:text-emerald-400 animate-in fade-in slide-in-from-bottom-1 duration-200">
+              <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+              Task started
+            </div>
+          )}
           {chatInput}
           <div className={cn(
             "text-muted-foreground mt-4 text-center",
@@ -656,6 +669,12 @@ export function ChatPanel({ chat, settings, credentialFlags, showClaudeLimitDial
           ? (hasQueued ? "px-[27px] pt-0 pb-3 pb-safe" : "px-[27px] py-3 pb-safe")
           : (hasQueued ? "px-[31px] pt-0 pb-4" : "px-[31px] pb-4 pt-2")
       )}>
+        {showRapidFireNotification && (
+          <div className="mb-2 flex items-center gap-1.5 text-xs text-emerald-600 dark:text-emerald-400 animate-in fade-in slide-in-from-bottom-1 duration-200">
+            <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+            Task started
+          </div>
+        )}
         {chatInput}
       </div>
 

--- a/packages/web/components/modals/SettingsModal.tsx
+++ b/packages/web/components/modals/SettingsModal.tsx
@@ -203,6 +203,7 @@ export function SettingsModal({ open, onClose, settings, credentialFlags, onSave
   const [defaultAgent, setDefaultAgent] = useState<Agent>(initialDefaultAgent)
   const [defaultModel, setDefaultModel] = useState(initialDefaultModel)
   const [selectedTheme, setSelectedTheme] = useState<Theme>(settings.theme)
+  const [rapidFireMode, setRapidFireMode] = useState(settings.rapidFireMode)
   const [activeSection, setActiveSection] = useState<SectionKey>(defaultSection)
 
   // Drag to dismiss (mobile only)
@@ -233,6 +234,7 @@ export function SettingsModal({ open, onClose, settings, credentialFlags, onSave
       setDefaultAgent(initialDefaultAgent)
       setDefaultModel(initialDefaultModel)
       setSelectedTheme(settings.theme)
+      setRapidFireMode(settings.rapidFireMode)
       setActiveSection(defaultSection)
     }
   }, [open, settings, credentialFlags, initialDefaultAgent, initialDefaultModel, defaultSection])
@@ -296,7 +298,8 @@ export function SettingsModal({ open, onClose, settings, credentialFlags, onSave
   const settingsChanged =
     defaultAgent !== initialDefaultAgent ||
     defaultModel !== initialDefaultModel ||
-    selectedTheme !== settings.theme
+    selectedTheme !== settings.theme ||
+    rapidFireMode !== settings.rapidFireMode
 
   const hasChanges = credChanged || settingsChanged
 
@@ -307,6 +310,7 @@ export function SettingsModal({ open, onClose, settings, credentialFlags, onSave
     if (defaultAgent !== initialDefaultAgent) settingsPatch.defaultAgent = defaultAgent
     if (defaultModel !== initialDefaultModel) settingsPatch.defaultModel = defaultModel
     if (selectedTheme !== settings.theme) settingsPatch.theme = selectedTheme
+    if (rapidFireMode !== settings.rapidFireMode) settingsPatch.rapidFireMode = rapidFireMode
 
     // Only send credential fields the user actually changed. Sending the
     // mask back ("***") would otherwise overwrite the real key.
@@ -397,6 +401,28 @@ export function SettingsModal({ open, onClose, settings, credentialFlags, onSave
             })}
           </SelectContent>
         </Select>
+      </SettingsRow>
+      <SettingsRow
+        label="Rapid fire mode"
+        description="Send tasks without switching to them. The input clears so you can quickly delegate multiple tasks."
+      >
+        <button
+          type="button"
+          role="switch"
+          aria-checked={rapidFireMode}
+          onClick={() => setRapidFireMode(!rapidFireMode)}
+          className={cn(
+            "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+            rapidFireMode ? "bg-primary" : "bg-input"
+          )}
+        >
+          <span
+            className={cn(
+              "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform duration-200 ease-in-out",
+              rapidFireMode ? "translate-x-4" : "translate-x-0"
+            )}
+          />
+        </button>
       </SettingsRow>
     </div>
   )

--- a/packages/web/components/search-palette/CommandPalette.tsx
+++ b/packages/web/components/search-palette/CommandPalette.tsx
@@ -84,6 +84,10 @@ interface CommandPaletteProps {
   currentTheme?: Theme
   /** Change theme. */
   onThemeChange?: (theme: Theme) => void
+  /** Whether rapid fire mode is on */
+  rapidFireMode?: boolean
+  /** Toggle rapid fire mode */
+  onToggleRapidFire?: () => void
 }
 
 export function CommandPalette({
@@ -309,6 +313,15 @@ export function CommandPalette({
             <CommandItem value="toggle sidebar" onSelect={() => run(onToggleSidebar)}>
               <PanelLeft className="mr-2 h-4 w-4 text-muted-foreground" />
               <span>Toggle sidebar</span>
+            </CommandItem>
+          )}
+          {onToggleRapidFire !== undefined && (
+            <CommandItem
+              value={rapidFireMode ? "disable rapid fire mode" : "enable rapid fire mode"}
+              onSelect={() => run(onToggleRapidFire)}
+            >
+              <Zap className={cn("mr-2 h-4 w-4", rapidFireMode ? "text-amber-500" : "text-muted-foreground")} />
+              <span>{rapidFireMode ? "Disable rapid fire mode" : "Enable rapid fire mode"}</span>
             </CommandItem>
           )}
           <CommandItem value="settings" onSelect={() => run(() => onOpenSettings())}>

--- a/packages/web/components/search-palette/PaletteProvider.tsx
+++ b/packages/web/components/search-palette/PaletteProvider.tsx
@@ -63,6 +63,10 @@ interface PaletteProviderProps {
    *  precedence over the flat chatIds rotation so the parent can walk the
    *  sidebar tree and auto-expand branches. */
   onNavigateChat?: (direction: "up" | "down") => void
+  /** Whether rapid fire mode is on */
+  rapidFireMode?: boolean
+  /** Toggle rapid fire mode */
+  onToggleRapidFire?: () => void
 }
 
 export function PaletteProvider({
@@ -100,6 +104,8 @@ export function PaletteProvider({
   currentChatId,
   onSelectChat,
   onNavigateChat,
+  rapidFireMode,
+  onToggleRapidFire,
 }: PaletteProviderProps) {
   const { theme, setTheme } = useTheme()
   const [searchOpen, setSearchOpenState] = useState(false)
@@ -222,6 +228,8 @@ export function PaletteProvider({
         onSelectChat={onSelectChat}
         currentTheme={(theme as Theme) ?? "system"}
         onThemeChange={(newTheme: Theme) => setTheme(newTheme)}
+        rapidFireMode={rapidFireMode}
+        onToggleRapidFire={onToggleRapidFire}
       />
     </PaletteContext.Provider>
   )

--- a/packages/web/lib/storage.ts
+++ b/packages/web/lib/storage.ts
@@ -59,6 +59,7 @@ export const DEFAULT_SETTINGS: Settings = {
   defaultAgent: null,
   defaultModel: null,
   theme: "system",
+  rapidFireMode: false,
 }
 
 const DEFAULT_LOCAL_STATE: LocalState = {

--- a/packages/web/lib/types.ts
+++ b/packages/web/lib/types.ts
@@ -211,6 +211,7 @@ export interface Settings {
   defaultAgent: string | null
   defaultModel: string | null
   theme: Theme
+  rapidFireMode: boolean
 }
 
 export type { CredentialId, Credentials, CredentialFlags } from "./credentials"


### PR DESCRIPTION
## Summary
- Adds a "rapid fire mode" toggle in Settings that lets users send messages as background tasks without switching away from their current chat
- Each rapid fire message creates a new independent chat and dispatches the agent, then shows a brief "Task started" confirmation
- Includes a command palette entry (`Ctrl+K`) to toggle the mode on/off
- Settings, types, storage, API, and UI components are all wired together

## How it works
When rapid fire mode is enabled, hitting Send creates a new background chat (inheriting the current chat's repo/branch context), sends the agent a message, and clears the input — so you can quickly delegate multiple tasks in succession without losing your place.
