### PR TITLE
Add more keyboard shortcuts

### DIFF
--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -1219,6 +1219,24 @@ function HomePageContent({ isMobile }: HomePageContentProps) {
             }
           : undefined
       }
+      onToggleTerminal={
+        currentChat?.sandboxId
+          ? () => {
+              const existingTerminal = preview.previewItems.find((i) => i.type === "terminal")
+              if (existingTerminal) {
+                // Terminal exists — toggle pane visibility
+                if (preview.previewOpen) {
+                  preview.closePreview()
+                } else {
+                  preview.openPreview(existingTerminal)
+                }
+              } else {
+                // No terminal yet — create one and show it
+                preview.openPreview({ type: "terminal", id: `${currentChat.sandboxId}-1` })
+              }
+            }
+          : undefined
+      }
       servers={availableServers}
       onOpenServer={(port, url) => preview.openPreview({ type: "server", port, url })}
       onClosePreview={preview.previewOpen ? preview.closePreview : undefined}
@@ -1231,7 +1249,7 @@ function HomePageContent({ isMobile }: HomePageContentProps) {
       onOpenMcpServers={displayCurrentChatId && session ? () => modals.setMcpServersModalOpen(true) : undefined}
       onOpenSkills={
         currentChat?.sandboxId && currentChat.repo !== NEW_REPOSITORY
-          ? () => setSkillsModalOpen(true)
+          ? () => setSkillsModalOpen((prev) => !prev)
           : undefined
       }
       chatIds={displayChats.map((c) => c.id)}

--- a/packages/web/components/modals/HelpModal.tsx
+++ b/packages/web/components/modals/HelpModal.tsx
@@ -46,6 +46,11 @@ export function HelpModal({ open, onClose, isMobile = false }: HelpModalProps) {
               <ul className="space-y-1 text-muted-foreground">
                 <li><kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">⌘P</kbd> Search chats, repos, and branches</li>
                 <li><kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">⌘K</kbd> Command palette</li>
+                <li><kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">⌘B</kbd> Toggle sidebar</li>
+                <li><kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">⌘J</kbd> Toggle terminal</li>
+                <li><kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">⌘S</kbd> Skills</li>
+                <li><kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">⌘O</kbd> New chat</li>
+                <li><kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">⌘⇧O</kbd> Branch chat</li>
                 <li><kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">⌥↑/↓</kbd> Switch chats</li>
                 <li><kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">⌥Enter</kbd> or <kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">⇧Enter</kbd> Branch and send to a new chat</li>
               </ul>

--- a/packages/web/components/search-palette/PaletteProvider.tsx
+++ b/packages/web/components/search-palette/PaletteProvider.tsx
@@ -45,6 +45,7 @@ interface PaletteProviderProps {
   onDeleteChat?: () => void
   onOpenInVSCode?: () => void
   onOpenTerminal?: () => void
+  onToggleTerminal?: () => void
   servers?: Array<{ port: number; url: string }>
   onOpenServer?: (port: number, url: string) => void
   onClosePreview?: () => void
@@ -91,6 +92,7 @@ export function PaletteProvider({
   onDeleteChat,
   onOpenInVSCode,
   onOpenTerminal,
+  onToggleTerminal,
   servers,
   onOpenServer,
   onClosePreview,
@@ -158,6 +160,41 @@ export function PaletteProvider({
         return
       }
 
+      // Cmd/Ctrl + B for toggle sidebar
+      if ((e.metaKey || e.ctrlKey) && e.key === "b") {
+        e.preventDefault()
+        onToggleSidebar?.()
+        return
+      }
+
+      // Cmd/Ctrl + J for toggle terminal
+      if ((e.metaKey || e.ctrlKey) && e.key === "j") {
+        e.preventDefault()
+        onToggleTerminal?.()
+        return
+      }
+
+      // Cmd/Ctrl + S for skills screen
+      if ((e.metaKey || e.ctrlKey) && e.key === "s") {
+        e.preventDefault()
+        onOpenSkills?.()
+        return
+      }
+
+      // Cmd/Ctrl + Shift + O for branch chat
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === "O") {
+        e.preventDefault()
+        onBranchChat?.()
+        return
+      }
+
+      // Cmd/Ctrl + O for new chat (check after Shift+O to avoid conflict)
+      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key === "o") {
+        e.preventDefault()
+        onNewChat()
+        return
+      }
+
       // Alt/Option, Cmd/Meta, or Ctrl + Up/Down for chat navigation (works even in inputs)
       if ((e.altKey || e.metaKey || e.ctrlKey) && (e.key === "ArrowUp" || e.key === "ArrowDown")) {
         if (onNavigateChat) {
@@ -184,7 +221,7 @@ export function PaletteProvider({
 
     window.addEventListener("keydown", handleKeyDown)
     return () => window.removeEventListener("keydown", handleKeyDown)
-  }, [chatIds, currentChatIndex, onSelectChat, openSearch, openCommand, onNavigateChat])
+  }, [chatIds, currentChatIndex, onSelectChat, openSearch, openCommand, onNavigateChat, onToggleSidebar, onToggleTerminal, onOpenSkills, onNewChat, onBranchChat])
 
   return (
     <PaletteContext.Provider value={{ openSearch, openCommand }}>


### PR DESCRIPTION
## Description
This pull request introduces global keyboard shortcuts to streamline workspace navigation and improve productivity within the application interface. It hooks into the global event listener to handle layout toggles, screen states, and chat creation/navigation operations.

### Key Changes

* **Sidebar Toggle**: 
* Added `Cmd/Ctrl + B` mapping to toggle sidebar visibility.
* **Terminal Toggle**:
* Added `Cmd/Ctrl + J` mapping to dynamically open or toggle the preview panel's terminal instance.
* **Skills Screen**:
* Added `Cmd/Ctrl + S` mapping to toggle the skills modal state using a functional updater.
* **Chat Management**:
* `Cmd/Ctrl + O`: Instantiates a new chat session.
* `Cmd/Ctrl + Shift + O`: Triggers the chat branch mechanism.