### PR TITLE
Feat/ Smithery Browse

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git checkout *)",
+      "Bash(git show *)",
+      "Bash(npx prisma *)",
+      "Bash(npx tsc *)",
+      "Bash(git add *)"
+    ]
+  }
+}

--- a/packages/agent-configuration/package.json
+++ b/packages/agent-configuration/package.json
@@ -32,6 +32,7 @@
   },
   "exports": {
     ".": "./src/index.ts",
-    "./git": "./src/git/index.ts"
+    "./git": "./src/git/index.ts",
+    "./mcp": "./src/mcp/index.ts"
   }
 }

--- a/packages/agent-configuration/src/index.ts
+++ b/packages/agent-configuration/src/index.ts
@@ -28,3 +28,6 @@
 
 // Re-export all git safety configuration
 export * from "./git"
+
+// Re-export MCP configuration
+export * from "./mcp"

--- a/packages/agent-configuration/src/mcp/index.ts
+++ b/packages/agent-configuration/src/mcp/index.ts
@@ -27,15 +27,14 @@ export interface AgentMcpServer {
   bearerToken: string
 }
 
-export interface McpConfigFile {
+interface McpConfigFile {
   filePath: string
   content: string
   /** JSON → use the merging path; YAML/TOML overwrite. */
   format: "json" | "toml" | "yaml"
 }
 
-/** Agents we know how to write configs for. */
-export const MCP_SUPPORTED_AGENTS = [
+const MCP_SUPPORTED_AGENTS = [
   "claude-code",
   "codex",
   "gemini",
@@ -43,9 +42,9 @@ export const MCP_SUPPORTED_AGENTS = [
   "goose",
 ] as const
 
-export type McpSupportedAgent = (typeof MCP_SUPPORTED_AGENTS)[number]
+type McpSupportedAgent = (typeof MCP_SUPPORTED_AGENTS)[number]
 
-export function agentSupportsMcp(agent: string): agent is McpSupportedAgent {
+function agentSupportsMcp(agent: string): agent is McpSupportedAgent {
   return MCP_SUPPORTED_AGENTS.includes(agent as McpSupportedAgent)
 }
 
@@ -151,10 +150,6 @@ function generateGooseConfig(servers: AgentMcpServer[]): McpConfigFile {
     lines.push(`    name: ${s.name}`)
     lines.push(`    uri: "${s.url}"`)
     lines.push(`    enabled: true`)
-    lines.push(`    envs:`)
-    // Goose passes envs to the MCP client; not used for headers, but doesn't
-    // hurt to keep them aligned for future debugging.
-    lines.push(`      MCP_AUTH: "Bearer ${s.bearerToken}"`)
     lines.push(`    headers:`)
     lines.push(`      Authorization: "Bearer ${s.bearerToken}"`)
   }
@@ -165,8 +160,7 @@ function generateGooseConfig(servers: AgentMcpServer[]): McpConfigFile {
   }
 }
 
-/** Dispatch to the right generator for this agent. */
-export function generateMcpConfigForAgent(
+function generateMcpConfigForAgent(
   agent: string,
   servers: AgentMcpServer[]
 ): McpConfigFile | null {

--- a/packages/agent-configuration/src/mcp/index.ts
+++ b/packages/agent-configuration/src/mcp/index.ts
@@ -1,0 +1,265 @@
+/**
+ * Per-agent MCP config writers.
+ *
+ * Each agent CLI loads MCP servers from a different config file with a
+ * different schema. Given a list of `{ name, url, bearerToken }` connections
+ * from the web layer, write the right file in the right format inside the
+ * sandbox so the agent picks them up on startup.
+ *
+ * Currently emits Streamable-HTTP configs for the URL provided. Smithery's
+ * connect endpoint (api.smithery.ai/connect/<ns>/<id>/mcp) is Streamable-HTTP,
+ * so no per-server transport flag is needed.
+ */
+
+import type { Sandbox } from "@daytonaio/sdk"
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/** One MCP server connection to write into the agent's config. */
+export interface AgentMcpServer {
+  /** Stable identifier for the config entry. Must be unique within the file. */
+  name: string
+  /** Remote MCP endpoint the agent CLI should call. */
+  url: string
+  /** Bearer token to send as `Authorization: Bearer <token>`. */
+  bearerToken: string
+}
+
+export interface McpConfigFile {
+  filePath: string
+  content: string
+  /** JSON → use the merging path; YAML/TOML overwrite. */
+  format: "json" | "toml" | "yaml"
+}
+
+/** Agents we know how to write configs for. */
+export const MCP_SUPPORTED_AGENTS = [
+  "claude-code",
+  "codex",
+  "gemini",
+  "opencode",
+  "goose",
+] as const
+
+export type McpSupportedAgent = (typeof MCP_SUPPORTED_AGENTS)[number]
+
+export function agentSupportsMcp(agent: string): agent is McpSupportedAgent {
+  return MCP_SUPPORTED_AGENTS.includes(agent as McpSupportedAgent)
+}
+
+// =============================================================================
+// Per-agent generators
+// =============================================================================
+
+/**
+ * Claude Code: ~/.claude.json — `mcpServers.<name>` with `type: "http"`.
+ * JSON, merged with existing settings so unrelated keys survive.
+ */
+function generateClaudeConfig(servers: AgentMcpServer[]): McpConfigFile {
+  const mcpServers: Record<string, unknown> = {}
+  for (const s of servers) {
+    mcpServers[s.name] = {
+      type: "http",
+      url: s.url,
+      headers: { Authorization: `Bearer ${s.bearerToken}` },
+    }
+  }
+  return {
+    filePath: "/home/daytona/.claude.json",
+    content: JSON.stringify({ mcpServers }, null, 2),
+    format: "json",
+  }
+}
+
+/**
+ * Codex: ~/.codex/config.toml — `[mcp_servers.<name>]` (underscore, not dot).
+ * Presence of `url` selects Streamable-HTTP; no `type` field exists.
+ */
+function generateCodexConfig(servers: AgentMcpServer[]): McpConfigFile {
+  const lines: string[] = []
+  for (const s of servers) {
+    lines.push(`[mcp_servers.${s.name}]`)
+    lines.push(`url = "${s.url}"`)
+    lines.push(`http_headers = { Authorization = "Bearer ${s.bearerToken}" }`)
+    lines.push(`enabled = true`)
+    lines.push(`startup_timeout_sec = 30`)
+    lines.push("")
+  }
+  return {
+    filePath: "/home/daytona/.codex/config.toml",
+    content: lines.join("\n").trimEnd(),
+    format: "toml",
+  }
+}
+
+/**
+ * Gemini CLI: ~/.gemini/settings.json — `mcpServers.<name>.httpUrl`.
+ * Use `httpUrl` (not `url`); `url` is the legacy SSE field.
+ */
+function generateGeminiConfig(servers: AgentMcpServer[]): McpConfigFile {
+  const mcpServers: Record<string, unknown> = {}
+  for (const s of servers) {
+    mcpServers[s.name] = {
+      httpUrl: s.url,
+      headers: { Authorization: `Bearer ${s.bearerToken}` },
+    }
+  }
+  return {
+    filePath: "/home/daytona/.gemini/settings.json",
+    content: JSON.stringify({ mcpServers }, null, 2),
+    format: "json",
+  }
+}
+
+/**
+ * OpenCode: <project>/opencode.json — `mcp.<name>` with `type: "remote"`.
+ * The `.opencode/` directory is for agents/commands/plugins, not config.
+ */
+function generateOpenCodeConfig(servers: AgentMcpServer[]): McpConfigFile {
+  const mcp: Record<string, unknown> = {}
+  for (const s of servers) {
+    mcp[s.name] = {
+      type: "remote",
+      url: s.url,
+      headers: { Authorization: `Bearer ${s.bearerToken}` },
+      enabled: true,
+    }
+  }
+  return {
+    filePath: "/home/daytona/project/opencode.json",
+    content: JSON.stringify(
+      { $schema: "https://opencode.ai/config.json", mcp },
+      null,
+      2
+    ),
+    format: "json",
+  }
+}
+
+/**
+ * Goose: ~/.config/goose/config.yaml — `extensions.<name>` with
+ * `type: streamable_http`. The `streamable_http` form is the Streamable-HTTP
+ * variant; `type: sse` is the legacy SSE transport.
+ */
+function generateGooseConfig(servers: AgentMcpServer[]): McpConfigFile {
+  const lines: string[] = ["extensions:"]
+  for (const s of servers) {
+    lines.push(`  ${s.name}:`)
+    lines.push(`    type: streamable_http`)
+    lines.push(`    name: ${s.name}`)
+    lines.push(`    uri: "${s.url}"`)
+    lines.push(`    enabled: true`)
+    lines.push(`    envs:`)
+    // Goose passes envs to the MCP client; not used for headers, but doesn't
+    // hurt to keep them aligned for future debugging.
+    lines.push(`      MCP_AUTH: "Bearer ${s.bearerToken}"`)
+    lines.push(`    headers:`)
+    lines.push(`      Authorization: "Bearer ${s.bearerToken}"`)
+  }
+  return {
+    filePath: "/home/daytona/.config/goose/config.yaml",
+    content: lines.join("\n"),
+    format: "yaml",
+  }
+}
+
+/** Dispatch to the right generator for this agent. */
+export function generateMcpConfigForAgent(
+  agent: string,
+  servers: AgentMcpServer[]
+): McpConfigFile | null {
+  if (!agentSupportsMcp(agent) || servers.length === 0) return null
+  switch (agent) {
+    case "claude-code":
+      return generateClaudeConfig(servers)
+    case "codex":
+      return generateCodexConfig(servers)
+    case "gemini":
+      return generateGeminiConfig(servers)
+    case "opencode":
+      return generateOpenCodeConfig(servers)
+    case "goose":
+      return generateGooseConfig(servers)
+  }
+}
+
+// =============================================================================
+// Sandbox writer
+// =============================================================================
+
+export interface SetupMcpOptions {
+  agent: string
+  servers: AgentMcpServer[]
+}
+
+/**
+ * Write the per-agent MCP config into the sandbox.
+ *
+ * Called once per agent run (before `createSession`). The agent picks up the
+ * config when it spawns, so this must run *before* the CLI starts.
+ */
+export async function setupMcpForAgent(
+  sandbox: Sandbox,
+  { agent, servers }: SetupMcpOptions
+): Promise<void> {
+  if (!agentSupportsMcp(agent)) return
+  if (servers.length === 0) return
+
+  const config = generateMcpConfigForAgent(agent, servers)
+  if (!config) return
+
+  const dir = config.filePath.substring(0, config.filePath.lastIndexOf("/"))
+  await sandbox.process.executeCommand(`mkdir -p ${dir}`)
+
+  if (config.format === "json") {
+    await mergeJsonConfig(sandbox, config.filePath, config.content)
+  } else {
+    await sandbox.fs.uploadFile(
+      Buffer.from(config.content, "utf-8"),
+      config.filePath
+    )
+  }
+}
+
+/**
+ * Merge new JSON config with existing — shallow-merge `mcpServers` and `mcp`
+ * sections so we don't clobber unrelated user settings (e.g. claude-code's
+ * non-MCP keys in ~/.claude.json).
+ */
+async function mergeJsonConfig(
+  sandbox: Sandbox,
+  filePath: string,
+  newContent: string
+): Promise<void> {
+  const result = (await sandbox.process.executeCommand(
+    `cat "${filePath}" 2>/dev/null || echo '{}'`
+  )) as { result: string }
+
+  let existing: Record<string, unknown>
+  try {
+    existing = JSON.parse(result.result.trim() || "{}")
+  } catch {
+    existing = {}
+  }
+
+  const incoming = JSON.parse(newContent) as Record<string, unknown>
+
+  if (incoming.mcpServers) {
+    const prev = (existing.mcpServers as Record<string, unknown>) || {}
+    existing.mcpServers = { ...prev, ...(incoming.mcpServers as object) }
+  }
+  if (incoming.mcp) {
+    const prev = (existing.mcp as Record<string, unknown>) || {}
+    existing.mcp = { ...prev, ...(incoming.mcp as object) }
+  }
+  if (incoming.$schema && !existing.$schema) {
+    existing.$schema = incoming.$schema
+  }
+
+  await sandbox.fs.uploadFile(
+    Buffer.from(JSON.stringify(existing, null, 2), "utf-8"),
+    filePath
+  )
+}

--- a/packages/web/app/api/chats/[chatId]/mcp-servers/[serverId]/route.ts
+++ b/packages/web/app/api/chats/[chatId]/mcp-servers/[serverId]/route.ts
@@ -1,0 +1,47 @@
+/**
+ * DELETE /api/chats/<chatId>/mcp-servers/<serverId>
+ *
+ * Removes the connection both from our DB and (best-effort) from Smithery.
+ */
+import { prisma } from "@/lib/db/prisma"
+import {
+  requireAuth,
+  isAuthError,
+  notFound,
+  internalError,
+  getChatWithAuth,
+} from "@/lib/db/api-helpers"
+import { deleteSmitheryConnection } from "@/lib/mcp/smithery-connect"
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Promise<{ chatId: string; serverId: string }> }
+): Promise<Response> {
+  const auth = await requireAuth()
+  if (isAuthError(auth)) return auth
+  const { userId } = auth
+  const { chatId, serverId } = await params
+
+  const chat = await getChatWithAuth(chatId, userId)
+  if (!chat) return notFound("Chat not found")
+
+  const server = await prisma.chatMcpServer.findUnique({
+    where: { id: serverId },
+  })
+  if (!server || server.chatId !== chatId) {
+    return notFound("Server not found")
+  }
+
+  try {
+    const apiKey = process.env.SMITHERY_API_KEY
+    if (apiKey && server.smitheryConnectionId) {
+      await deleteSmitheryConnection(server.smitheryConnectionId, apiKey)
+    }
+
+    await prisma.chatMcpServer.delete({ where: { id: serverId } })
+
+    return Response.json({ deleted: true })
+  } catch (err) {
+    return internalError(err)
+  }
+}

--- a/packages/web/app/api/chats/[chatId]/mcp-servers/[serverId]/smithery-finalize/route.ts
+++ b/packages/web/app/api/chats/[chatId]/mcp-servers/[serverId]/smithery-finalize/route.ts
@@ -1,0 +1,60 @@
+/**
+ * POST /api/chats/<chatId>/mcp-servers/<serverId>/smithery-finalize
+ *
+ * Called by the client after the Smithery OAuth popup closes. Polls Smithery
+ * for `connected` state and persists the credentials on success.
+ *
+ * Returns { connected: true } on success, 400 otherwise so the modal can show
+ * a "try again" message.
+ */
+import { prisma } from "@/lib/db/prisma"
+import {
+  requireAuth,
+  isAuthError,
+  badRequest,
+  notFound,
+  serverConfigError,
+  internalError,
+  getChatWithAuth,
+} from "@/lib/db/api-helpers"
+import { finalizeSmitheryConnection } from "@/lib/mcp/smithery-connect"
+
+export async function POST(
+  _req: Request,
+  { params }: { params: Promise<{ chatId: string; serverId: string }> }
+): Promise<Response> {
+  const auth = await requireAuth()
+  if (isAuthError(auth)) return auth
+  const { userId } = auth
+  const { chatId, serverId } = await params
+
+  const chat = await getChatWithAuth(chatId, userId)
+  if (!chat) return notFound("Chat not found")
+
+  const server = await prisma.chatMcpServer.findUnique({
+    where: { id: serverId },
+  })
+  if (!server || server.chatId !== chatId) return notFound("Server not found")
+
+  if (!server.smitheryConnectionId) {
+    return badRequest("Server has no Smithery connection id")
+  }
+
+  const apiKey = process.env.SMITHERY_API_KEY
+  if (!apiKey) return serverConfigError("SMITHERY_API_KEY")
+
+  try {
+    const ok = await finalizeSmitheryConnection(
+      serverId,
+      server.smitheryConnectionId,
+      apiKey
+    )
+    if (ok) return Response.json({ connected: true })
+    return Response.json(
+      { error: "Connection not yet authorized. Please try again." },
+      { status: 400 }
+    )
+  } catch (err) {
+    return internalError(err)
+  }
+}

--- a/packages/web/app/api/chats/[chatId]/mcp-servers/route.ts
+++ b/packages/web/app/api/chats/[chatId]/mcp-servers/route.ts
@@ -103,85 +103,51 @@ export async function POST(
   }
 
   try {
-    // Upsert by (chatId, qualifiedName). Re-clicking Connect on an existing
-    // row is fine — Smithery's PUT is idempotent.
-    const existing = await prisma.chatMcpServer.findUnique({
-      where: { chatId_qualifiedName: { chatId, qualifiedName: slug } },
-    })
-
+    // Smithery's PUT is idempotent; safe to call before we touch our DB.
     const connectionId = getSmitheryConnectionId(chatId, slug)
-
-    let serverId: string
-    if (existing) {
-      serverId = existing.id
-      await prisma.chatMcpServer.update({
-        where: { id: existing.id },
-        data: {
-          displayName: name,
-          iconUrl: iconUrl ?? null,
-          status: "pending",
-          lastError: null,
-        },
-      })
-    } else {
-      const created = await prisma.chatMcpServer.create({
-        data: {
-          chatId,
-          qualifiedName: slug,
-          displayName: name,
-          iconUrl: iconUrl ?? null,
-          smitheryConnectionId: connectionId,
-          smitheryNamespace: "", // populated by createSmitheryConnection
-          mcpUrl: url, // placeholder; replaced with Smithery endpoint on success
-          status: "pending",
-        },
-      })
-      serverId = created.id
-    }
-
     const result = await createSmitheryConnection(url, connectionId, name, apiKey)
 
-    if (result.status === "auth_required" && result.authorizationUrl) {
-      // Persist namespace + endpoint URL now so the finalize call has them.
-      await prisma.chatMcpServer.update({
-        where: { id: serverId },
-        data: {
-          smitheryNamespace: result.namespace,
-          mcpUrl: result.mcpEndpoint,
-        },
-      })
-      return Response.json({
-        connected: false,
-        serverId,
-        authUrl: result.authorizationUrl,
-      })
+    if (result.status === "error") {
+      return Response.json(
+        { error: result.error ?? "Smithery connection failed" },
+        { status: 502 }
+      )
     }
 
-    if (result.status === "connected") {
-      await prisma.chatMcpServer.update({
-        where: { id: serverId },
-        data: {
-          smitheryNamespace: result.namespace,
-          mcpUrl: result.mcpEndpoint,
-          encryptedApiKey: encrypt(apiKey),
-          status: "connected",
-          lastError: null,
-        },
-      })
+    const isConnected = result.status === "connected"
+    const row = {
+      smitheryConnectionId: connectionId,
+      smitheryNamespace: result.namespace,
+      mcpUrl: result.mcpEndpoint,
+      status: isConnected ? "connected" : "pending",
+      encryptedApiKey: isConnected ? encrypt(apiKey) : null,
+      lastError: null,
+    }
+    const { id: serverId } = await prisma.chatMcpServer.upsert({
+      where: { chatId_qualifiedName: { chatId, qualifiedName: slug } },
+      create: {
+        chatId,
+        qualifiedName: slug,
+        displayName: name,
+        iconUrl: iconUrl ?? null,
+        ...row,
+      },
+      update: {
+        displayName: name,
+        iconUrl: iconUrl ?? null,
+        ...row,
+      },
+      select: { id: true },
+    })
+
+    if (isConnected) {
       return Response.json({ connected: true, serverId })
     }
-
-    await prisma.chatMcpServer.update({
-      where: { id: serverId },
-      data: {
-        status: "error",
-        lastError: result.error ?? "Smithery connection failed",
-      },
+    return Response.json({
+      connected: false,
+      serverId,
+      authUrl: result.authorizationUrl,
     })
-    return Response.json(
-      { error: result.error ?? "Smithery connection failed" },
-      { status: 502 }
-    )
   } catch (err) {
     return internalError(err)
   }

--- a/packages/web/app/api/chats/[chatId]/mcp-servers/route.ts
+++ b/packages/web/app/api/chats/[chatId]/mcp-servers/route.ts
@@ -1,0 +1,188 @@
+/**
+ * GET  /api/chats/<chatId>/mcp-servers     list connections on this chat
+ * POST /api/chats/<chatId>/mcp-servers     start a new connection via Smithery
+ *
+ * POST body: { slug, url?, name, iconUrl? }
+ *   - slug          qualifiedName from the registry (e.g. "exa/exa-search")
+ *   - url           remote MCP URL. If absent (non-deployed server), the client
+ *                   should have fetched it from /api/mcp-registry/<slug> first.
+ *   - name          display name
+ *   - iconUrl       optional
+ *
+ * POST returns one of:
+ *   { connected: true,  serverId }                    instant-connect succeeded
+ *   { connected: false, serverId, authUrl }           open authUrl in a popup,
+ *                                                     then POST /smithery-finalize
+ */
+import { prisma } from "@/lib/db/prisma"
+import { encrypt } from "@/lib/db/encryption"
+import {
+  requireAuth,
+  isAuthError,
+  badRequest,
+  notFound,
+  serverConfigError,
+  internalError,
+  getChatWithAuth,
+} from "@/lib/db/api-helpers"
+import {
+  createSmitheryConnection,
+  getSmitheryConnectionId,
+  isSmitheryServer,
+} from "@/lib/mcp/smithery-connect"
+
+interface ConnectBody {
+  slug?: string
+  url?: string
+  name?: string
+  iconUrl?: string | null
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ chatId: string }> }
+): Promise<Response> {
+  const auth = await requireAuth()
+  if (isAuthError(auth)) return auth
+  const { userId } = auth
+  const { chatId } = await params
+
+  const chat = await getChatWithAuth(chatId, userId)
+  if (!chat) return notFound("Chat not found")
+
+  const servers = await prisma.chatMcpServer.findMany({
+    where: { chatId },
+    orderBy: { createdAt: "desc" },
+    select: {
+      id: true,
+      qualifiedName: true,
+      displayName: true,
+      iconUrl: true,
+      status: true,
+      lastError: true,
+      createdAt: true,
+    },
+  })
+
+  return Response.json({ servers })
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ chatId: string }> }
+): Promise<Response> {
+  const auth = await requireAuth()
+  if (isAuthError(auth)) return auth
+  const { userId } = auth
+  const { chatId } = await params
+
+  const chat = await getChatWithAuth(chatId, userId)
+  if (!chat) return notFound("Chat not found")
+
+  const apiKey = process.env.SMITHERY_API_KEY
+  if (!apiKey) return serverConfigError("SMITHERY_API_KEY")
+
+  let body: ConnectBody
+  try {
+    body = await req.json()
+  } catch {
+    return badRequest("Invalid JSON body")
+  }
+
+  const { slug, url, name, iconUrl } = body
+  if (!slug || !url || !name) {
+    return badRequest("Missing required fields: slug, url, name")
+  }
+
+  // We only support Smithery-hosted servers in this PR. Standard MCP OAuth
+  // discovery is intentionally out of scope here.
+  if (!isSmitheryServer(url)) {
+    return badRequest(
+      "Only Smithery-hosted servers (server.smithery.ai) are supported"
+    )
+  }
+
+  try {
+    // Upsert by (chatId, qualifiedName). Re-clicking Connect on an existing
+    // row is fine — Smithery's PUT is idempotent.
+    const existing = await prisma.chatMcpServer.findUnique({
+      where: { chatId_qualifiedName: { chatId, qualifiedName: slug } },
+    })
+
+    const connectionId = getSmitheryConnectionId(chatId, slug)
+
+    let serverId: string
+    if (existing) {
+      serverId = existing.id
+      await prisma.chatMcpServer.update({
+        where: { id: existing.id },
+        data: {
+          displayName: name,
+          iconUrl: iconUrl ?? null,
+          status: "pending",
+          lastError: null,
+        },
+      })
+    } else {
+      const created = await prisma.chatMcpServer.create({
+        data: {
+          chatId,
+          qualifiedName: slug,
+          displayName: name,
+          iconUrl: iconUrl ?? null,
+          smitheryConnectionId: connectionId,
+          smitheryNamespace: "", // populated by createSmitheryConnection
+          mcpUrl: url, // placeholder; replaced with Smithery endpoint on success
+          status: "pending",
+        },
+      })
+      serverId = created.id
+    }
+
+    const result = await createSmitheryConnection(url, connectionId, name, apiKey)
+
+    if (result.status === "auth_required" && result.authorizationUrl) {
+      // Persist namespace + endpoint URL now so the finalize call has them.
+      await prisma.chatMcpServer.update({
+        where: { id: serverId },
+        data: {
+          smitheryNamespace: result.namespace,
+          mcpUrl: result.mcpEndpoint,
+        },
+      })
+      return Response.json({
+        connected: false,
+        serverId,
+        authUrl: result.authorizationUrl,
+      })
+    }
+
+    if (result.status === "connected") {
+      await prisma.chatMcpServer.update({
+        where: { id: serverId },
+        data: {
+          smitheryNamespace: result.namespace,
+          mcpUrl: result.mcpEndpoint,
+          encryptedApiKey: encrypt(apiKey),
+          status: "connected",
+          lastError: null,
+        },
+      })
+      return Response.json({ connected: true, serverId })
+    }
+
+    await prisma.chatMcpServer.update({
+      where: { id: serverId },
+      data: {
+        status: "error",
+        lastError: result.error ?? "Smithery connection failed",
+      },
+    })
+    return Response.json(
+      { error: result.error ?? "Smithery connection failed" },
+      { status: 502 }
+    )
+  } catch (err) {
+    return internalError(err)
+  }
+}

--- a/packages/web/app/api/chats/[chatId]/messages/route.ts
+++ b/packages/web/app/api/chats/[chatId]/messages/route.ts
@@ -19,6 +19,7 @@ import {
 import { logActivityAsync } from "@/lib/db/activity-log"
 import { checkSharedClaudeUsage } from "@/lib/db/usage-limit"
 import { createBackgroundAgentSession, type Agent } from "@/lib/agent-session"
+import { loadChatMcpServers } from "@/lib/mcp/agent-servers"
 import { getClaudeCredentials } from "@/lib/claude-credentials"
 import { getEnvForModel } from "@upstream/common"
 import { decrypt } from "@/lib/db/encryption"
@@ -472,6 +473,15 @@ export async function POST(
     // Merge: system env vars first, then user env vars (user takes precedence)
     const env = { ...systemEnv, ...userEnv }
 
+    // Fetch this chat's connected MCP servers so the agent sees them as tools.
+    // Best-effort — a fetch error shouldn't block the turn.
+    let mcpServers: Awaited<ReturnType<typeof loadChatMcpServers>> = []
+    try {
+      mcpServers = await loadChatMcpServers(chatId)
+    } catch (err) {
+      console.error("[messages] loadChatMcpServers failed:", err)
+    }
+
     const bgSession = await createBackgroundAgentSession(sandbox, {
       repoPath,
       previewUrlPattern: previewUrlPattern ?? undefined,
@@ -481,6 +491,7 @@ export async function POST(
       model: payload.model,
       env: Object.keys(env).length > 0 ? env : undefined,
       planMode: payload.planMode,
+      mcpServers,
     })
 
     // ── Stage 5: persist messages + chat status (transactional) ────────────

--- a/packages/web/app/api/mcp-registry/[...slug]/route.ts
+++ b/packages/web/app/api/mcp-registry/[...slug]/route.ts
@@ -1,0 +1,72 @@
+/**
+ * GET /api/mcp-registry/<namespace>/<name>
+ *
+ * Per-server detail. Used when the user clicks Connect on a non-deployed
+ * server (no URL came back in the registry list) — we need to fetch the
+ * connection URL before kicking off Smithery Connect.
+ */
+import { NextResponse } from "next/server"
+import { serverConfigError } from "@/lib/db/api-helpers"
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ slug: string[] }> }
+): Promise<Response> {
+  const { slug } = await params
+  const qualifiedName = slug.join("/")
+
+  if (slug.length < 2) {
+    return NextResponse.json(
+      { error: "Invalid server identifier. Expected format: namespace/name" },
+      { status: 400 }
+    )
+  }
+
+  const apiKey = process.env.SMITHERY_API_KEY
+  if (!apiKey) return serverConfigError("SMITHERY_API_KEY")
+
+  try {
+    const response = await fetch(
+      `https://api.smithery.ai/servers/${encodeURIComponent(qualifiedName)}`,
+      {
+        headers: {
+          Accept: "application/json",
+          Authorization: `Bearer ${apiKey}`,
+        },
+        next: { revalidate: 300 },
+      }
+    )
+
+    if (response.status === 404) {
+      return NextResponse.json({ error: "Server not found" }, { status: 404 })
+    }
+    if (!response.ok) {
+      console.error(
+        "[MCP-registry/detail] Smithery fetch failed:",
+        response.status
+      )
+      return NextResponse.json(
+        { error: "Failed to fetch server details" },
+        { status: 502 }
+      )
+    }
+
+    const data = await response.json()
+    return NextResponse.json({
+      slug: qualifiedName,
+      name: data.displayName || qualifiedName,
+      description: data.description || "",
+      iconUrl: data.iconUrl || null,
+      url: data.connectionUrl || data.url || null,
+      tools: data.tools || [],
+      verified: data.verified || false,
+      useCount: data.useCount || 0,
+    })
+  } catch (err) {
+    console.error("[MCP-registry/detail] Error:", err)
+    return NextResponse.json(
+      { error: "Failed to fetch server details" },
+      { status: 500 }
+    )
+  }
+}

--- a/packages/web/app/api/mcp-registry/[...slug]/route.ts
+++ b/packages/web/app/api/mcp-registry/[...slug]/route.ts
@@ -58,9 +58,6 @@ export async function GET(
       description: data.description || "",
       iconUrl: data.iconUrl || null,
       url: data.connectionUrl || data.url || null,
-      tools: data.tools || [],
-      verified: data.verified || false,
-      useCount: data.useCount || 0,
     })
   } catch (err) {
     console.error("[MCP-registry/detail] Error:", err)

--- a/packages/web/app/api/mcp-registry/route.ts
+++ b/packages/web/app/api/mcp-registry/route.ts
@@ -51,7 +51,6 @@ function transformServer(server: SmitheryServer) {
     url,
     verified: server.verified,
     useCount: server.useCount,
-    isDeployed: server.isDeployed,
   }
 }
 

--- a/packages/web/app/api/mcp-registry/route.ts
+++ b/packages/web/app/api/mcp-registry/route.ts
@@ -1,0 +1,114 @@
+/**
+ * GET /api/mcp-registry
+ *
+ * Thin proxy over Smithery's server registry. Filters to `remote=true` since
+ * the agent runs in a sandbox and can't spawn local stdio servers.
+ *
+ * Query params:
+ *   - search    free-text passed to Smithery as `q`
+ *   - page      1-based (default 1)
+ *   - pageSize  1..50 (default 20)
+ */
+import { NextResponse } from "next/server"
+import { serverConfigError } from "@/lib/db/api-helpers"
+
+interface SmitheryServer {
+  id: string
+  qualifiedName: string
+  displayName: string
+  description: string
+  iconUrl: string | null
+  verified: boolean
+  useCount: number
+  remote: boolean | null
+  isDeployed: boolean
+  createdAt: string
+  homepage: string | null
+  owner: string | null
+}
+
+interface SmitheryResponse {
+  servers: SmitheryServer[]
+  pagination: {
+    currentPage: number
+    pageSize: number
+    totalPages: number
+    totalCount: number
+  }
+}
+
+function transformServer(server: SmitheryServer) {
+  // Deployed servers expose the MCP URL via predictable path; non-deployed
+  // need a follow-up detail fetch on connect.
+  const url = server.isDeployed
+    ? `https://server.smithery.ai/${server.qualifiedName}/mcp`
+    : null
+  return {
+    slug: server.qualifiedName,
+    name: server.displayName,
+    description: server.description || "",
+    iconUrl: server.iconUrl,
+    url,
+    verified: server.verified,
+    useCount: server.useCount,
+    isDeployed: server.isDeployed,
+  }
+}
+
+export async function GET(req: Request): Promise<Response> {
+  const { searchParams } = new URL(req.url)
+  const search = searchParams.get("search") || ""
+  const page = Math.max(parseInt(searchParams.get("page") || "1"), 1)
+  const pageSize = Math.min(
+    Math.max(parseInt(searchParams.get("pageSize") || "20"), 1),
+    50
+  )
+
+  const apiKey = process.env.SMITHERY_API_KEY
+  if (!apiKey) return serverConfigError("SMITHERY_API_KEY")
+
+  try {
+    const registryUrl = new URL("https://api.smithery.ai/servers")
+    registryUrl.searchParams.set("page", String(page))
+    registryUrl.searchParams.set("pageSize", String(pageSize))
+    registryUrl.searchParams.set("remote", "true")
+    if (search) registryUrl.searchParams.set("q", search)
+
+    const response = await fetch(registryUrl.toString(), {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      // 5-min cache: the registry doesn't change often and search latency
+      // dominates the modal UX otherwise.
+      next: { revalidate: 300 },
+    })
+
+    if (!response.ok) {
+      console.error(
+        "[MCP-registry] Smithery fetch failed:",
+        response.status,
+        await response.text()
+      )
+      return NextResponse.json(
+        { error: "Failed to fetch registry" },
+        { status: 502 }
+      )
+    }
+
+    const data: SmitheryResponse = await response.json()
+    return NextResponse.json({
+      servers: data.servers.map(transformServer),
+      page: data.pagination.currentPage,
+      pageSize: data.pagination.pageSize,
+      totalPages: data.pagination.totalPages,
+      totalCount: data.pagination.totalCount,
+    })
+  } catch (err) {
+    console.error("[MCP-registry] Proxy error:", err)
+    return NextResponse.json(
+      { error: "Failed to fetch registry" },
+      { status: 500 }
+    )
+  }
+}

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -17,6 +17,7 @@ import { LimitReachedDialog } from "@/components/modals/LimitReachedDialog"
 import { BranchPickerModal } from "@/components/modals/BranchPickerModal"
 import { MergeDialog, RebaseDialog, PRDialog, SquashDialog, ForcePushDialog, useGitDialogs } from "@/components/modals/GitDialogs"
 import { EnvironmentVariablesModal } from "@/components/modals/EnvironmentVariablesModal"
+import { McpServersModal } from "@/components/modals/McpServersModal"
 import { MobileCommandsMenu } from "@/components/MobileCommandsMenu"
 import { MobileRenameModal } from "@/components/ui/MobileBottomSheet"
 import { ScheduledJobForm } from "@/components/scheduled-jobs/ScheduledJobForm"
@@ -1085,6 +1086,7 @@ function HomePageContent({ isMobile }: HomePageContentProps) {
       onCopyCloneCommand={currentChat?.repo && currentChat.repo !== NEW_REPOSITORY ? handleCopyCloneCommand : undefined}
       onCopyCheckoutCommand={currentChat?.branch ? handleCopyCheckoutCommand : undefined}
       onOpenEnvVars={currentChat ? handleOpenEnvVars : undefined}
+      onOpenMcpServers={currentChat ? () => modals.setMcpServersModalOpen(true) : undefined}
       onOpenSkills={
         currentChat?.sandboxId && currentChat.repo !== NEW_REPOSITORY
           ? () => setSkillsModalOpen(true)
@@ -1322,6 +1324,14 @@ function HomePageContent({ isMobile }: HomePageContentProps) {
           initialRepoEnvVars={envVarsRepoEnvVars}
           isMobile={isMobile}
         />
+
+        {displayCurrentChatId && (
+          <McpServersModal
+            open={modals.mcpServersModalOpen}
+            onClose={() => modals.setMcpServersModalOpen(false)}
+            chatId={displayCurrentChatId}
+          />
+        )}
 
       {/* Skills Search Modal */}
       {currentChat?.sandboxId && currentChat.repo !== NEW_REPOSITORY && (

--- a/packages/web/components/modals/McpServersModal.tsx
+++ b/packages/web/components/modals/McpServersModal.tsx
@@ -49,7 +49,6 @@ interface RegistryServer {
   url: string | null
   verified: boolean
   useCount: number
-  isDeployed: boolean
 }
 
 type TabKey = "connected" | "browse"

--- a/packages/web/components/modals/McpServersModal.tsx
+++ b/packages/web/components/modals/McpServersModal.tsx
@@ -1,0 +1,562 @@
+"use client"
+
+/**
+ * McpServersModal — per-chat MCP server browser + connection manager.
+ *
+ * Two tabs:
+ *   - Connected:  list of ChatMcpServer rows; disconnect removes the row
+ *                 AND the upstream Smithery connection (best-effort)
+ *   - Browse:     paginated, debounced search over Smithery's registry.
+ *                 Click Connect:
+ *                   - instant-connect server → row appears in Connected
+ *                   - auth-required server   → open OAuth popup, then call
+ *                                              /smithery-finalize on close
+ */
+
+import * as Dialog from "@radix-ui/react-dialog"
+import {
+  BadgeCheck,
+  Loader2,
+  Plug,
+  Plus,
+  Search,
+  Trash2,
+  X,
+} from "lucide-react"
+import { useCallback, useEffect, useRef, useState } from "react"
+import { Input } from "@/components/ui/input"
+import { focusChatPrompt } from "@/components/ui/modal-header"
+import { cn } from "@/lib/utils"
+
+// =============================================================================
+// Types
+// =============================================================================
+
+interface ConnectedServer {
+  id: string
+  qualifiedName: string
+  displayName: string
+  iconUrl: string | null
+  status: "pending" | "connected" | "error"
+  lastError: string | null
+}
+
+interface RegistryServer {
+  slug: string
+  name: string
+  description: string
+  iconUrl: string | null
+  url: string | null
+  verified: boolean
+  useCount: number
+  isDeployed: boolean
+}
+
+type TabKey = "connected" | "browse"
+
+interface McpServersModalProps {
+  open: boolean
+  onClose: () => void
+  chatId: string
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+export function McpServersModal({
+  open,
+  onClose,
+  chatId,
+}: McpServersModalProps) {
+  const [tab, setTab] = useState<TabKey>("connected")
+
+  // Connected list
+  const [connected, setConnected] = useState<ConnectedServer[]>([])
+  const [loadingConnected, setLoadingConnected] = useState(false)
+  const [deletingId, setDeletingId] = useState<string | null>(null)
+
+  // Registry browse
+  const [registry, setRegistry] = useState<RegistryServer[]>([])
+  const [loadingRegistry, setLoadingRegistry] = useState(false)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [search, setSearch] = useState("")
+  const [page, setPage] = useState(1)
+  const [totalPages, setTotalPages] = useState(1)
+  const [connectingSlug, setConnectingSlug] = useState<string | null>(null)
+
+  const popupTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  // Reset state when the modal opens.
+  useEffect(() => {
+    if (!open) return
+    setTab("connected")
+    setSearch("")
+    setPage(1)
+  }, [open])
+
+  // =============================================================================
+  // Fetchers
+  // =============================================================================
+
+  const loadConnected = useCallback(async () => {
+    setLoadingConnected(true)
+    try {
+      const res = await fetch(`/api/chats/${chatId}/mcp-servers`)
+      if (res.ok) {
+        const data = await res.json()
+        setConnected(data.servers || [])
+      }
+    } catch (err) {
+      console.error("[McpServersModal] loadConnected failed:", err)
+    } finally {
+      setLoadingConnected(false)
+    }
+  }, [chatId])
+
+  const loadRegistry = useCallback(
+    async (q: string, p: number, append: boolean) => {
+      if (append) setLoadingMore(true)
+      else setLoadingRegistry(true)
+      try {
+        const params = new URLSearchParams({ page: String(p) })
+        if (q) params.set("search", q)
+        const res = await fetch(`/api/mcp-registry?${params}`)
+        if (res.ok) {
+          const data = await res.json()
+          setRegistry((prev) =>
+            append ? [...prev, ...(data.servers || [])] : data.servers || []
+          )
+          setTotalPages(data.totalPages || 1)
+        }
+      } catch (err) {
+        console.error("[McpServersModal] loadRegistry failed:", err)
+      } finally {
+        setLoadingRegistry(false)
+        setLoadingMore(false)
+      }
+    },
+    []
+  )
+
+  // Load connected list every time the modal opens.
+  useEffect(() => {
+    if (open) loadConnected()
+  }, [open, loadConnected])
+
+  // Load registry when entering Browse, then re-load on debounced search.
+  useEffect(() => {
+    if (!open || tab !== "browse") return
+    setPage(1)
+    const t = setTimeout(() => loadRegistry(search, 1, false), 300)
+    return () => clearTimeout(t)
+  }, [open, tab, search, loadRegistry])
+
+  // Tear down any leftover popup-polling on unmount.
+  useEffect(() => {
+    return () => {
+      if (popupTimerRef.current) clearInterval(popupTimerRef.current)
+    }
+  }, [])
+
+  // =============================================================================
+  // Actions
+  // =============================================================================
+
+  async function handleDisconnect(serverId: string) {
+    if (deletingId) return
+    setDeletingId(serverId)
+    try {
+      const res = await fetch(
+        `/api/chats/${chatId}/mcp-servers/${serverId}`,
+        { method: "DELETE" }
+      )
+      if (res.ok) {
+        setConnected((prev) => prev.filter((s) => s.id !== serverId))
+      }
+    } finally {
+      setDeletingId(null)
+    }
+  }
+
+  async function handleConnect(server: RegistryServer) {
+    if (connectingSlug) return
+    setConnectingSlug(server.slug)
+    try {
+      // Non-deployed servers don't expose a URL in the registry list — fetch
+      // the detail endpoint to get one before we POST.
+      let url = server.url
+      if (!url) {
+        const detailRes = await fetch(`/api/mcp-registry/${server.slug}`)
+        if (!detailRes.ok) throw new Error("Failed to fetch server details")
+        const detail = await detailRes.json()
+        url = detail.url
+        if (!url) throw new Error("Server does not expose a remote URL")
+      }
+
+      const res = await fetch(`/api/chats/${chatId}/mcp-servers`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          slug: server.slug,
+          url,
+          name: server.name,
+          iconUrl: server.iconUrl,
+        }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || "Connect failed")
+
+      // Instant-connect (authless server) — refresh list, switch tab, done.
+      if (data.connected) {
+        setConnectingSlug(null)
+        await loadConnected()
+        setTab("connected")
+        return
+      }
+
+      // Auth required: open Smithery's auth URL in a popup and poll for close.
+      const popup = window.open(
+        data.authUrl,
+        "smithery-oauth",
+        "width=600,height=700,scrollbars=yes"
+      )
+      if (!popup || popup.closed) {
+        // Browser blocked the popup. Bail without leaving the spinner on.
+        setConnectingSlug(null)
+        return
+      }
+
+      if (popupTimerRef.current) clearInterval(popupTimerRef.current)
+      popupTimerRef.current = setInterval(async () => {
+        if (!popup.closed) return
+        if (popupTimerRef.current) {
+          clearInterval(popupTimerRef.current)
+          popupTimerRef.current = null
+        }
+        try {
+          await fetch(
+            `/api/chats/${chatId}/mcp-servers/${data.serverId}/smithery-finalize`,
+            { method: "POST" }
+          )
+        } catch (err) {
+          console.error("[McpServersModal] finalize failed:", err)
+        }
+        setConnectingSlug(null)
+        await loadConnected()
+        setTab("connected")
+      }, 500)
+    } catch (err) {
+      console.error("[McpServersModal] handleConnect failed:", err)
+      setConnectingSlug(null)
+    }
+  }
+
+  // =============================================================================
+  // Render
+  // =============================================================================
+
+  const tabs: { key: TabKey; label: string; icon: typeof Plug }[] = [
+    { key: "connected", label: "Connected", icon: Plug },
+    { key: "browse", label: "Browse", icon: Plus },
+  ]
+
+  return (
+    <Dialog.Root open={open} onOpenChange={(o) => !o && onClose()}>
+      <Dialog.Portal>
+        <Dialog.Overlay
+          className={cn(
+            "fixed inset-0 z-50 bg-black/15 backdrop-blur-[1px] transition-opacity duration-300",
+            open ? "opacity-100" : "opacity-0"
+          )}
+        />
+        <Dialog.Content
+          onCloseAutoFocus={(e) => {
+            e.preventDefault()
+            focusChatPrompt()
+          }}
+          className="fixed z-50 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-xl h-[560px] max-h-[80vh] bg-popover border border-border rounded-xl shadow-xl flex flex-col overflow-hidden"
+        >
+          <div className="flex items-center justify-between px-5 pt-4 pb-2">
+            <Dialog.Title className="text-lg font-semibold">
+              MCP Servers
+            </Dialog.Title>
+            <Dialog.Close
+              className="flex items-center justify-center h-7 w-7 rounded-md hover:bg-accent text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+              aria-label="Close"
+            >
+              <X className="h-4 w-4" />
+            </Dialog.Close>
+          </div>
+
+          <div className="flex border-b border-border px-5">
+            {tabs.map((t) => {
+              const Icon = t.icon
+              const isActive = tab === t.key
+              return (
+                <button
+                  key={t.key}
+                  onClick={() => setTab(t.key)}
+                  className={cn(
+                    "flex items-center gap-2 px-4 py-2.5 text-sm transition-colors border-b-2 -mb-px cursor-pointer",
+                    isActive
+                      ? "border-primary text-foreground"
+                      : "border-transparent text-muted-foreground hover:text-foreground"
+                  )}
+                >
+                  <Icon className="h-4 w-4" />
+                  {t.label}
+                </button>
+              )
+            })}
+          </div>
+
+          <div className="flex-1 overflow-y-auto px-5 py-4">
+            {tab === "connected" && (
+              <ConnectedView
+                servers={connected}
+                loading={loadingConnected}
+                deletingId={deletingId}
+                onDisconnect={handleDisconnect}
+                onBrowse={() => setTab("browse")}
+              />
+            )}
+            {tab === "browse" && (
+              <BrowseView
+                servers={registry}
+                connectedSlugs={new Set(connected.map((s) => s.qualifiedName))}
+                loading={loadingRegistry}
+                loadingMore={loadingMore}
+                search={search}
+                onSearchChange={setSearch}
+                connectingSlug={connectingSlug}
+                onConnect={handleConnect}
+                hasMore={page < totalPages}
+                onLoadMore={() => {
+                  const next = page + 1
+                  setPage(next)
+                  loadRegistry(search, next, true)
+                }}
+              />
+            )}
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}
+
+// =============================================================================
+// Subviews
+// =============================================================================
+
+function ConnectedView({
+  servers,
+  loading,
+  deletingId,
+  onDisconnect,
+  onBrowse,
+}: {
+  servers: ConnectedServer[]
+  loading: boolean
+  deletingId: string | null
+  onDisconnect: (id: string) => void
+  onBrowse: () => void
+}) {
+  if (loading) {
+    return (
+      <div className="flex justify-center py-12 text-muted-foreground">
+        <Loader2 className="h-5 w-5 animate-spin" />
+      </div>
+    )
+  }
+  if (servers.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-center">
+        <Plug className="h-8 w-8 text-muted-foreground/40 mb-3" />
+        <p className="text-sm text-muted-foreground mb-4">
+          No MCP servers connected for this chat yet.
+        </p>
+        <button
+          onClick={onBrowse}
+          className="rounded-md bg-primary text-primary-foreground hover:bg-primary/90 px-3 py-1.5 text-sm cursor-pointer"
+        >
+          Browse servers
+        </button>
+      </div>
+    )
+  }
+  return (
+    <div className="space-y-2">
+      {servers.map((s) => (
+        <div
+          key={s.id}
+          className="flex items-center gap-3 rounded-lg border border-border p-3"
+        >
+          {s.iconUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={s.iconUrl}
+              alt=""
+              className="h-8 w-8 rounded shrink-0"
+            />
+          ) : (
+            <div className="h-8 w-8 rounded bg-muted shrink-0 flex items-center justify-center">
+              <Plug className="h-4 w-4 text-muted-foreground" />
+            </div>
+          )}
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium truncate">{s.displayName}</p>
+            <p className="text-xs text-muted-foreground truncate">
+              {s.qualifiedName}
+            </p>
+            {s.status === "error" && s.lastError && (
+              <p className="text-xs text-destructive mt-0.5">{s.lastError}</p>
+            )}
+            {s.status === "pending" && (
+              <p className="text-xs text-muted-foreground mt-0.5">
+                Awaiting authorization…
+              </p>
+            )}
+          </div>
+          <button
+            onClick={() => onDisconnect(s.id)}
+            disabled={deletingId === s.id}
+            className="p-1.5 rounded-md text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors cursor-pointer disabled:opacity-50"
+            aria-label="Disconnect"
+          >
+            {deletingId === s.id ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Trash2 className="h-4 w-4" />
+            )}
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function BrowseView({
+  servers,
+  connectedSlugs,
+  loading,
+  loadingMore,
+  search,
+  onSearchChange,
+  connectingSlug,
+  onConnect,
+  hasMore,
+  onLoadMore,
+}: {
+  servers: RegistryServer[]
+  connectedSlugs: Set<string>
+  loading: boolean
+  loadingMore: boolean
+  search: string
+  onSearchChange: (v: string) => void
+  connectingSlug: string | null
+  onConnect: (s: RegistryServer) => void
+  hasMore: boolean
+  onLoadMore: () => void
+}) {
+  return (
+    <div>
+      <div className="relative mb-3">
+        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+        <Input
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+          placeholder="Search MCP servers (e.g. exa, github, postgres)"
+          className="pl-8 text-sm"
+          autoComplete="off"
+          spellCheck={false}
+        />
+      </div>
+      {loading ? (
+        <div className="flex justify-center py-8 text-muted-foreground">
+          <Loader2 className="h-5 w-5 animate-spin" />
+        </div>
+      ) : servers.length === 0 ? (
+        <p className="text-sm text-muted-foreground text-center py-8">
+          No servers found.
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {servers.map((s) => {
+            const isConnected = connectedSlugs.has(s.slug)
+            const isConnecting = connectingSlug === s.slug
+            return (
+              <div
+                key={s.slug}
+                className="flex items-center gap-3 rounded-lg border border-border p-3"
+              >
+                {s.iconUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={s.iconUrl}
+                    alt=""
+                    className="h-8 w-8 rounded shrink-0"
+                  />
+                ) : (
+                  <div className="h-8 w-8 rounded bg-muted shrink-0 flex items-center justify-center">
+                    <Plug className="h-4 w-4 text-muted-foreground" />
+                  </div>
+                )}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-1">
+                    <p className="text-sm font-medium truncate">{s.name}</p>
+                    {s.verified && (
+                      <BadgeCheck className="h-3.5 w-3.5 text-blue-500 shrink-0" />
+                    )}
+                  </div>
+                  <p className="text-xs text-muted-foreground line-clamp-2">
+                    {s.description}
+                  </p>
+                  {s.useCount > 0 && (
+                    <p className="text-[11px] text-muted-foreground/70 mt-0.5">
+                      {s.useCount >= 1000
+                        ? `${(s.useCount / 1000).toFixed(1).replace(/\.0$/, "")}k uses`
+                        : `${s.useCount} uses`}
+                    </p>
+                  )}
+                </div>
+                {isConnected ? (
+                  <span className="text-xs text-muted-foreground px-2">
+                    Connected
+                  </span>
+                ) : (
+                  <button
+                    onClick={() => onConnect(s)}
+                    disabled={isConnecting || !!connectingSlug}
+                    className="rounded bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 cursor-pointer flex items-center gap-1"
+                  >
+                    {isConnecting ? (
+                      <Loader2 className="h-3 w-3 animate-spin" />
+                    ) : (
+                      <Plus className="h-3 w-3" />
+                    )}
+                    Connect
+                  </button>
+                )}
+              </div>
+            )
+          })}
+          {hasMore && (
+            <button
+              onClick={onLoadMore}
+              disabled={loadingMore}
+              className="w-full flex items-center justify-center gap-1.5 rounded-md bg-secondary px-3 py-2 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground cursor-pointer disabled:opacity-50"
+            >
+              {loadingMore ? (
+                <Loader2 className="h-3 w-3 animate-spin" />
+              ) : (
+                "Load More"
+              )}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/web/components/search-palette/CommandPalette.tsx
+++ b/packages/web/components/search-palette/CommandPalette.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { GitMerge, GitBranch, GitPullRequest, GitCommitVertical, Plus, GitBranchPlus, Settings, Github, PanelLeft, LogIn, LogOut, FolderGit2, Trash2, Code2, TerminalSquare, Globe, PanelRightClose, PanelRightOpen, Download, Copy, MessageSquare, Key, Sun, Moon, Monitor, Zap } from "lucide-react"
+import { GitMerge, GitBranch, GitPullRequest, GitCommitVertical, Plus, GitBranchPlus, Settings, Github, PanelLeft, LogIn, LogOut, FolderGit2, Trash2, Code2, TerminalSquare, Globe, PanelRightClose, PanelRightOpen, Download, Copy, MessageSquare, Key, Sun, Moon, Monitor, Zap, Plug } from "lucide-react"
 import {
   CommandDialog,
   CommandInput,
@@ -74,6 +74,7 @@ interface CommandPaletteProps {
   onCopyCheckoutCommand?: () => void
   /** Open environment variables modal. Omitted when no chat is active. */
   onOpenEnvVars?: () => void
+  onOpenMcpServers?: () => void
   /** Open skills manager. Omitted when no sandbox exists. */
   onOpenSkills?: () => void
   /** Chats for search. */
@@ -115,6 +116,7 @@ export function CommandPalette({
   onCopyCloneCommand,
   onCopyCheckoutCommand,
   onOpenEnvVars,
+  onOpenMcpServers,
   onOpenSkills,
   chats = [],
   onSelectChat,
@@ -245,6 +247,12 @@ export function CommandPalette({
             <CommandItem value="environment variables" onSelect={() => run(onOpenEnvVars)}>
               <VariableIcon className="mr-2 h-4 w-4 text-muted-foreground" />
               <span>Environment variables</span>
+            </CommandItem>
+          )}
+          {onOpenMcpServers && (
+            <CommandItem value="mcp servers tools" onSelect={() => run(onOpenMcpServers)}>
+              <Plug className="mr-2 h-4 w-4 text-muted-foreground" />
+              <span>MCP servers</span>
             </CommandItem>
           )}
           {onOpenSkills && (

--- a/packages/web/components/search-palette/PaletteProvider.tsx
+++ b/packages/web/components/search-palette/PaletteProvider.tsx
@@ -54,6 +54,7 @@ interface PaletteProviderProps {
   onCopyCloneCommand?: () => void
   onCopyCheckoutCommand?: () => void
   onOpenEnvVars?: () => void
+  onOpenMcpServers?: () => void
   onOpenSkills?: () => void
   // For Alt+Up/Down chat navigation
   chatIds: string[]
@@ -99,6 +100,7 @@ export function PaletteProvider({
   onCopyCloneCommand,
   onCopyCheckoutCommand,
   onOpenEnvVars,
+  onOpenMcpServers,
   onOpenSkills,
   chatIds,
   currentChatId,
@@ -223,6 +225,7 @@ export function PaletteProvider({
         onCopyCloneCommand={onCopyCloneCommand}
         onCopyCheckoutCommand={onCopyCheckoutCommand}
         onOpenEnvVars={onOpenEnvVars}
+        onOpenMcpServers={onOpenMcpServers}
         onOpenSkills={onOpenSkills}
         chats={chats.map((c) => ({ id: c.id, displayName: c.displayName }))}
         onSelectChat={onSelectChat}

--- a/packages/web/lib/agent-session.ts
+++ b/packages/web/lib/agent-session.ts
@@ -22,6 +22,10 @@ import {
   setupCodexRules,
   OPENCODE_PERMISSION_ENV,
 } from "@upstream/agent-configuration/git"
+import {
+  setupMcpForAgent,
+  type AgentMcpServer,
+} from "@upstream/agent-configuration/mcp"
 import type { Sandbox as DaytonaSandbox } from "@daytonaio/sdk"
 
 // Re-export Agent type for convenience
@@ -69,6 +73,12 @@ export interface AgentSessionOptions {
   env?: Record<string, string>
   /** When true, agent should plan before acting */
   planMode?: boolean
+  /**
+   * MCP servers to expose to the agent. The web layer fetches these from
+   * `ChatMcpServer` and decrypts the per-row Smithery API key before passing
+   * them in — this module stays generic and doesn't touch the DB.
+   */
+  mcpServers?: AgentMcpServer[]
 }
 
 // =============================================================================
@@ -127,6 +137,20 @@ Your plan should include:
     await setupClaudeHooks(sandbox)
   } else if (agent === "codex") {
     await setupCodexRules(sandbox)
+  }
+
+  // Write per-agent MCP config files for the connected Smithery servers.
+  // Must run before createSession() so the CLI loads them on spawn.
+  if (options.mcpServers && options.mcpServers.length > 0) {
+    try {
+      await setupMcpForAgent(sandbox, {
+        agent,
+        servers: options.mcpServers,
+      })
+    } catch (err) {
+      // MCP setup is best-effort — a failure here shouldn't block the turn.
+      console.error("[agent-session] setupMcpForAgent failed:", err)
+    }
   }
 
   // For OpenCode, inject permission rules via environment variable

--- a/packages/web/lib/contexts/ModalContext.tsx
+++ b/packages/web/lib/contexts/ModalContext.tsx
@@ -39,6 +39,10 @@ export interface ModalContextValue {
   envVarsModalOpen: boolean
   setEnvVarsModalOpen: (open: boolean) => void
 
+  // MCP servers modal
+  mcpServersModalOpen: boolean
+  setMcpServersModalOpen: (open: boolean) => void
+
   // Scheduled jobs
   scheduledJobFormOpen: boolean
   setScheduledJobFormOpen: (open: boolean) => void
@@ -84,6 +88,9 @@ export function ModalProvider({ children, isMobile, onMobileSidebarClose }: Moda
 
   // Environment variables modal
   const [envVarsModalOpen, setEnvVarsModalOpen] = useState(false)
+
+  // MCP servers modal
+  const [mcpServersModalOpen, setMcpServersModalOpen] = useState(false)
 
   // Scheduled jobs
   const [scheduledJobFormOpen, setScheduledJobFormOpen] = useState(false)
@@ -154,6 +161,10 @@ export function ModalProvider({ children, isMobile, onMobileSidebarClose }: Moda
     // Environment variables modal
     envVarsModalOpen,
     setEnvVarsModalOpen,
+
+    // MCP servers modal
+    mcpServersModalOpen,
+    setMcpServersModalOpen,
 
     // Scheduled jobs
     scheduledJobFormOpen,

--- a/packages/web/lib/mcp/agent-servers.ts
+++ b/packages/web/lib/mcp/agent-servers.ts
@@ -10,10 +10,7 @@ import type { AgentMcpServer } from "@upstream/agent-configuration/mcp"
 
 /** Sanitize Smithery's slugs into a name acceptable to every agent CLI. */
 function safeServerName(qualifiedName: string): string {
-  return qualifiedName
-    .replace(/\//g, "-")
-    .replace(/[^a-zA-Z0-9_-]/g, "-")
-    .toLowerCase()
+  return qualifiedName.replace(/[^a-zA-Z0-9_-]/g, "-").toLowerCase()
 }
 
 export async function loadChatMcpServers(

--- a/packages/web/lib/mcp/agent-servers.ts
+++ b/packages/web/lib/mcp/agent-servers.ts
@@ -1,0 +1,41 @@
+/**
+ * Load a chat's connected MCP servers in the shape `setupMcpForAgent` wants.
+ *
+ * Returns only `connected` rows (skips pending/error). Decrypts the per-row
+ * Smithery API key here so callers don't need to touch encryption.
+ */
+import { prisma } from "@/lib/db/prisma"
+import { decrypt } from "@/lib/db/encryption"
+import type { AgentMcpServer } from "@upstream/agent-configuration/mcp"
+
+/** Sanitize Smithery's slugs into a name acceptable to every agent CLI. */
+function safeServerName(qualifiedName: string): string {
+  return qualifiedName
+    .replace(/\//g, "-")
+    .replace(/[^a-zA-Z0-9_-]/g, "-")
+    .toLowerCase()
+}
+
+export async function loadChatMcpServers(
+  chatId: string
+): Promise<AgentMcpServer[]> {
+  const rows = await prisma.chatMcpServer.findMany({
+    where: { chatId, status: "connected" },
+    select: {
+      qualifiedName: true,
+      mcpUrl: true,
+      encryptedApiKey: true,
+    },
+  })
+
+  const out: AgentMcpServer[] = []
+  for (const row of rows) {
+    if (!row.encryptedApiKey || !row.mcpUrl) continue
+    out.push({
+      name: safeServerName(row.qualifiedName),
+      url: row.mcpUrl,
+      bearerToken: decrypt(row.encryptedApiKey),
+    })
+  }
+  return out
+}

--- a/packages/web/lib/mcp/smithery-connect.ts
+++ b/packages/web/lib/mcp/smithery-connect.ts
@@ -1,0 +1,323 @@
+/**
+ * Smithery Connect — connection lifecycle helpers.
+ *
+ * We use Smithery Connect (not the legacy SSE registry) so the per-connection
+ * MCP endpoint lives at `api.smithery.ai/connect/<ns>/<connId>/mcp`. The agent
+ * speaks MCP to that URL with `Authorization: Bearer <SMITHERY_API_KEY>` —
+ * Smithery handles transport + per-server OAuth.
+ *
+ * Two flows from `createSmitheryConnection`:
+ *   - `connected`     authless server, ready to use immediately
+ *   - `auth_required` open `authorizationUrl` in a popup, then call
+ *                     `finalizeSmitheryConnection` after it closes
+ *
+ * Namespace resolution is best-effort: SMITHERY_NAMESPACE if set, else the
+ * first namespace the API key owns, else create `upstream-<keyHash>`
+ * (namespace names are globally unique, so we suffix to avoid collisions).
+ */
+import { createHash } from "crypto"
+import { encrypt } from "@/lib/db/encryption"
+import { prisma } from "@/lib/db/prisma"
+
+const SMITHERY_API_BASE = "https://api.smithery.ai"
+
+// Resolved once per process. Smithery namespace lookups are cheap but pointless
+// to repeat — the answer is stable for a given API key.
+let resolvedNamespace: string | null = null
+
+async function getNamespace(apiKey: string): Promise<string | null> {
+  if (resolvedNamespace) return resolvedNamespace
+
+  const envNamespace = process.env.SMITHERY_NAMESPACE
+  if (envNamespace) {
+    const ok = await ensureNamespace(envNamespace, apiKey)
+    if (ok) {
+      resolvedNamespace = envNamespace
+      return resolvedNamespace
+    }
+    return null
+  }
+
+  try {
+    const response = await fetch(`${SMITHERY_API_BASE}/namespaces`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    })
+    if (response.ok) {
+      const data = await response.json()
+      const namespaces = data.data || data.namespaces || data
+      if (Array.isArray(namespaces) && namespaces.length > 0) {
+        resolvedNamespace = namespaces[0].name
+        console.log(
+          "[Smithery Connect] Using existing namespace:",
+          resolvedNamespace
+        )
+        return resolvedNamespace
+      }
+    } else {
+      const body = await response.text()
+      console.error(
+        "[Smithery Connect] Failed to list namespaces:",
+        response.status,
+        body
+      )
+    }
+  } catch (err) {
+    console.error("[Smithery Connect] Failed to list namespaces:", err)
+  }
+
+  // Globally-unique namespace name: suffix with a stable hash of the API key so
+  // two different accounts don't collide on a friendly prefix.
+  const keyHash = createHash("sha256").update(apiKey).digest("hex").slice(0, 8)
+  const newName = `upstream-${keyHash}`
+  console.log("[Smithery Connect] Creating namespace:", newName)
+  const ok = await ensureNamespace(newName, apiKey)
+  if (ok) {
+    resolvedNamespace = newName
+    return resolvedNamespace
+  }
+
+  return null
+}
+
+/** Smithery-hosted server URLs all live under server.smithery.ai. */
+export function isSmitheryServer(url: string): boolean {
+  try {
+    return new URL(url).hostname === "server.smithery.ai"
+  } catch {
+    return false
+  }
+}
+
+/** Deterministic connection id per (chat, qualifiedName) — safe to recreate. */
+export function getSmitheryConnectionId(
+  chatId: string,
+  qualifiedName: string
+): string {
+  // Slashes in qualifiedName (e.g. "exa/exa-search") would be parsed as path
+  // segments by Smithery, so flatten them.
+  const safeName = qualifiedName.replace(/\//g, "-")
+  return `chat-${chatId}-${safeName}`
+}
+
+/** Per-connection MCP endpoint the agent will call. */
+export function getSmitheryMcpEndpoint(
+  namespace: string,
+  connectionId: string
+): string {
+  return `${SMITHERY_API_BASE}/connect/${namespace}/${connectionId}/mcp`
+}
+
+async function ensureNamespace(
+  name: string,
+  apiKey: string
+): Promise<boolean> {
+  try {
+    const response = await fetch(`${SMITHERY_API_BASE}/namespaces/${name}`, {
+      method: "PUT",
+      headers: { Authorization: `Bearer ${apiKey}` },
+    })
+
+    if (!response.ok) {
+      const body = await response.text()
+      // 409 = name taken. Only safe if WE own it; Smithery's error body
+      // mentions "another user" when it's someone else's.
+      if (response.status === 409 && !body.includes("another user")) {
+        return true
+      }
+      console.error(
+        "[Smithery Connect] Failed to create namespace:",
+        response.status,
+        body
+      )
+      return false
+    }
+
+    return true
+  } catch (err) {
+    console.error("[Smithery Connect] Namespace creation error:", err)
+    return false
+  }
+}
+
+export interface SmitheryConnectionResult {
+  status: "connected" | "auth_required" | "error"
+  authorizationUrl?: string
+  connectionId: string
+  namespace: string
+  mcpEndpoint: string
+  error?: string
+}
+
+/**
+ * Create or refresh a Smithery Connect connection for `mcpUrl`.
+ * Idempotent — calling twice with the same connectionId updates in place.
+ */
+export async function createSmitheryConnection(
+  mcpUrl: string,
+  connectionId: string,
+  name: string,
+  apiKey: string
+): Promise<SmitheryConnectionResult> {
+  try {
+    const namespace = await getNamespace(apiKey)
+    if (!namespace) {
+      return {
+        status: "error",
+        connectionId,
+        namespace: "",
+        mcpEndpoint: "",
+        error: "Failed to resolve Smithery namespace",
+      }
+    }
+
+    const mcpEndpoint = getSmitheryMcpEndpoint(namespace, connectionId)
+
+    const response = await fetch(
+      `${SMITHERY_API_BASE}/connect/${namespace}/${connectionId}`,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({ mcpUrl, name }),
+      }
+    )
+
+    if (!response.ok) {
+      const errorText = await response.text()
+      console.error(
+        "[Smithery Connect] PUT /connect failed:",
+        response.status,
+        errorText
+      )
+      return {
+        status: "error",
+        connectionId,
+        namespace,
+        mcpEndpoint,
+        error: `Smithery API returned ${response.status}`,
+      }
+    }
+
+    const data = await response.json()
+    const state = data.status?.state || data.status
+
+    if (state === "auth_required") {
+      return {
+        status: "auth_required",
+        authorizationUrl: data.status?.authorizationUrl,
+        connectionId: data.connectionId || connectionId,
+        namespace,
+        mcpEndpoint,
+      }
+    }
+
+    if (state === "connected") {
+      return {
+        status: "connected",
+        connectionId: data.connectionId || connectionId,
+        namespace,
+        mcpEndpoint,
+      }
+    }
+
+    if (state === "error") {
+      return {
+        status: "error",
+        connectionId,
+        namespace,
+        mcpEndpoint,
+        error: data.status?.message || "Smithery connection error",
+      }
+    }
+
+    return {
+      status: "error",
+      connectionId,
+      namespace,
+      mcpEndpoint,
+      error: `Unexpected status: ${JSON.stringify(data.status)}`,
+    }
+  } catch (err) {
+    console.error("[Smithery Connect] Connection error:", err)
+    return {
+      status: "error",
+      connectionId,
+      namespace: "",
+      mcpEndpoint: "",
+      error: err instanceof Error ? err.message : "Connection failed",
+    }
+  }
+}
+
+/**
+ * After the OAuth popup closes, ping Smithery to verify the connection is now
+ * `connected`. On success, persist the endpoint + encrypted API key on the
+ * ChatMcpServer row so agent runs can use it.
+ */
+export async function finalizeSmitheryConnection(
+  serverId: string,
+  connectionId: string,
+  apiKey: string
+): Promise<boolean> {
+  try {
+    const namespace = await getNamespace(apiKey)
+    if (!namespace) return false
+
+    const mcpEndpoint = getSmitheryMcpEndpoint(namespace, connectionId)
+
+    const response = await fetch(
+      `${SMITHERY_API_BASE}/connect/${namespace}/${connectionId}`,
+      { headers: { Authorization: `Bearer ${apiKey}` } }
+    )
+
+    if (!response.ok) {
+      console.error(
+        "[Smithery Connect] Status check failed:",
+        response.status
+      )
+      return false
+    }
+
+    const data = await response.json()
+    const state = data.status?.state || data.status
+
+    if (state === "connected") {
+      await prisma.chatMcpServer.update({
+        where: { id: serverId },
+        data: {
+          mcpUrl: mcpEndpoint,
+          smitheryNamespace: namespace,
+          encryptedApiKey: encrypt(apiKey),
+          status: "connected",
+          lastError: null,
+        },
+      })
+      return true
+    }
+
+    return false
+  } catch (err) {
+    console.error("[Smithery Connect] Finalize error:", err)
+    return false
+  }
+}
+
+/** Delete the Smithery connection (best-effort) when a row is removed. */
+export async function deleteSmitheryConnection(
+  connectionId: string,
+  apiKey: string
+): Promise<void> {
+  try {
+    const namespace = await getNamespace(apiKey)
+    if (!namespace) return
+    await fetch(`${SMITHERY_API_BASE}/connect/${namespace}/${connectionId}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${apiKey}` },
+    })
+  } catch (err) {
+    // Connection delete is best-effort — DB row deletion is what matters.
+    console.warn("[Smithery Connect] DELETE failed (non-fatal):", err)
+  }
+}

--- a/packages/web/lib/mcp/smithery-connect.ts
+++ b/packages/web/lib/mcp/smithery-connect.ts
@@ -100,7 +100,7 @@ export function getSmitheryConnectionId(
 }
 
 /** Per-connection MCP endpoint the agent will call. */
-export function getSmitheryMcpEndpoint(
+function getSmitheryMcpEndpoint(
   namespace: string,
   connectionId: string
 ): string {

--- a/packages/web/prisma/migrations/20260512100000_add_chat_mcp_server/migration.sql
+++ b/packages/web/prisma/migrations/20260512100000_add_chat_mcp_server/migration.sql
@@ -1,0 +1,27 @@
+-- CreateTable
+CREATE TABLE "ChatMcpServer" (
+    "id" TEXT NOT NULL,
+    "chatId" TEXT NOT NULL,
+    "qualifiedName" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "iconUrl" TEXT,
+    "smitheryConnectionId" TEXT NOT NULL,
+    "smitheryNamespace" TEXT NOT NULL,
+    "mcpUrl" TEXT NOT NULL,
+    "encryptedApiKey" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "lastError" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ChatMcpServer_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ChatMcpServer_chatId_qualifiedName_key" ON "ChatMcpServer"("chatId", "qualifiedName");
+
+-- CreateIndex
+CREATE INDEX "ChatMcpServer_chatId_idx" ON "ChatMcpServer"("chatId");
+
+-- AddForeignKey
+ALTER TABLE "ChatMcpServer" ADD CONSTRAINT "ChatMcpServer_chatId_fkey" FOREIGN KEY ("chatId") REFERENCES "Chat"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/web/prisma/schema.prisma
+++ b/packages/web/prisma/schema.prisma
@@ -131,14 +131,53 @@ model Chat {
   environmentVariables Json?
 
   // Relations
-  user     User      @relation(fields: [userId], references: [id], onDelete: Cascade)
-  messages Message[]
+  user       User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  messages   Message[]
+  mcpServers ChatMcpServer[]
 
   // Link back to scheduled run (if this chat belongs to one)
   scheduledJobRun ScheduledJobRun?
 
   @@index([userId, updatedAt])
   @@index([userId, lastActiveAt])
+}
+
+// =============================================================================
+// ChatMcpServer - per-chat MCP connections (via Smithery Connect)
+// =============================================================================
+// Each row is one connected MCP server for a specific chat. The agent in the
+// sandbox will get a config entry pointing at `mcpUrl` with `encryptedApiKey`
+// decrypted into an Authorization header.
+
+model ChatMcpServer {
+  id     String @id @default(cuid())
+  chatId String
+
+  // Identity from Smithery's registry
+  qualifiedName String // e.g. "exa/exa-search" — stable handle
+  displayName   String
+  iconUrl       String?
+
+  // Smithery Connect connection details
+  smitheryConnectionId String // e.g. "chat-<id>-exa-exa-search"
+  smitheryNamespace    String // the namespace owning the connection
+  mcpUrl               String // api.smithery.ai/connect/<ns>/<id>/mcp
+
+  // Encrypted Smithery API key used to call mcpUrl. Stored per-row so that
+  // rotating the global key doesn't silently break existing connections.
+  encryptedApiKey String? @db.Text
+
+  // Lifecycle
+  status    String  @default("pending") // pending | connected | error
+  lastError String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  chat Chat @relation(fields: [chatId], references: [id], onDelete: Cascade)
+
+  @@unique([chatId, qualifiedName])
+  @@index([chatId])
 }
 
 // =============================================================================


### PR DESCRIPTION
# Browse and connect MCP servers via Smithery (per chat)

  Adds an "MCP Servers" modal where users can browse Smithery's  3000+ MCP servers and connect any of them to the current chat.
  Connected servers are exposed as tools to the agent on every  subsequent message. Smithery Connect handles per-server OAuth —
  no provider-specific auth code lives in this PR.

  ## How it works

  1. **Browse** — modal calls `/api/mcp-registry`, which proxies
  `api.smithery.ai/servers` server-side so `SMITHERY_API_KEY`
  never reaches the browser.
  2. **Connect** — `POST /api/chats/<chatId>/mcp-servers` calls
  Smithery Connect (`PUT /connect/<ns>/<connId>`).
     - **Authless server** → returns `connected` immediately. Row
  stored, agent picks it up on the next message.
     - **OAuth-required** → returns `auth_required` +
  `authorizationUrl`. Modal opens it in a popup, polls for close,
  then `POST /smithery-finalize` confirms with Smithery and stores   credentials.
  3. **Agent runtime** — before each turn, `messages/route.ts`
  calls `loadChatMcpServers(chatId)`, decrypts the per-row
  Smithery API key, and `setupMcpForAgent` writes the correct
  config file in the sandbox with `Authorization: Bearer
  <SMITHERY_API_KEY>`.

  ## What ships

  **Schema**
  - New table `ChatMcpServer` (one row per connected server per
  chat). Stores Smithery connection metadata + encrypted Smithery
  API key.
  - Migration `20260512100000_add_chat_mcp_server` (additive
  only).

  **Backend**
  - `lib/mcp/smithery-connect.ts` — Smithery Connect helpers
  (namespace resolution with hashed-suffix auto-create, connection   create / finalize / delete).
  - `lib/mcp/agent-servers.ts` — `loadChatMcpServers(chatId)`
  returns decrypted, agent-ready connections.
  - `app/api/mcp-registry/{route,[...slug]}.ts` — server-side
  registry browse + detail.
  - `app/api/chats/[chatId]/mcp-servers/` — list / connect /
  disconnect / finalize.

  **UI**
  - `components/modals/McpServersModal.tsx` — Connected + Browse
  tabs, debounced search, pagination, instant-connect vs OAuth
  popup handling.
  - Triggered from command palette (`Cmd/Ctrl+K → "MCP servers"`).
  **Per-agent config writers**
  (`packages/agent-configuration/src/mcp/`)

  Smithery's Connect endpoint is Streamable-HTTP, so every
  generator emits Streamable-HTTP entries:

  | Agent | File | Key shape |
  |---|---|---|
  | claude-code | `~/.claude.json` | `mcpServers.<n>` with `type:
  "http"`, `headers` |
  | codex | `~/.codex/config.toml` | `[mcp_servers.<n>]`
  (underscore), `http_headers` |
  | gemini | `~/.gemini/settings.json` | `mcpServers.<n>.httpUrl`
  |
  | opencode | `<project>/opencode.json` | `mcp.<n>` with `type:
  "remote"` |
  | goose | `~/.config/goose/config.yaml` | `extensions.<n>` with
  `type: streamable_http` |

  JSON configs are shallow-merged with existing content so
  unrelated user settings survive.

  ## Environment variables

  | Var | Required | Purpose |
  |---|---|---|
  | `SMITHERY_API_KEY` | yes | Registry browse + Smithery Connect
  calls + bearer token the agent CLI sends to the MCP endpoint. |
  | `SMITHERY_NAMESPACE` | no | Override namespace. Defaults to
  the API key owner's first namespace, else auto-creates
  `upstream-<sha256(apiKey)[:8]>`. |
  | `ENCRYPTION_KEY` | yes (already required) | Encrypts the
  per-row Smithery API key in `ChatMcpServer.encryptedApiKey`. |

  ## Setup

  ```bash
  # 1. Add SMITHERY_API_KEY to your env (sign up at smithery.ai)

  # 2. Apply migration
  cd packages/web
  npx prisma migrate deploy

  # 3. Restart dev server
  ```

  Then in any chat: `Cmd/Ctrl+K` → "MCP servers" → Browse →
  Connect.

  ## Scope and known limits

  - **Per-chat scope.** Each chat has its own connection list.
  Connecting Exa to chat A does not connect it to chat B.
  (Scope-agnostic on the agent and Smithery sides — flipping to
  per-user later is a localized change.)
  - **Smithery-hosted servers only.** Non-`server.smithery.ai`
  URLs are rejected with 400. Standard MCP OAuth discovery is
  intentionally out of scope.
  
  ## Verified

  Connected and used **Clear Thought** (authless) with claude-code
  end-to-end — agent received the tool, called it, results
  streamed back.

