### PR TITLE
Feat/MCP Configuration on new chats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7685,6 +7685,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -155,6 +155,7 @@ function HomePageContent({ isMobile }: HomePageContentProps) {
     draftChatConfig,
     isDraftChatId,
     updateDraftChatConfig,
+    materializeDraft,
     setOnConflictStateChange,
     limitReachedState,
     setLimitReachedState,
@@ -362,6 +363,16 @@ function HomePageContent({ isMobile }: HomePageContentProps) {
       })
     }
   }, [currentChatId, isDraftChatId, chats])
+
+  // Materialize the draft chat when the MCP modal needs to commit a change.
+  // Returns the real chatId, or null if materialization failed.
+  const handleMaterializeDraftForMcp = useCallback(
+    async (draftId: string): Promise<string | null> => {
+      const materialized = await materializeDraft(draftId)
+      return materialized?.id ?? null
+    },
+    [materializeDraft]
+  )
 
   // Auto-enter draft mode if user is authenticated but has no chat selected.
   // This replaces the old auto-create behavior - now we just enter draft mode
@@ -1056,7 +1067,7 @@ function HomePageContent({ isMobile }: HomePageContentProps) {
       onCopyCloneCommand={currentChat?.repo && currentChat.repo !== NEW_REPOSITORY ? handleCopyCloneCommand : undefined}
       onCopyCheckoutCommand={currentChat?.branch ? handleCopyCheckoutCommand : undefined}
       onOpenEnvVars={currentChat ? handleOpenEnvVars : undefined}
-      onOpenMcpServers={currentChat ? () => modals.setMcpServersModalOpen(true) : undefined}
+      onOpenMcpServers={displayCurrentChatId && session ? () => modals.setMcpServersModalOpen(true) : undefined}
       onOpenSkills={
         currentChat?.sandboxId && currentChat.repo !== NEW_REPOSITORY
           ? () => setSkillsModalOpen(true)
@@ -1263,6 +1274,8 @@ function HomePageContent({ isMobile }: HomePageContentProps) {
             open={modals.mcpServersModalOpen}
             onClose={() => modals.setMcpServersModalOpen(false)}
             chatId={displayCurrentChatId}
+            isDraftChat={isDraftChatId(displayCurrentChatId)}
+            onMaterializeDraft={handleMaterializeDraftForMcp}
           />
         )}
 

--- a/packages/web/components/modals/McpServersModal.tsx
+++ b/packages/web/components/modals/McpServersModal.tsx
@@ -66,6 +66,10 @@ interface McpServersModalProps {
   open: boolean
   onClose: () => void
   chatId: string
+  /** True when chatId is a not-yet-persisted draft id (e.g. "draft-..."). */
+  isDraftChat: boolean
+  /** Persists the draft chat to the DB and returns the real chatId. */
+  onMaterializeDraft: (draftId: string) => Promise<string | null>
 }
 
 /** Sentinel used by the server-side ChatMcpServer row for the GitHub MCP. */
@@ -79,8 +83,33 @@ export function McpServersModal({
   open,
   onClose,
   chatId,
+  isDraftChat,
+  onMaterializeDraft,
 }: McpServersModalProps) {
   const [tab, setTab] = useState<TabKey>("connected")
+
+  // Effective chat id used for all chat-scoped API calls. Starts as the
+  // (possibly draft) chatId and is replaced with the real id once we
+  // materialize on first commit.
+  const [effectiveChatId, setEffectiveChatId] = useState(chatId)
+  const [isDraft, setIsDraft] = useState(isDraftChat)
+
+  // Re-sync local state whenever the prop changes (e.g., switching chats).
+  useEffect(() => {
+    setEffectiveChatId(chatId)
+    setIsDraft(isDraftChat)
+  }, [chatId, isDraftChat])
+
+  // Materialize the draft on demand. Returns the real chatId for the caller
+  // to use in its API call. Returns null if materialization failed.
+  const resolveChatId = useCallback(async (): Promise<string | null> => {
+    if (!isDraft) return effectiveChatId
+    const realId = await onMaterializeDraft(effectiveChatId)
+    if (!realId) return null
+    setEffectiveChatId(realId)
+    setIsDraft(false)
+    return realId
+  }, [isDraft, effectiveChatId, onMaterializeDraft])
 
   // Connected list
   const [connected, setConnected] = useState<ConnectedServer[]>([])
@@ -115,10 +144,13 @@ export function McpServersModal({
   // Fetchers
   // =============================================================================
 
-  const loadConnected = useCallback(async () => {
+  // Fetch connected servers for an explicit chat id. Used by handlers that
+  // just materialized a draft and need to reload before React re-renders
+  // with the new state.
+  const loadConnectedFor = useCallback(async (id: string) => {
     setLoadingConnected(true)
     try {
-      const res = await fetch(`/api/chats/${chatId}/mcp-servers`)
+      const res = await fetch(`/api/chats/${id}/mcp-servers`)
       if (res.ok) {
         const data = await res.json()
         setConnected(data.servers || [])
@@ -128,7 +160,17 @@ export function McpServersModal({
     } finally {
       setLoadingConnected(false)
     }
-  }, [chatId])
+  }, [])
+
+  const loadConnected = useCallback(async () => {
+    // Drafts have no row in the DB yet — skip the fetch and show the empty
+    // state. Once the user connects something we materialize and reload.
+    if (isDraft) {
+      setConnected([])
+      return
+    }
+    await loadConnectedFor(effectiveChatId)
+  }, [isDraft, effectiveChatId, loadConnectedFor])
 
   const loadRegistry = useCallback(
     async (q: string, p: number, append: boolean) => {
@@ -201,10 +243,12 @@ export function McpServersModal({
 
   async function handleDisconnect(serverId: string) {
     if (deletingId) return
+    // No connected rows can exist on a draft, so disconnect is a no-op there.
+    if (isDraft) return
     setDeletingId(serverId)
     try {
       const res = await fetch(
-        `/api/chats/${chatId}/mcp-servers/${serverId}`,
+        `/api/chats/${effectiveChatId}/mcp-servers/${serverId}`,
         { method: "DELETE" }
       )
       if (res.ok) {
@@ -217,10 +261,12 @@ export function McpServersModal({
 
   /** Add the GitHub MCP sentinel row to this chat. */
   async function addGithubToChat() {
-    const res = await fetch(`/api/chats/${chatId}/mcp-servers/github`, {
+    const id = await resolveChatId()
+    if (!id) return
+    const res = await fetch(`/api/chats/${id}/mcp-servers/github`, {
       method: "POST",
     })
-    if (res.ok) await loadConnected()
+    if (res.ok) await loadConnectedFor(id)
   }
 
   /**
@@ -318,7 +364,14 @@ export function McpServersModal({
         if (!url) throw new Error("Server does not expose a remote URL")
       }
 
-      const res = await fetch(`/api/chats/${chatId}/mcp-servers`, {
+      // Resolve the real chat id (materializes draft on first connect).
+      const id = await resolveChatId()
+      if (!id) {
+        setConnectingSlug(null)
+        return
+      }
+
+      const res = await fetch(`/api/chats/${id}/mcp-servers`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -334,7 +387,7 @@ export function McpServersModal({
       // Instant-connect (authless server) — refresh list, switch tab, done.
       if (data.connected) {
         setConnectingSlug(null)
-        await loadConnected()
+        await loadConnectedFor(id)
         setTab("connected")
         return
       }
@@ -360,14 +413,14 @@ export function McpServersModal({
         }
         try {
           await fetch(
-            `/api/chats/${chatId}/mcp-servers/${data.serverId}/smithery-finalize`,
+            `/api/chats/${id}/mcp-servers/${data.serverId}/smithery-finalize`,
             { method: "POST" }
           )
         } catch (err) {
           console.error("[McpServersModal] finalize failed:", err)
         }
         setConnectingSlug(null)
-        await loadConnected()
+        await loadConnectedFor(id)
         setTab("connected")
       }, 500)
     } catch (err) {

--- a/packages/web/lib/hooks/useChatWithSync.ts
+++ b/packages/web/lib/hooks/useChatWithSync.ts
@@ -968,6 +968,7 @@ export function useChatWithSync() {
     draftChatConfig,
     isDraftChatId,
     updateDraftChatConfig,
+    materializeDraft,
     // Conflict state callback
     setOnConflictStateChange,
     // Daily limit reached


### PR DESCRIPTION
## Allow MCP server configuration on new chats

  ### Summary  Previously the **MCP servers** option in the command palette was gated on `currentChat`, so it only
  appeared after a chat had been persisted (i.e. after the first message was sent). Users couldn't  connect MCP servers up front, which meant the first message ran without any MCP tools — even if the
  user intended to use them.

  This PR lets users connect MCP servers from a brand-new (draft) chat, so connections are active from
  the very first message.

  ### Approach
  Materialize the draft chat **lazily** — only when the user actually clicks **Connect**, not when they
  merely open the modal. Browsing the registry doesn't touch the DB.

  - `packages/web/lib/hooks/useChatWithSync.ts` — expose `materializeDraft` from the hook.
  - `packages/web/app/page.tsx`
    - Pass `isDraftChat` + `onMaterializeDraft` into `McpServersModal`.
    - Palette gate: `displayCurrentChatId && session` (also hides the option for unauthenticated users,
  who can't create chats).
  - `packages/web/components/modals/McpServersModal.tsx`
    - Track an `effectiveChatId` locally; `resolveChatId()` returns it, or materializes the draft and
  returns the new real id.
    - `loadConnected` short-circuits to an empty list for drafts (no row exists yet).
    - `handleConnect` / `addGithubToChat` materialize on demand and use the resolved id for the POST and
  for the smithery-finalize callback after the OAuth popup closes.
    - Added a `loadConnectedFor(id)` helper so the post-materialize refresh uses the freshly-resolved id
  rather than a stale closure.

  ### What this avoids
  - **No orphan chat rows** from users who open MCP but never commit — the chat is only persisted if they   click Connect.
  - **No silent side effect** from opening a settings modal — DB writes are tied to an explicit user
  action.
  - **Unauthenticated users don't see a non-functional MCP option** — gated at the palette level.

  ### Test plan
  - [ ] Sign in → start a brand new chat (no message yet) → open command palette → **MCP servers** is
  visible.
  - [ ] In a draft chat, open MCP → Connected tab shows the empty state with no network errors; Browse
  tab loads the registry.
  - [ ] Close the modal without connecting anything → no new chat row in the sidebar / DB.
  - [ ] In a draft chat, click **Connect** on a server → draft is persisted, connection appears in
  Connected tab, sidebar shows the new chat.
  - [ ] In a draft chat, click **Connect** on the featured GitHub row (with and without the GitHub App
  already installed) → draft persists, GitHub MCP attached.
  - [ ] Connect a server requiring OAuth in a draft chat → popup opens, after closing the connection
  finalizes against the real chat id (not the draft id).
  - [ ] Send a first message in that chat → the agent has access to the MCP tools configured pre-send.
  - [ ] Sign out → start app → MCP servers option does **not** appear in the palette.
  - [ ] Existing real chats: open MCP, connect/disconnect → unchanged behavior.