### PR TITLE
Agent Skills Spec Compliance

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -19,6 +19,7 @@ export {
   buildSystemPrompt,
   buildContentBlocks,
   type BuildContentBlocksResult,
+  type SkillCatalogEntry,
 } from "./session"
 
 // Agent configuration

--- a/packages/common/src/session.ts
+++ b/packages/common/src/session.ts
@@ -34,9 +34,17 @@ function mapToolName(sdkTool: string): string {
 // System Prompt Builder
 // =============================================================================
 
+export interface SkillCatalogEntry {
+  name: string
+  description: string
+  /** Absolute path to SKILL.md inside the sandbox */
+  location: string
+}
+
 export function buildSystemPrompt(
   repoPath: string,
-  previewUrlPattern?: string
+  previewUrlPattern?: string,
+  skills?: SkillCatalogEntry[]
 ): string {
   let prompt = `You are an AI coding agent running in a Daytona sandbox.
 The repository is cloned at ${repoPath}.
@@ -52,12 +60,30 @@ The repository is cloned at ${repoPath}.
 
 ## File Operations
 - Use ${repoPath} for all file operations.
-- Always check the current state of files before editing them.
+- Always check the current state of files before editing them.`
+
+  if (skills && skills.length > 0) {
+    const catalog = skills
+      .map(
+        (s) =>
+          `  <skill>\n    <name>${s.name}</name>\n    <description>${s.description}</description>\n    <location>${s.location}</location>\n  </skill>`
+      )
+      .join("\n")
+
+    prompt += `
 
 ## Agent Skills
-- You may have "skills" (custom instructions, guidelines, and rules) installed in the repository.
-- To check what skills are installed and what they do, look inside the ${repoPath}/.agents/skills/ directory.
-- Always adhere to any instructions defined in these skills.
+The following skills provide specialized instructions for specific tasks.
+When a task matches a skill's description, read the full SKILL.md at the listed
+location before proceeding. Resolve any relative paths in the skill against its
+directory (the parent folder of SKILL.md).
+
+<available_skills>
+${catalog}
+</available_skills>`
+  }
+
+  prompt += `
 
 ## Logs Directory
 - Write any log files to ${PATHS.LOGS_DIR}.

--- a/packages/common/tests/session.test.ts
+++ b/packages/common/tests/session.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Unit tests for buildSystemPrompt.
+ *
+ * Pure function — no mocks needed.
+ */
+import { describe, it, expect } from "vitest"
+import { buildSystemPrompt } from "../src/session"
+import type { SkillCatalogEntry } from "../src/session"
+
+describe("buildSystemPrompt", () => {
+  const repoPath = "/home/daytona/project"
+
+  it("includes the repo path", () => {
+    const prompt = buildSystemPrompt(repoPath)
+    expect(prompt).toContain(repoPath)
+  })
+
+  it("omits the Agent Skills section when no skills are provided", () => {
+    const prompt = buildSystemPrompt(repoPath)
+    expect(prompt).not.toContain("Agent Skills")
+    expect(prompt).not.toContain("<available_skills>")
+  })
+
+  it("omits the Agent Skills section when skills array is empty", () => {
+    const prompt = buildSystemPrompt(repoPath, undefined, [])
+    expect(prompt).not.toContain("Agent Skills")
+    expect(prompt).not.toContain("<available_skills>")
+  })
+
+  it("injects <available_skills> catalog when skills are provided", () => {
+    const skills: SkillCatalogEntry[] = [
+      {
+        name: "react-best-practices",
+        description: "Enforces React patterns. Use when writing React components.",
+        location: `${repoPath}/.agents/skills/react-best-practices/SKILL.md`,
+      },
+    ]
+
+    const prompt = buildSystemPrompt(repoPath, undefined, skills)
+    expect(prompt).toContain("## Agent Skills")
+    expect(prompt).toContain("<available_skills>")
+    expect(prompt).toContain("<name>react-best-practices</name>")
+    expect(prompt).toContain("<description>Enforces React patterns. Use when writing React components.</description>")
+    expect(prompt).toContain(`<location>${repoPath}/.agents/skills/react-best-practices/SKILL.md</location>`)
+    expect(prompt).toContain("</available_skills>")
+  })
+
+  it("includes all skills in the catalog", () => {
+    const skills: SkillCatalogEntry[] = [
+      {
+        name: "react-best-practices",
+        description: "Enforces React patterns.",
+        location: `${repoPath}/.agents/skills/react-best-practices/SKILL.md`,
+      },
+      {
+        name: "code-review",
+        description: "Reviews code for bugs and style.",
+        location: `${repoPath}/.agents/skills/code-review/SKILL.md`,
+      },
+    ]
+
+    const prompt = buildSystemPrompt(repoPath, undefined, skills)
+    expect(prompt).toContain("<name>react-best-practices</name>")
+    expect(prompt).toContain("<name>code-review</name>")
+  })
+
+  it("includes the preview URL section when a pattern is provided", () => {
+    const prompt = buildSystemPrompt(repoPath, "https://preview.example.com/{port}")
+    expect(prompt).toContain("preview URL")
+    expect(prompt).toContain("https://preview.example.com/{port}")
+  })
+
+  it("omits the preview URL section when no pattern is provided", () => {
+    const prompt = buildSystemPrompt(repoPath)
+    expect(prompt).not.toContain("preview URL")
+  })
+
+  it("includes both skills catalog and preview URL when both are provided", () => {
+    const skills: SkillCatalogEntry[] = [
+      {
+        name: "my-skill",
+        description: "Does something.",
+        location: `${repoPath}/.agents/skills/my-skill/SKILL.md`,
+      },
+    ]
+
+    const prompt = buildSystemPrompt(repoPath, "https://preview.example.com/{port}", skills)
+    expect(prompt).toContain("<available_skills>")
+    expect(prompt).toContain("preview URL")
+  })
+
+  it("includes git rules", () => {
+    const prompt = buildSystemPrompt(repoPath)
+    expect(prompt).toContain("## Git Rules")
+    expect(prompt).toContain("Do not push")
+  })
+
+  it("always includes the logs directory section", () => {
+    const prompt = buildSystemPrompt(repoPath)
+    expect(prompt).toContain("## Logs Directory")
+  })
+})

--- a/packages/skills/src/index.ts
+++ b/packages/skills/src/index.ts
@@ -32,6 +32,7 @@ export type {
   SkillInstallResult,
   SkillsInstallResult,
   SkillRecord,
+  DiscoveredSkill,
 } from "./types"
 
 // Registry client
@@ -45,6 +46,7 @@ export {
   parseSkillHandle,
   uninstallSkill,
   getSkillNameFromHandle,
+  discoverInstalledSkills,
   type OnSkillRemove,
 } from "./sandbox"
 

--- a/packages/skills/src/sandbox/discover.ts
+++ b/packages/skills/src/sandbox/discover.ts
@@ -1,0 +1,123 @@
+/**
+ * Discover installed skills by scanning .agents/skills/ in the sandbox.
+ *
+ * Reads each SKILL.md file, extracts the name and description from YAML
+ * frontmatter, and returns a lightweight catalog for the system prompt.
+ */
+
+import type { Sandbox } from "@daytonaio/sdk"
+import type { DiscoveredSkill } from "../types"
+
+/**
+ * Parse YAML frontmatter from a SKILL.md file content.
+ *
+ * Extracts name and description from the block between leading `---` markers.
+ * No external YAML parser — uses simple line-by-line parsing which is
+ * sufficient for the flat key/value pairs defined in the spec.
+ *
+ * Returns null if the frontmatter is missing or description is absent
+ * (per spec: skills without a description must be skipped).
+ */
+function parseFrontmatter(
+  content: string
+): { name: string; description: string } | null {
+  const lines = content.split("\n")
+
+  // Must start with ---
+  if (lines[0]?.trim() !== "---") return null
+
+  // Find closing ---
+  let closeIdx = -1
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i]?.trim() === "---") {
+      closeIdx = i
+      break
+    }
+  }
+  if (closeIdx === -1) return null
+
+  const frontmatterLines = lines.slice(1, closeIdx)
+
+  let name = ""
+  let description = ""
+
+  for (const line of frontmatterLines) {
+    // Simple key: value parsing — handles the required fields only
+    const match = line.match(/^(\w[\w-]*):\s*(.+)$/)
+    if (!match) continue
+    const key = match[1]
+    const value = match[2].trim().replace(/^["']|["']$/g, "") // strip optional quotes
+    if (key === "name") name = value
+    if (key === "description") description = value
+  }
+
+  if (!description) return null // spec: skip if no description
+
+  return { name: name || "", description }
+}
+
+/**
+ * Scan .agents/skills/ in the sandbox and return discovered skills.
+ *
+ * Each skill directory must contain a SKILL.md file. Only skills with a
+ * valid name and description are returned; others are silently skipped.
+ *
+ * @param sandbox - Daytona sandbox instance
+ * @param repoPath - Absolute path to the repository in the sandbox
+ * @returns Array of discovered skills (empty if none installed)
+ */
+export async function discoverInstalledSkills(
+  sandbox: Sandbox,
+  repoPath: string
+): Promise<DiscoveredSkill[]> {
+  const skillsDir = `${repoPath}/.agents/skills`
+
+  // Find all SKILL.md files up to 3 levels deep (skill-name/SKILL.md)
+  let findOutput: string
+  try {
+    const cmd = await sandbox.process.executeCommand(
+      `find ${skillsDir} -maxdepth 3 -name "SKILL.md" 2>/dev/null`
+    )
+    findOutput = cmd.result?.trim() ?? ""
+  } catch {
+    // .agents/skills doesn't exist — no skills installed
+    return []
+  }
+
+  if (!findOutput) return []
+
+  const skillPaths = findOutput.split("\n").filter(Boolean)
+  const discovered: DiscoveredSkill[] = []
+
+  for (const skillMdPath of skillPaths) {
+    try {
+      const cmd = await sandbox.process.executeCommand(
+        `cat "${skillMdPath}" 2>/dev/null`
+      )
+      const content = cmd.result ?? ""
+      if (!content.trim()) continue
+
+      const parsed = parseFrontmatter(content)
+      if (!parsed) {
+        console.warn(`[skills/discover] Skipping ${skillMdPath}: missing or invalid frontmatter`)
+        continue
+      }
+      if (!parsed.description) {
+        console.warn(`[skills/discover] Skipping ${skillMdPath}: missing description`)
+        continue
+      }
+
+      // Use directory name as fallback name if frontmatter name is empty
+      const dirName = skillMdPath.split("/").slice(-2, -1)[0] ?? ""
+      discovered.push({
+        name: parsed.name || dirName,
+        description: parsed.description,
+        location: skillMdPath,
+      })
+    } catch (err) {
+      console.warn(`[skills/discover] Failed to read ${skillMdPath}:`, err)
+    }
+  }
+
+  return discovered
+}

--- a/packages/skills/src/sandbox/index.ts
+++ b/packages/skills/src/sandbox/index.ts
@@ -10,3 +10,4 @@ export {
   type OnSkillRemove,
 } from "./install"
 export { uninstallSkill, getSkillNameFromHandle } from "./uninstall"
+export { discoverInstalledSkills } from "./discover"

--- a/packages/skills/src/types.ts
+++ b/packages/skills/src/types.ts
@@ -68,3 +68,14 @@ export interface SkillRecord {
   id: string
   fullHandle: string
 }
+
+/**
+ * A skill discovered by scanning .agents/skills/ inside the sandbox.
+ * Contains only the metadata needed for the system prompt catalog.
+ */
+export interface DiscoveredSkill {
+  name: string
+  description: string
+  /** Absolute path to SKILL.md inside the sandbox */
+  location: string
+}

--- a/packages/skills/tests/sandbox/discover.test.ts
+++ b/packages/skills/tests/sandbox/discover.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for discoverInstalledSkills.
+ *
+ * These are pure unit tests — no real sandbox. We mock
+ * sandbox.process.executeCommand to simulate the filesystem responses.
+ */
+import { describe, it, expect, vi } from "vitest"
+import { discoverInstalledSkills } from "../../src/sandbox/discover"
+import type { Sandbox } from "@daytonaio/sdk"
+
+// Helper: build a minimal sandbox mock
+function makeSandbox(responses: Record<string, string>): Sandbox {
+  return {
+    process: {
+      executeCommand: vi.fn(async (cmd: string) => {
+        for (const [pattern, result] of Object.entries(responses)) {
+          if (cmd.includes(pattern)) {
+            return { exitCode: 0, result }
+          }
+        }
+        return { exitCode: 0, result: "" }
+      }),
+    },
+  } as unknown as Sandbox
+}
+
+const SKILL_MD_VALID = `---
+name: react-best-practices
+description: Enforces React patterns and hooks conventions. Use when writing React components.
+license: MIT
+---
+# React Best Practices
+
+Follow these rules when writing React code.
+`
+
+const SKILL_MD_NO_DESCRIPTION = `---
+name: broken-skill
+---
+# No description here
+`
+
+const SKILL_MD_NO_FRONTMATTER = `# Just plain markdown
+
+No frontmatter at all.
+`
+
+const SKILL_MD_QUOTED_VALUES = `---
+name: code-review
+description: "Reviews code for bugs and style. Use when asked to review a PR."
+---
+Body here.
+`
+
+describe("discoverInstalledSkills", () => {
+  it("returns empty array when .agents/skills does not exist", async () => {
+    const sandbox = {
+      process: {
+        executeCommand: vi.fn(async () => {
+          throw new Error("No such file or directory")
+        }),
+      },
+    } as unknown as Sandbox
+
+    const result = await discoverInstalledSkills(sandbox, "/repo")
+    expect(result).toEqual([])
+  })
+
+  it("returns empty array when find returns no SKILL.md files", async () => {
+    const sandbox = makeSandbox({ "find": "" })
+    const result = await discoverInstalledSkills(sandbox, "/repo")
+    expect(result).toEqual([])
+  })
+
+  it("parses a valid SKILL.md and returns name, description, location", async () => {
+    const sandbox = makeSandbox({
+      "find": "/repo/.agents/skills/react-best-practices/SKILL.md",
+      "SKILL.md": SKILL_MD_VALID,
+    })
+
+    const result = await discoverInstalledSkills(sandbox, "/repo")
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual({
+      name: "react-best-practices",
+      description: "Enforces React patterns and hooks conventions. Use when writing React components.",
+      location: "/repo/.agents/skills/react-best-practices/SKILL.md",
+    })
+  })
+
+  it("strips quotes from frontmatter values", async () => {
+    const sandbox = makeSandbox({
+      "find": "/repo/.agents/skills/code-review/SKILL.md",
+      "SKILL.md": SKILL_MD_QUOTED_VALUES,
+    })
+
+    const result = await discoverInstalledSkills(sandbox, "/repo")
+    expect(result[0]?.description).toBe("Reviews code for bugs and style. Use when asked to review a PR.")
+  })
+
+  it("skips a skill with missing description", async () => {
+    const sandbox = makeSandbox({
+      "find": "/repo/.agents/skills/broken-skill/SKILL.md",
+      "SKILL.md": SKILL_MD_NO_DESCRIPTION,
+    })
+
+    const result = await discoverInstalledSkills(sandbox, "/repo")
+    expect(result).toHaveLength(0)
+  })
+
+  it("skips a skill with no frontmatter at all", async () => {
+    const sandbox = makeSandbox({
+      "find": "/repo/.agents/skills/plain-skill/SKILL.md",
+      "SKILL.md": SKILL_MD_NO_FRONTMATTER,
+    })
+
+    const result = await discoverInstalledSkills(sandbox, "/repo")
+    expect(result).toHaveLength(0)
+  })
+
+  it("uses directory name as fallback when frontmatter name is empty", async () => {
+    const noNameSkill = `---
+description: Does something useful.
+---
+Body.
+`
+    const sandbox = makeSandbox({
+      "find": "/repo/.agents/skills/my-skill/SKILL.md",
+      "SKILL.md": noNameSkill,
+    })
+
+    const result = await discoverInstalledSkills(sandbox, "/repo")
+    expect(result).toHaveLength(1)
+    expect(result[0]?.name).toBe("my-skill")
+  })
+
+  it("handles multiple skills and skips invalid ones", async () => {
+    const sandbox = {
+      process: {
+        executeCommand: vi.fn(async (cmd: string) => {
+          if (cmd.includes("find")) {
+            return {
+              exitCode: 0,
+              result: [
+                "/repo/.agents/skills/react-best-practices/SKILL.md",
+                "/repo/.agents/skills/broken-skill/SKILL.md",
+              ].join("\n"),
+            }
+          }
+          if (cmd.includes("react-best-practices")) {
+            return { exitCode: 0, result: SKILL_MD_VALID }
+          }
+          if (cmd.includes("broken-skill")) {
+            return { exitCode: 0, result: SKILL_MD_NO_DESCRIPTION }
+          }
+          return { exitCode: 0, result: "" }
+        }),
+      },
+    } as unknown as Sandbox
+
+    const result = await discoverInstalledSkills(sandbox, "/repo")
+    expect(result).toHaveLength(1)
+    expect(result[0]?.name).toBe("react-best-practices")
+  })
+})

--- a/packages/web/app/api/chats/[chatId]/messages/route.ts
+++ b/packages/web/app/api/chats/[chatId]/messages/route.ts
@@ -28,8 +28,10 @@ import {
   deleteSandboxQuietly,
   ensureSandboxStarted,
   installSkillsForRepo,
+  discoverSkillsForRepo,
   uploadFilesToSandbox,
 } from "@/lib/sandbox"
+
 
 export const maxDuration = 300
 
@@ -485,6 +487,15 @@ export async function POST(
     // Debug: log planMode from payload
     console.log(`[messages route] payload.planMode=${payload.planMode}`)
 
+    // ── Stage 3b: discover installed skills ───────────────────────────────
+    // Scan .agents/skills/ to build the skill catalog for the system prompt.
+    // Runs on every message so the catalog stays current (e.g. skills added
+    // between turns or committed in the repo). Best-effort — never blocks.
+    let discoveredSkills: { name: string; description: string; location: string }[] = []
+    if (chat.repo !== NEW_REPOSITORY) {
+      discoveredSkills = await discoverSkillsForRepo(sandbox, repoPath)
+    }
+
     const bgSession = await createBackgroundAgentSession(sandbox, {
       repoPath,
       previewUrlPattern: previewUrlPattern ?? undefined,
@@ -495,6 +506,7 @@ export async function POST(
       env: Object.keys(env).length > 0 ? env : undefined,
       planMode: payload.planMode,
       mcpServers,
+      skills: discoveredSkills.length > 0 ? discoveredSkills : undefined,
     })
 
     // ── Stage 5: persist messages + chat status (transactional) ────────────

--- a/packages/web/lib/agent-session.ts
+++ b/packages/web/lib/agent-session.ts
@@ -16,6 +16,7 @@ import {
   type Agent,
   type ContentBlock,
   type ToolCall,
+  type SkillCatalogEntry,
 } from "@upstream/common"
 import {
   setupClaudeHooks,
@@ -74,6 +75,11 @@ export interface AgentSessionOptions {
   /** When true, agent should plan before acting */
   planMode?: boolean
   /**
+   * Discovered skills to inject as a structured catalog in the system prompt.
+   * Populated by scanning .agents/skills/ after install.
+   */
+  skills?: SkillCatalogEntry[]
+  /**
    * MCP servers to expose to the agent. The web layer fetches these from
    * `ChatMcpServer` and decrypts the per-row Smithery API key before passing
    * them in — this module stays generic and doesn't touch the DB.
@@ -101,7 +107,8 @@ export async function createBackgroundAgentSession(
 ): Promise<BackgroundAgentSession> {
   const systemPrompt = buildSystemPrompt(
     options.repoPath,
-    options.previewUrlPattern
+    options.previewUrlPattern,
+    options.skills
   )
 
   // Map agent type to SDK provider name
@@ -142,6 +149,9 @@ export async function createBackgroundAgentSession(
   if (agent === "opencode" && !options.planMode) {
     env.OPENCODE_PERMISSION = OPENCODE_PERMISSION_ENV
   }
+
+  // Debug: log the full assembled system prompt before sending to the LLM
+  console.log("[agent-session] System prompt:\n" + systemPrompt)
 
   const bgSession = await createSession(provider, {
     sandbox: sandbox as any,
@@ -268,7 +278,8 @@ export async function finalizeTurn(
   try {
     const systemPrompt = buildSystemPrompt(
       options.repoPath,
-      options.previewUrlPattern
+      options.previewUrlPattern,
+      options.skills
     )
     const bgSession = await getSession(backgroundSessionId, {
       sandbox: sandbox as any,
@@ -292,7 +303,8 @@ export async function cancelBackgroundAgent(
   try {
     const systemPrompt = buildSystemPrompt(
       options.repoPath,
-      options.previewUrlPattern
+      options.previewUrlPattern,
+      options.skills
     )
 
     const bgSession = await getSession(backgroundSessionId, {
@@ -320,7 +332,8 @@ export async function snapshotBackgroundAgent(
   try {
     const systemPrompt = buildSystemPrompt(
       options.repoPath,
-      options.previewUrlPattern
+      options.previewUrlPattern,
+      options.skills
     )
 
     const bgSession = await getSession(backgroundSessionId, {

--- a/packages/web/lib/sandbox.ts
+++ b/packages/web/lib/sandbox.ts
@@ -9,7 +9,7 @@
 import type { Daytona, Sandbox } from "@daytonaio/sdk"
 import { randomUUID } from "crypto"
 import { createSandboxGit } from "@upstream/daytona-git"
-import { installSkills } from "@upstream/skills/sandbox"
+import { installSkills, discoverInstalledSkills } from "@upstream/skills/sandbox"
 import { PATHS, SANDBOX_CONFIG } from "@/lib/constants"
 import { NEW_REPOSITORY } from "@/lib/types"
 import { prisma } from "@/lib/db/prisma"
@@ -284,6 +284,29 @@ export async function deleteSandboxQuietly(
 }
 
 /**
+ * Discover installed skills in a sandbox for a given repo path.
+ *
+ * Scans .agents/skills/ and parses SKILL.md frontmatter for each installed
+ * skill. Returns a catalog suitable for injection into the system prompt.
+ * Best-effort — returns an empty array on any error.
+ */
+export async function discoverSkillsForRepo(
+  sandbox: Awaited<ReturnType<Daytona["get"]>>,
+  repoPath: string
+): Promise<{ name: string; description: string; location: string }[]> {
+  try {
+    const skills = await discoverInstalledSkills(sandbox, repoPath)
+    if (skills.length > 0) {
+      console.log(`[sandbox] Discovered ${skills.length} skill(s) in ${repoPath}`)
+    }
+    return skills
+  } catch (err) {
+    console.error("[sandbox] discoverSkillsForRepo failed:", err)
+    return []
+  }
+}
+
+/**
  * Install all repo-scoped skills into a sandbox.
  *
  * Called during sandbox creation/restoration to ensure skills are present
@@ -296,6 +319,7 @@ export async function installSkillsForRepo(
   userId: string,
   repo: string
 ): Promise<{ installed: number; total: number }> {
+
   const skills = await prisma.skill.findMany({
     where: { userId, repo },
     orderBy: { createdAt: "asc" },


### PR DESCRIPTION
## Overview

Agents were previously told to "go check `.agents/skills/`" with no structured awareness of what skills were installed or when to use them. This led to skills being silently ignored — the agent had to waste tool calls discovering what existed, and often didn't bother.

This PR implements the client-side of the [Agent Skills specification](https://agentskills.io/client-implementation/adding-skills-support) — the same standard Claude Code, Codex, and OpenCode follow — giving agents a structured, lightweight catalog of installed skills at session start.

## What changed

**`@upstream/skills`**
- New `src/sandbox/discover.ts` — scans `.agents/skills/` in the sandbox via `find`, reads each `SKILL.md`, and extracts `name` and `description` from YAML frontmatter. No new dependencies. Lenient per spec: skips skills with missing description, falls back to directory name if `name` field is absent.
- New `DiscoveredSkill` type in `src/types.ts`, exported from the sandbox sub-path and package root.

**`@upstream/common`**
- `buildSystemPrompt` now accepts an optional `skills?` array.
- When skills are present, injects a structured `<available_skills>` XML catalog into the system prompt, matching the format the spec defines.
- When no skills are present, the Agent Skills section is **omitted entirely** — no wasted tokens, no vague instructions.
- Exported `SkillCatalogEntry` type.

**Web layer**
- `AgentSessionOptions` gains a `skills?` field, threaded through all four `buildSystemPrompt` call sites in `agent-session.ts`.
- New `discoverSkillsForRepo` wrapper in `lib/sandbox.ts`.
- `messages/route.ts` calls `discoverSkillsForRepo` before creating each background session — runs on every message so the catalog stays current regardless of when skills were installed.
- Added a full system prompt log right before the session is created, for debugging.

## What didn't change

Marketplace search, install/uninstall UI, DB persistence, auto-install on sandbox creation, stale skill pruning.

## Spec compliance

| Step | Status |
|------|--------|
| Step 1: Discover | ✅ |
| Step 2: Parse frontmatter | ✅ |
| Step 3: Disclose via `<available_skills>` | ✅ |
| Step 4: Activate (agent reads SKILL.md via its file-read tool) | ✅ delegated to agent |
| Step 5: Context management | — not applicable (agents manage their own context) |

Closes #114 