### PR TITLE
feat: github mcp integration using github app

### DIFF
--- a/packages/agent-configuration/src/mcp/index.ts
+++ b/packages/agent-configuration/src/mcp/index.ts
@@ -164,7 +164,9 @@ function generateMcpConfigForAgent(
   agent: string,
   servers: AgentMcpServer[]
 ): McpConfigFile | null {
-  if (!agentSupportsMcp(agent) || servers.length === 0) return null
+  if (!agentSupportsMcp(agent)) return null
+  // NOTE: empty `servers` is intentional — we still write the config so
+  // previously-connected servers are removed from the file.
   switch (agent) {
     case "claude-code":
       return generateClaudeConfig(servers)
@@ -199,8 +201,10 @@ export async function setupMcpForAgent(
   { agent, servers }: SetupMcpOptions
 ): Promise<void> {
   if (!agentSupportsMcp(agent)) return
-  if (servers.length === 0) return
 
+  // Always write — even with no servers — so removing the last connection
+  // clears the previous file instead of leaving stale entries the agent CLI
+  // would still try to load.
   const config = generateMcpConfigForAgent(agent, servers)
   if (!config) return
 
@@ -240,13 +244,15 @@ async function mergeJsonConfig(
 
   const incoming = JSON.parse(newContent) as Record<string, unknown>
 
-  if (incoming.mcpServers) {
-    const prev = (existing.mcpServers as Record<string, unknown>) || {}
-    existing.mcpServers = { ...prev, ...(incoming.mcpServers as object) }
+  // Replace the MCP section wholesale — we are the source of truth for which
+  // servers should be present. A shallow merge would leak removed servers
+  // (e.g. user disconnects GitHub but the entry survives on disk).
+  // Top-level keys outside these sections are preserved by `existing` itself.
+  if (incoming.mcpServers !== undefined) {
+    existing.mcpServers = incoming.mcpServers
   }
-  if (incoming.mcp) {
-    const prev = (existing.mcp as Record<string, unknown>) || {}
-    existing.mcp = { ...prev, ...(incoming.mcp as object) }
+  if (incoming.mcp !== undefined) {
+    existing.mcp = incoming.mcp
   }
   if (incoming.$schema && !existing.$schema) {
     existing.$schema = incoming.$schema

--- a/packages/web/app/api/chats/[chatId]/mcp-servers/github/route.ts
+++ b/packages/web/app/api/chats/[chatId]/mcp-servers/github/route.ts
@@ -1,0 +1,71 @@
+/**
+ * POST /api/chats/<chatId>/mcp-servers/github
+ *
+ * Add a sentinel ChatMcpServer row that points at GitHub's hosted MCP
+ * (api.githubcopilot.com/mcp/). No Smithery involved — the agent-side
+ * loader detects the sentinel qualifiedName and mints a fresh installation
+ * token on every turn.
+ *
+ * Requires the user to have completed the GitHub App install first
+ * (User.githubAppInstallationId must be set).
+ */
+import { prisma } from "@/lib/db/prisma"
+import {
+  requireAuth,
+  isAuthError,
+  notFound,
+  internalError,
+  getChatWithAuth,
+} from "@/lib/db/api-helpers"
+import { GITHUB_MCP_QUALIFIED_NAME, GITHUB_MCP_URL } from "@/lib/github/app"
+
+export async function POST(
+  _req: Request,
+  { params }: { params: Promise<{ chatId: string }> }
+): Promise<Response> {
+  const auth = await requireAuth()
+  if (isAuthError(auth)) return auth
+  const { userId } = auth
+  const { chatId } = await params
+
+  const chat = await getChatWithAuth(chatId, userId)
+  if (!chat) return notFound("Chat not found")
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { githubAppInstallationId: true },
+  })
+  if (!user?.githubAppInstallationId) {
+    return Response.json(
+      { error: "GitHub App not installed for this user" },
+      { status: 409 }
+    )
+  }
+
+  try {
+    const { id: serverId } = await prisma.chatMcpServer.upsert({
+      where: {
+        chatId_qualifiedName: {
+          chatId,
+          qualifiedName: GITHUB_MCP_QUALIFIED_NAME,
+        },
+      },
+      create: {
+        chatId,
+        qualifiedName: GITHUB_MCP_QUALIFIED_NAME,
+        displayName: "GitHub",
+        iconUrl: null,
+        mcpUrl: GITHUB_MCP_URL,
+        status: "connected",
+      },
+      update: {
+        status: "connected",
+        lastError: null,
+      },
+      select: { id: true },
+    })
+    return Response.json({ connected: true, serverId })
+  } catch (err) {
+    return internalError(err)
+  }
+}

--- a/packages/web/app/api/mcp-registry/route.ts
+++ b/packages/web/app/api/mcp-registry/route.ts
@@ -96,8 +96,14 @@ export async function GET(req: Request): Promise<Response> {
     }
 
     const data: SmitheryResponse = await response.json()
+    // We expose GitHub through our own App connection (pinned in the modal),
+    // so suppress every Smithery server with "github" in its qualifiedName
+    // to avoid duplicate / confusing entries in the user's search results.
+    const servers = data.servers
+      .filter((s) => !/github/i.test(s.qualifiedName))
+      .map(transformServer)
     return NextResponse.json({
-      servers: data.servers.map(transformServer),
+      servers,
       page: data.pagination.currentPage,
       pageSize: data.pagination.pageSize,
       totalPages: data.pagination.totalPages,

--- a/packages/web/app/api/mcp/connect/github/callback/route.ts
+++ b/packages/web/app/api/mcp/connect/github/callback/route.ts
@@ -1,0 +1,77 @@
+/**
+ * GET /api/mcp/connect/github/callback
+ *
+ * Where GitHub redirects after the user installs (or re-configures) our App.
+ * We persist `installation_id` on the User and return a tiny HTML page that
+ * closes the popup. The parent window polls /api/mcp/connect/github so it
+ * notices the connected state on its own.
+ *
+ * Query params from GitHub:
+ *   - installation_id  the installation we'll use for this user
+ *   - setup_action     "install" | "update"
+ *   - code, state      OAuth bits we don't use
+ */
+
+import { NextRequest } from "next/server"
+import { prisma } from "@/lib/db/prisma"
+import { requireAuth, isAuthError } from "@/lib/db/api-helpers"
+
+function closingPage(opts: { ok: boolean; message: string }): Response {
+  const safe = opts.message.replace(/[<>&]/g, (c) =>
+    c === "<" ? "&lt;" : c === ">" ? "&gt;" : "&amp;"
+  )
+  const body = `<!doctype html>
+<html><head><meta charset="utf-8"><title>GitHub setup ${opts.ok ? "complete" : "failed"}</title>
+<style>
+  body { font: 14px system-ui, sans-serif; padding: 24px; color: #333; }
+  .ok { color: #1a7f37; }
+  .err { color: #cf222e; }
+</style>
+</head>
+<body>
+  <p class="${opts.ok ? "ok" : "err"}">${safe}</p>
+  <p>You can close this window.</p>
+  <script>
+    try { window.opener && window.opener.postMessage({ source: "github-app-install", ok: ${opts.ok} }, "*"); } catch (e) {}
+    setTimeout(function () { try { window.close(); } catch (e) {} }, 800);
+  </script>
+</body></html>`
+  return new Response(body, {
+    status: opts.ok ? 200 : 400,
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  })
+}
+
+export async function GET(req: NextRequest): Promise<Response> {
+  const auth = await requireAuth()
+  if (isAuthError(auth)) {
+    return closingPage({
+      ok: false,
+      message: "You must be signed in to finish GitHub setup.",
+    })
+  }
+  const { userId } = auth
+
+  const installationId = new URL(req.url).searchParams.get("installation_id")
+  if (!installationId) {
+    return closingPage({
+      ok: false,
+      message: "GitHub did not return an installation id. Please try again.",
+    })
+  }
+
+  try {
+    await prisma.user.update({
+      where: { id: userId },
+      data: { githubAppInstallationId: installationId },
+    })
+    return closingPage({
+      ok: true,
+      message: "GitHub connected. You can return to the app.",
+    })
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error)
+    console.error(`[MCP-callback] failed for user ${userId}: ${msg}`)
+    return closingPage({ ok: false, message: `GitHub setup failed: ${msg}` })
+  }
+}

--- a/packages/web/app/api/mcp/connect/github/route.ts
+++ b/packages/web/app/api/mcp/connect/github/route.ts
@@ -1,0 +1,103 @@
+/**
+ * /api/mcp/connect/github
+ *
+ * Manages the user's GitHub App installation. The install itself happens on
+ * github.com and finishes in /api/mcp/connect/github/callback.
+ *
+ * GET   →   is the App installed for this user? + the install URL the popup
+ *           should open if not.
+ * DELETE →  clear our recorded installationId. Does NOT uninstall the App
+ *           from the user's GitHub account — that's a user-initiated action
+ *           on github.com.
+ */
+
+import { NextRequest } from "next/server"
+import { prisma } from "@/lib/db/prisma"
+import {
+  requireAuth,
+  isAuthError,
+  internalError,
+  serverConfigError,
+} from "@/lib/db/api-helpers"
+import {
+  getInstallUrl,
+  invalidateInstallationToken,
+} from "@/lib/github/app"
+
+interface ConnectResponse {
+  /** True iff the user has installed our GitHub App. */
+  connected: boolean
+  /** The URL to open in a popup when not connected. */
+  installUrl?: string
+  /** Present iff connected — used to build the github.com management URL. */
+  installationId?: string
+}
+
+function requireConfig(): Response | null {
+  if (!process.env.GITHUB_APP_ID) return serverConfigError("GITHUB_APP_ID")
+  if (!process.env.GITHUB_APP_SLUG) return serverConfigError("GITHUB_APP_SLUG")
+  if (!process.env.GITHUB_APP_PRIVATE_KEY) {
+    return serverConfigError("GITHUB_APP_PRIVATE_KEY")
+  }
+  return null
+}
+
+async function getStatus(userId: string): Promise<ConnectResponse> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { githubAppInstallationId: true },
+  })
+  if (user?.githubAppInstallationId) {
+    return { connected: true, installationId: user.githubAppInstallationId }
+  }
+  return { connected: false, installUrl: getInstallUrl() }
+}
+
+export async function GET(_req: NextRequest): Promise<Response> {
+  const auth = await requireAuth()
+  if (isAuthError(auth)) return auth
+  const cfgErr = requireConfig()
+  if (cfgErr) return cfgErr
+
+  try {
+    return Response.json(await getStatus(auth.userId))
+  } catch (error) {
+    return internalError(error)
+  }
+}
+
+export async function DELETE(_req: NextRequest): Promise<Response> {
+  const auth = await requireAuth()
+  if (isAuthError(auth)) return auth
+  const cfgErr = requireConfig()
+  if (cfgErr) return cfgErr
+
+  const { userId } = auth
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { githubAppInstallationId: true },
+  })
+
+  // Drop the cached installation token before clearing the id; otherwise a
+  // re-install with the same installation id could briefly hit the stale
+  // cached token.
+  if (user?.githubAppInstallationId) {
+    invalidateInstallationToken(user.githubAppInstallationId)
+  }
+
+  await prisma.user.update({
+    where: { id: userId },
+    data: { githubAppInstallationId: null },
+  })
+
+  // Also drop any per-chat GitHub MCP rows that point at this user's chats,
+  // so the modal stops showing GitHub as connected.
+  await prisma.chatMcpServer.deleteMany({
+    where: {
+      chat: { userId },
+      qualifiedName: "github/github",
+    },
+  })
+
+  return Response.json({ disconnected: true })
+}

--- a/packages/web/components/modals/McpServersModal.tsx
+++ b/packages/web/components/modals/McpServersModal.tsx
@@ -16,16 +16,25 @@
 import * as Dialog from "@radix-ui/react-dialog"
 import {
   BadgeCheck,
+  ExternalLink,
+  Github,
   Loader2,
   Plug,
   Plus,
   Search,
+  Settings,
   Trash2,
   X,
 } from "lucide-react"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { Input } from "@/components/ui/input"
 import { focusChatPrompt } from "@/components/ui/modal-header"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import { cn } from "@/lib/utils"
 
 // =============================================================================
@@ -59,6 +68,9 @@ interface McpServersModalProps {
   chatId: string
 }
 
+/** Sentinel used by the server-side ChatMcpServer row for the GitHub MCP. */
+const GITHUB_QUALIFIED_NAME = "github/github"
+
 // =============================================================================
 // Component
 // =============================================================================
@@ -85,6 +97,11 @@ export function McpServersModal({
   const [connectingSlug, setConnectingSlug] = useState<string | null>(null)
 
   const popupTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  // GitHub App install state (user-level)
+  const [githubInstalled, setGithubInstalled] = useState<boolean | null>(null)
+  const [githubInstallationId, setGithubInstallationId] = useState<string | null>(null)
+  const [githubBusy, setGithubBusy] = useState(false)
 
   // Reset state when the modal opens.
   useEffect(() => {
@@ -138,10 +155,30 @@ export function McpServersModal({
     []
   )
 
-  // Load connected list every time the modal opens.
+  const loadGithubStatus = useCallback(async () => {
+    try {
+      const res = await fetch("/api/mcp/connect/github")
+      if (res.ok) {
+        const data = await res.json()
+        setGithubInstalled(!!data.connected)
+        setGithubInstallationId(data.installationId ?? null)
+      } else {
+        setGithubInstalled(false)
+        setGithubInstallationId(null)
+      }
+    } catch {
+      setGithubInstalled(false)
+      setGithubInstallationId(null)
+    }
+  }, [])
+
+  // Load connected list + GitHub status every time the modal opens.
   useEffect(() => {
-    if (open) loadConnected()
-  }, [open, loadConnected])
+    if (open) {
+      loadConnected()
+      loadGithubStatus()
+    }
+  }, [open, loadConnected, loadGithubStatus])
 
   // Load registry when entering Browse, then re-load on debounced search.
   useEffect(() => {
@@ -175,6 +212,94 @@ export function McpServersModal({
       }
     } finally {
       setDeletingId(null)
+    }
+  }
+
+  /** Add the GitHub MCP sentinel row to this chat. */
+  async function addGithubToChat() {
+    const res = await fetch(`/api/chats/${chatId}/mcp-servers/github`, {
+      method: "POST",
+    })
+    if (res.ok) await loadConnected()
+  }
+
+  /**
+   * Install the GitHub App if needed, then add the GitHub MCP row to the chat.
+   * Status check tells us which path we're on.
+   */
+  async function handleConnectGithub() {
+    if (githubBusy) return
+    setGithubBusy(true)
+    try {
+      const statusRes = await fetch("/api/mcp/connect/github")
+      if (!statusRes.ok) throw new Error("Failed to check GitHub status")
+      const status = await statusRes.json()
+
+      if (status.connected) {
+        await addGithubToChat()
+        return
+      }
+
+      // Open install popup and wait for the callback to postMessage success.
+      const popup = window.open(
+        status.installUrl,
+        "github-app-install",
+        "width=600,height=700,scrollbars=yes"
+      )
+      if (!popup || popup.closed) return
+
+      await new Promise<void>((resolve) => {
+        function onMessage(e: MessageEvent) {
+          const data = e.data as { source?: string; ok?: boolean } | null
+          if (data?.source === "github-app-install") {
+            window.removeEventListener("message", onMessage)
+            resolve()
+          }
+        }
+        window.addEventListener("message", onMessage)
+
+        // Also resolve when the popup closes — postMessage can be blocked by
+        // some browsers / CSPs, but a closed popup is a reliable signal.
+        const t = setInterval(() => {
+          if (popup.closed) {
+            clearInterval(t)
+            window.removeEventListener("message", onMessage)
+            resolve()
+          }
+        }, 500)
+      })
+
+      // Re-fetch status: if it's now connected, add the row.
+      const after = await fetch("/api/mcp/connect/github")
+      const afterData = after.ok ? await after.json() : { connected: false }
+      setGithubInstalled(!!afterData.connected)
+      if (afterData.connected) await addGithubToChat()
+    } catch (err) {
+      console.error("[McpServersModal] handleConnectGithub failed:", err)
+    } finally {
+      setGithubBusy(false)
+    }
+  }
+
+  /**
+   * Hard disconnect: clear installationId on the user and drop every GitHub
+   * row across this user's chats. The actual App stays installed on
+   * github.com until the user removes it there — we just lose access.
+   */
+  async function handleUninstallGithubApp() {
+    if (!confirm("Uninstall the GitHub App for your account? This removes GitHub MCP from every chat.")) {
+      return
+    }
+    setGithubBusy(true)
+    try {
+      const res = await fetch("/api/mcp/connect/github", { method: "DELETE" })
+      if (res.ok) {
+        setGithubInstalled(false)
+        setGithubInstallationId(null)
+        await loadConnected()
+      }
+    } finally {
+      setGithubBusy(false)
     }
   }
 
@@ -318,6 +443,9 @@ export function McpServersModal({
                 deletingId={deletingId}
                 onDisconnect={handleDisconnect}
                 onBrowse={() => setTab("browse")}
+                githubInstallationId={githubInstallationId}
+                onUninstallGithub={handleUninstallGithubApp}
+                githubBusy={githubBusy}
               />
             )}
             {tab === "browse" && (
@@ -336,6 +464,11 @@ export function McpServersModal({
                   setPage(next)
                   loadRegistry(search, next, true)
                 }}
+                githubConnected={connected.some(
+                  (s) => s.qualifiedName === GITHUB_QUALIFIED_NAME
+                )}
+                githubBusy={githubBusy}
+                onConnectGithub={handleConnectGithub}
               />
             )}
           </div>
@@ -355,12 +488,18 @@ function ConnectedView({
   deletingId,
   onDisconnect,
   onBrowse,
+  githubInstallationId,
+  onUninstallGithub,
+  githubBusy,
 }: {
   servers: ConnectedServer[]
   loading: boolean
   deletingId: string | null
   onDisconnect: (id: string) => void
   onBrowse: () => void
+  githubInstallationId: string | null
+  onUninstallGithub: () => void
+  githubBusy: boolean
 }) {
   if (loading) {
     return (
@@ -387,51 +526,91 @@ function ConnectedView({
   }
   return (
     <div className="space-y-2">
-      {servers.map((s) => (
-        <div
-          key={s.id}
-          className="flex items-center gap-3 rounded-lg border border-border p-3"
-        >
-          {s.iconUrl ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              src={s.iconUrl}
-              alt=""
-              className="h-8 w-8 rounded shrink-0"
-            />
-          ) : (
-            <div className="h-8 w-8 rounded bg-muted shrink-0 flex items-center justify-center">
-              <Plug className="h-4 w-4 text-muted-foreground" />
-            </div>
-          )}
-          <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium truncate">{s.displayName}</p>
-            <p className="text-xs text-muted-foreground truncate">
-              {s.qualifiedName}
-            </p>
-            {s.status === "error" && s.lastError && (
-              <p className="text-xs text-destructive mt-0.5">{s.lastError}</p>
-            )}
-            {s.status === "pending" && (
-              <p className="text-xs text-muted-foreground mt-0.5">
-                Awaiting authorization…
-              </p>
-            )}
-          </div>
-          <button
-            onClick={() => onDisconnect(s.id)}
-            disabled={deletingId === s.id}
-            className="p-1.5 rounded-md text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors cursor-pointer disabled:opacity-50"
-            aria-label="Disconnect"
+      {servers.map((s) => {
+        const isGithub = s.qualifiedName === GITHUB_QUALIFIED_NAME
+        return (
+          <div
+            key={s.id}
+            className="flex items-center gap-3 rounded-lg border border-border p-3"
           >
-            {deletingId === s.id ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
+            {isGithub ? (
+              <div className="h-8 w-8 rounded bg-muted shrink-0 flex items-center justify-center">
+                <Github className="h-4 w-4 text-muted-foreground" />
+              </div>
+            ) : s.iconUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={s.iconUrl}
+                alt=""
+                className="h-8 w-8 rounded shrink-0"
+              />
             ) : (
-              <Trash2 className="h-4 w-4" />
+              <div className="h-8 w-8 rounded bg-muted shrink-0 flex items-center justify-center">
+                <Plug className="h-4 w-4 text-muted-foreground" />
+              </div>
             )}
-          </button>
-        </div>
-      ))}
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium truncate">{s.displayName}</p>
+              <p className="text-xs text-muted-foreground truncate">
+                {s.qualifiedName}
+              </p>
+              {s.status === "error" && s.lastError && (
+                <p className="text-xs text-destructive mt-0.5">{s.lastError}</p>
+              )}
+              {s.status === "pending" && (
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  Awaiting authorization…
+                </p>
+              )}
+            </div>
+            {isGithub && githubInstallationId && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors cursor-pointer disabled:opacity-50"
+                    disabled={githubBusy}
+                    aria-label="GitHub settings"
+                  >
+                    <Settings className="h-4 w-4" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem asChild>
+                    <a
+                      href={`https://github.com/settings/installations/${githubInstallationId}`}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      className="flex items-center gap-2 px-2 py-1.5 text-sm cursor-pointer rounded-sm hover:bg-accent"
+                    >
+                      <ExternalLink className="h-3.5 w-3.5" />
+                      Manage repositories
+                    </a>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onSelect={onUninstallGithub}
+                    className="flex items-center gap-2 px-2 py-1.5 text-sm cursor-pointer rounded-sm text-destructive focus:bg-destructive/10 focus:text-destructive"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                    Uninstall app entirely
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
+            <button
+              onClick={() => onDisconnect(s.id)}
+              disabled={deletingId === s.id}
+              className="p-1.5 rounded-md text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors cursor-pointer disabled:opacity-50"
+              aria-label="Disconnect"
+            >
+              {deletingId === s.id ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Trash2 className="h-4 w-4" />
+              )}
+            </button>
+          </div>
+        )
+      })}
     </div>
   )
 }
@@ -447,6 +626,9 @@ function BrowseView({
   onConnect,
   hasMore,
   onLoadMore,
+  githubConnected,
+  githubBusy,
+  onConnectGithub,
 }: {
   servers: RegistryServer[]
   connectedSlugs: Set<string>
@@ -458,6 +640,9 @@ function BrowseView({
   onConnect: (s: RegistryServer) => void
   hasMore: boolean
   onLoadMore: () => void
+  githubConnected: boolean
+  githubBusy: boolean
+  onConnectGithub: () => void
 }) {
   return (
     <div>
@@ -466,11 +651,49 @@ function BrowseView({
         <Input
           value={search}
           onChange={(e) => onSearchChange(e.target.value)}
-          placeholder="Search MCP servers (e.g. exa, github, postgres)"
+          placeholder="Search MCP servers (e.g. exa, postgres, notion)"
           className="pl-8 text-sm"
           autoComplete="off"
           spellCheck={false}
         />
+      </div>
+
+      {/* Featured: our GitHub App entry. Always shown above the registry
+          search results, regardless of the search query. */}
+      <div className="mb-3">
+        <p className="text-[11px] uppercase tracking-wide text-muted-foreground/70 mb-1.5 px-1">
+          Featured
+        </p>
+        <div className="flex items-center gap-3 rounded-lg border border-border p-3 bg-muted/30">
+          <div className="h-8 w-8 rounded bg-muted shrink-0 flex items-center justify-center">
+            <Github className="h-4 w-4 text-muted-foreground" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium">GitHub · via our app</p>
+            <p className="text-xs text-muted-foreground line-clamp-2">
+              Issues, PRs, code search, and repo access via a scoped GitHub App
+              installation.
+            </p>
+          </div>
+          {githubConnected ? (
+            <span className="text-xs text-muted-foreground px-2">
+              Connected
+            </span>
+          ) : (
+            <button
+              onClick={onConnectGithub}
+              disabled={githubBusy}
+              className="rounded bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 cursor-pointer flex items-center gap-1"
+            >
+              {githubBusy ? (
+                <Loader2 className="h-3 w-3 animate-spin" />
+              ) : (
+                <Plus className="h-3 w-3" />
+              )}
+              Connect
+            </button>
+          )}
+        </div>
       </div>
       {loading ? (
         <div className="flex justify-center py-8 text-muted-foreground">

--- a/packages/web/lib/agent-session.ts
+++ b/packages/web/lib/agent-session.ts
@@ -139,9 +139,12 @@ Your plan should include:
     await setupCodexRules(sandbox)
   }
 
-  // Write per-agent MCP config files for the connected Smithery servers.
+  // Write per-agent MCP config files for the connected MCP servers.
   // Must run before createSession() so the CLI loads them on spawn.
-  if (options.mcpServers && options.mcpServers.length > 0) {
+  // Always call — even with an empty list — so that disconnecting the last
+  // server overwrites the previous on-disk config in a reused sandbox. Skipping
+  // the call here would leave stale entries the agent CLI still loads.
+  if (options.mcpServers) {
     try {
       await setupMcpForAgent(sandbox, {
         agent,

--- a/packages/web/lib/github/app.ts
+++ b/packages/web/lib/github/app.ts
@@ -1,0 +1,136 @@
+/**
+ * GitHub App helpers — JWT signing + installation access tokens.
+ *
+ * The app points the agent at GitHub's hosted MCP server
+ * (api.githubcopilot.com/mcp/) and authenticates with a short-lived
+ * installation access token minted from our App. The agent never sees the
+ * App private key, only the per-request bearer token.
+ *
+ * Tokens are cached in-process by installationId and re-minted lazily before
+ * expiry. We mint a fresh token at the start of each agent turn (where the
+ * caller plugs it into the per-agent MCP config), so the 5-min refresh slack
+ * here is purely a safety net against handing out an about-to-expire token.
+ */
+
+import { SignJWT } from "jose"
+import { createPrivateKey, type KeyObject } from "crypto"
+
+interface InstallationToken {
+  token: string
+  /** ms-epoch when GitHub will reject this token. */
+  expiresAt: number
+}
+
+const tokenCache = new Map<string, InstallationToken>()
+
+const REFRESH_BEFORE_MS = 5 * 60 * 1000
+
+function readEnv(name: string): string {
+  const v = process.env[name]
+  if (!v) throw new Error(`${name} is not set`)
+  return v
+}
+
+/**
+ * Parse the App private key. Accepts:
+ *   - single-line PEM with literal `\n` between rows (typical .env style)
+ *   - real multi-line PEM (some env loaders)
+ * Node's createPrivateKey accepts both PKCS#1 and PKCS#8.
+ */
+let _cachedKey: KeyObject | null = null
+function getPrivateKey(): KeyObject {
+  if (_cachedKey) return _cachedKey
+  const raw = readEnv("GITHUB_APP_PRIVATE_KEY")
+  const pem = raw.includes("\\n") ? raw.replace(/\\n/g, "\n") : raw
+  _cachedKey = createPrivateKey({ key: pem, format: "pem" })
+  return _cachedKey
+}
+
+/**
+ * Sign a 9-minute JWT identifying our GitHub App. GitHub's hard limit is
+ * 10 minutes; we leave a minute of slack and backdate `iat` 60s for clock
+ * skew.
+ */
+async function signAppJwt(): Promise<string> {
+  const key = getPrivateKey()
+  const now = Math.floor(Date.now() / 1000)
+  return await new SignJWT({})
+    .setProtectedHeader({ alg: "RS256" })
+    .setIssuedAt(now - 60)
+    .setExpirationTime(now + 540)
+    .setIssuer(readEnv("GITHUB_APP_ID"))
+    .sign(key)
+}
+
+/**
+ * Exchange the App JWT for a 1-hour installation access token. This token is
+ * what the agent's tool calls actually use against api.githubcopilot.com.
+ */
+async function mintInstallationToken(
+  installationId: string
+): Promise<InstallationToken> {
+  const jwt = await signAppJwt()
+  const res = await fetch(
+    `https://api.github.com/app/installations/${installationId}/access_tokens`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    }
+  )
+  if (!res.ok) {
+    const body = await res.text().catch(() => "")
+    throw new Error(
+      `GitHub installation token request failed: ${res.status} ${body}`
+    )
+  }
+  const data = (await res.json()) as { token: string; expires_at: string }
+  return {
+    token: data.token,
+    expiresAt: new Date(data.expires_at).getTime(),
+  }
+}
+
+/**
+ * Get a fresh installation token. Refreshes lazily when within
+ * REFRESH_BEFORE_MS of expiry so callers never get an about-to-die token.
+ */
+export async function getInstallationToken(
+  installationId: string
+): Promise<string> {
+  const cached = tokenCache.get(installationId)
+  const now = Date.now()
+  if (cached && cached.expiresAt - now > REFRESH_BEFORE_MS) {
+    return cached.token
+  }
+  const fresh = await mintInstallationToken(installationId)
+  tokenCache.set(installationId, fresh)
+  return fresh.token
+}
+
+/** Drop a cached token — used after disconnect. */
+export function invalidateInstallationToken(installationId: string): void {
+  tokenCache.delete(installationId)
+}
+
+/**
+ * GitHub's hosted MCP server. Accepts `Authorization: Bearer <installation-
+ * token>` and exposes issues, PRs, repos, code search, etc.
+ */
+export const GITHUB_MCP_URL = "https://api.githubcopilot.com/mcp/"
+
+/** Sentinel qualifiedName we use for the GitHub MCP row in ChatMcpServer. */
+export const GITHUB_MCP_QUALIFIED_NAME = "github/github"
+
+/** Public app slug used to build the install URL. */
+function getAppSlug(): string {
+  return readEnv("GITHUB_APP_SLUG")
+}
+
+/** Where to send the user to install/authorize the App. */
+export function getInstallUrl(): string {
+  return `https://github.com/apps/${getAppSlug()}/installations/new`
+}

--- a/packages/web/lib/mcp/agent-servers.ts
+++ b/packages/web/lib/mcp/agent-servers.ts
@@ -1,11 +1,18 @@
 /**
  * Load a chat's connected MCP servers in the shape `setupMcpForAgent` wants.
  *
- * Returns only `connected` rows (skips pending/error). Decrypts the per-row
- * Smithery API key here so callers don't need to touch encryption.
+ * Two kinds of rows:
+ *   - Smithery rows  → decrypt the stored Smithery API key for the bearer.
+ *   - GitHub row     → mint a fresh installation token via getInstallationToken
+ *                      (tokens are 1-hour, so we re-mint on every turn instead
+ *                      of trying to keep them in sync with the DB).
  */
 import { prisma } from "@/lib/db/prisma"
 import { decrypt } from "@/lib/db/encryption"
+import {
+  GITHUB_MCP_QUALIFIED_NAME,
+  getInstallationToken,
+} from "@/lib/github/app"
 import type { AgentMcpServer } from "@upstream/agent-configuration/mcp"
 
 /** Sanitize Smithery's slugs into a name acceptable to every agent CLI. */
@@ -22,12 +29,38 @@ export async function loadChatMcpServers(
       qualifiedName: true,
       mcpUrl: true,
       encryptedApiKey: true,
+      chat: { select: { user: { select: { githubAppInstallationId: true } } } },
     },
   })
 
   const out: AgentMcpServer[] = []
   for (const row of rows) {
-    if (!row.encryptedApiKey || !row.mcpUrl) continue
+    if (!row.mcpUrl) continue
+
+    if (row.qualifiedName === GITHUB_MCP_QUALIFIED_NAME) {
+      const installationId = row.chat.user.githubAppInstallationId
+      if (!installationId) {
+        // Row exists but App has been uninstalled — skip silently so the agent
+        // doesn't get a row with no usable auth.
+        continue
+      }
+      try {
+        const token = await getInstallationToken(installationId)
+        out.push({
+          name: safeServerName(row.qualifiedName),
+          url: row.mcpUrl,
+          bearerToken: token,
+        })
+      } catch (err) {
+        console.error(
+          "[agent-servers] failed to mint GitHub installation token:",
+          err
+        )
+      }
+      continue
+    }
+
+    if (!row.encryptedApiKey) continue
     out.push({
       name: safeServerName(row.qualifiedName),
       url: row.mcpUrl,

--- a/packages/web/prisma/migrations/20260513100000_add_github_app_and_nullable_smithery_fields/migration.sql
+++ b/packages/web/prisma/migrations/20260513100000_add_github_app_and_nullable_smithery_fields/migration.sql
@@ -1,0 +1,10 @@
+-- AlterTable: capture the user's GitHub App installation
+-- IF NOT EXISTS keeps this migration idempotent across DBs that already had
+-- this column from an earlier branch.
+ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "githubAppInstallationId" TEXT;
+
+-- AlterTable: allow non-Smithery rows (e.g. GitHub MCP) in ChatMcpServer.
+-- DROP NOT NULL is itself idempotent — Postgres accepts it on already-nullable
+-- columns without error.
+ALTER TABLE "ChatMcpServer" ALTER COLUMN "smitheryConnectionId" DROP NOT NULL;
+ALTER TABLE "ChatMcpServer" ALTER COLUMN "smitheryNamespace" DROP NOT NULL;

--- a/packages/web/prisma/schema.prisma
+++ b/packages/web/prisma/schema.prisma
@@ -38,6 +38,12 @@ model User {
   // { "owner/repo": { "KEY1": "encrypted_value1", ... }, ... }
   repoEnvironmentVariables Json?
 
+  // GitHub App installation id, captured in the install callback. Null until
+  // the user installs our GitHub App. Used to mint short-lived installation
+  // access tokens at agent-run time so the agent can call GitHub's MCP server
+  // with properly-scoped credentials.
+  githubAppInstallationId String?
+
   chats         Chat[]
   accounts      Account[]
   sessions      Session[]
@@ -158,10 +164,11 @@ model ChatMcpServer {
   displayName   String
   iconUrl       String?
 
-  // Smithery Connect connection details
-  smitheryConnectionId String // e.g. "chat-<id>-exa-exa-search"
-  smitheryNamespace    String // the namespace owning the connection
-  mcpUrl               String // api.smithery.ai/connect/<ns>/<id>/mcp
+  // Smithery Connect connection details. Null for non-Smithery rows (e.g. the
+  // GitHub MCP row, which goes directly to api.githubcopilot.com).
+  smitheryConnectionId String?
+  smitheryNamespace    String?
+  mcpUrl               String // remote MCP endpoint the agent will call
 
   // Encrypted Smithery API key used to call mcpUrl. Stored per-row so that
   // rotating the global key doesn't silently break existing connections.


### PR DESCRIPTION
## PR: GitHub MCP via dedicated GitHub App
  
  ### Summary

  This branch builds on the Smithery browse PR (#91) by  adding a **first-class GitHub MCP connection backed by 
  our own GitHub App** instead of going through Smithery's
  hosted GitHub OAuth. Smithery handles every other server
  in its 3000+ registry; GitHub gets its own scoped App so
  users can pick which repositories the agent can touch.

  Both flows share the same `ChatMcpServer` table — GitHub
  is just a special row identified by the sentinel
  `qualifiedName: "github/github"`. The agent runner
  doesn't distinguish them; only the loader cares (Smithery   → decrypt stored key, GitHub → mint a fresh installation   token).

  ### How it works now

  **Smithery flow (unchanged from main):**
  - User browses Smithery's registry in the modal → clicks
  Connect
  - For OAuth servers, a Smithery popup completes the
  handshake
  - We store `{ smitheryConnectionId, smitheryNamespace,
  encryptedApiKey }` in `ChatMcpServer`
  - At agent turn time, decrypt the key and hand the agent
  `https://server.smithery.ai/<ns>/mcp` + bearer token

  **GitHub flow (new):**
  - "Featured" tile pinned at the top of the Browse tab,
  "Connect" button
  - Click → popup to
  `https://github.com/apps/<slug>/installations/new` → user   picks repos
  - Callback at `/api/mcp/connect/github/callback` records
  `installation_id` on the `User`
  - Adding to a chat creates a `ChatMcpServer` row with
  `qualifiedName: "github/github"`, no Smithery fields, no
  stored key
  - At agent turn time, mint a fresh 1-hour installation
  access token (JWT-signed against the App's private key)
  and hand the agent `https://api.githubcopilot.com/mcp/` +   that token
  - Gear menu on the connected row → "Manage repositories"
  (link to github.com) or "Uninstall app entirely"
  - Smithery registry results are filtered to drop anything   with `github` in the qualifiedName so there's no
  duplicate entry

  ### Backend message flow

  
<img width="589" height="2773" alt="Flowchart Diagram by Mermaid" src="https://github.com/user-attachments/assets/8115a46a-53a2-4d5a-837f-98b09a1f81d9" />

 ### Database changes

  One migration: `20260513100000_add_github_app_and_nullabl  e_smithery_fields`.

  **`User` table — new column**
  - `githubAppInstallationId String?` — stores the GitHub
  App installation id returned by GitHub's callback after a   user installs the App. Nullable because most users won't   have GitHub connected. One installation per user
  (re-installing on github.com overwrites). Cleared by
  `DELETE /api/mcp/connect/github` ("Uninstall app
  entirely").

  **`ChatMcpServer` table — relaxed NOT NULL on two
  columns**
  - `smitheryConnectionId` → `String?` (was `String`)
  - `smitheryNamespace` → `String?` (was `String`)

  Both were required for Smithery rows but make no sense
  for a GitHub row (GitHub talks directly to
  `api.githubcopilot.com/mcp`, not through Smithery's
  connect proxy). Dropping `NOT NULL` lets us reuse the
  same table for both kinds of MCP servers without a
  discriminator column or a second table. The row type is
  implied by `qualifiedName`:
  - `qualifiedName === "github/github"` → GitHub row, both
  Smithery fields are `null`, `encryptedApiKey` is `null`
  (token minted at turn time)
  - otherwise → Smithery row, both fields are populated and   `encryptedApiKey` is set

  **Migration SQL (idempotent):**

  ```sql
  ALTER TABLE "User" ADD COLUMN IF NOT EXISTS
  "githubAppInstallationId" TEXT;
  ALTER TABLE "ChatMcpServer" ALTER COLUMN
  "smitheryConnectionId" DROP NOT NULL;
  ALTER TABLE "ChatMcpServer" ALTER COLUMN
  "smitheryNamespace" DROP NOT NULL;
  ```

  `ADD COLUMN IF NOT EXISTS` guards against re-running on
  databases where the column already exists from an earlier   branch; `DROP NOT NULL` is naturally idempotent in
  Postgres. Safe to apply repeatedly.

  **What is NOT stored**
  - GitHub installation **access tokens** are never
  persisted — they expire in 1 hour and are minted fresh
  inside `loadChatMcpServers` on every turn (with a
  short-lived in-memory cache in `lib/github/app.ts`).
  - GitHub App **private key** lives in
  `GITHUB_APP_PRIVATE_KEY` env, never in the DB.


  ### Changes in this branch

  **New files**
  - `packages/web/lib/github/app.ts` — JWT signing,
  installation-token mint + in-memory cache with 5-min
  refresh slack, `invalidateInstallationToken`,
  `getInstallUrl`
  - `packages/web/app/api/mcp/connect/github/route.ts` —
  `GET` status / `DELETE` clear installationId and drop all   `github/github` rows
  - `packages/web/app/api/mcp/connect/github/callback/route  .ts` — saves `installation_id` and `postMessage`s the
  opener
  - `packages/web/app/api/chats/[chatId]/mcp-servers/github  /route.ts` — `POST` to add the sentinel row to a chat
  - `packages/web/prisma/migrations/20260513100000_add_gith  ub_app_and_nullable_smithery_fields/migration.sql` — adds   `githubAppInstallationId`, makes Smithery columns
  nullable (`IF NOT EXISTS` / `DROP NOT NULL` for
  idempotency)

  **Modified**
  - `packages/web/prisma/schema.prisma` —
  `User.githubAppInstallationId?`, nullable
  `ChatMcpServer.smitheryConnectionId?` /
  `smitheryNamespace?`
  - `packages/web/lib/mcp/agent-servers.ts` — branches on
  `qualifiedName === "github/github"`; pulls
  `chat.user.githubAppInstallationId` in the same query and   mints token there
  - `packages/web/app/api/mcp-registry/route.ts` —
  `.filter((s) => !/github/i.test(s.qualifiedName))` so
  Smithery's GitHub entries don't show up in search
  - `packages/web/components/modals/McpServersModal.tsx` —
  Featured tile + gear/settings dropdown (Radix
  `DropdownMenu`) on the connected GitHub row
  - `packages/agent-configuration/src/mcp/index.ts` — three   correctness fixes:
    1. `generateMcpConfigForAgent` no longer short-circuits   on empty servers
    2. `setupMcpForAgent` always writes (so
  disconnect-the-last-server actually clears the on-disk
  config in a reused sandbox)
    3. `mergeJsonConfig` replaces `mcpServers` / `mcp`
  sections **wholesale** instead of shallow-merging (a
  shallow merge was leaving removed entries on disk)
  - `packages/web/lib/agent-session.ts` — drop the
  `mcpServers.length > 0` gate before `setupMcpForAgent`;
  empty list must still trigger the writer for the same
  reason
  
  ### Setup

  **New environment variables (web package):**

  ```
  GITHUB_APP_ID=<numeric app id>
  GITHUB_APP_SLUG=<app slug used in install URL>
  GITHUB_APP_PRIVATE_KEY=<PEM contents, newlines preserved>  ```

  **GitHub App configuration (one-time, on github.com):**
  - Create a new GitHub App
  - Set callback URL →
  `<your-host>/api/mcp/connect/github/callback`
  - Permissions per GitHub MCP server requirements
  (Contents, Issues, Pull requests, Metadata, etc.)
  - Generate a private key, paste contents into
  `GITHUB_APP_PRIVATE_KEY`
  - Note the App ID and slug

  **Database:**

  ```bash
  npx prisma migrate deploy
  ```

  The migration is idempotent (`ADD COLUMN IF NOT EXISTS`,
  `DROP NOT NULL`), safe to re-run.

  **Smithery setup** is unchanged from the prior PR —
  `SMITHERY_API_KEY` still required.

  ### Test plan

  - [ ] Install the GitHub App via the Featured tile →
  callback closes popup → modal shows "Connected"
  - [ ] Add to chat → row appears in Connected tab with
  gear icon
  - [ ] Start an agent turn → agent has GitHub tools
  available (try "list my repos")
  - [ ] Delete the row (trash) → new agent turn must NOT
  have GitHub tools
  - [ ] Click gear → "Manage repositories" opens
  github.com/settings/installations/`<id>`
  - [ ] Click gear → "Uninstall app entirely" → row
  disappears across every chat, status flips to "Connect"
  - [ ] Smithery search for "github" → no results (filtered   out)
  - [ ] Each agent (claude-code, codex, gemini, opencode,
  goose) sees the GitHub MCP after add and loses it after
  delete

