### PR TITLE
fix/gemini-trust-issue

### DIFF
--- a/packages/agents/src/agents/gemini/index.ts
+++ b/packages/agents/src/agents/gemini/index.ts
@@ -35,6 +35,10 @@ export const geminiAgent: AgentDefinition = {
 
     // Enable full tool access (shell, file writes, etc.) - safe in sandbox environment
     args.push("--yolo")
+    
+    // Skip trust checks since we're in a controlled environment
+    args.push("--skip-trust")             
+                                      
 
     // Add model if specified (e.g., "gemini-2.0-flash", "gemini-1.5-pro")
     if (options.model) {


### PR DESCRIPTION
## Summary

- Add `--skip-trust` argument to the Gemini agent CLI invocation in `packages/agents/src/agents/gemini/index.ts` to bypass trust prompts in our controlled sandbox environment.
- Pairs with the existing `--yolo` flag so Gemini runs non-interactively without blocking on trust confirmations.

## Test plan

- [ ] Run a Gemini agent task end-to-end and confirm it starts without prompting for trust.
- [ ] Verify `--yolo` behavior (tool access) is unchanged.
