### PR TITLE
Fix : Agent Timeout

### DIFF
--- a/packages/common/src/session.ts
+++ b/packages/common/src/session.ts
@@ -93,6 +93,12 @@ ${catalog}
 - Always start web servers using nohup to ensure they run in the background and persist.
 - Example: nohup npm start > server.log 2>&1 &
 
+## Running Long Commands
+- For any command that may take more than a few minutes (builds, dependency installs, full test suites, data migrations), run it in the background with nohup and redirect output to a log file instead of blocking on it in the foreground.
+- Example: nohup npm run build > ${PATHS.LOGS_DIR}/build.log 2>&1 &
+- Poll the log file to follow progress (e.g. tail -n 20 ${PATHS.LOGS_DIR}/build.log) and check whether the process is still running before moving on.
+- Backgrounding keeps your turn responsive and prevents a single long-blocking command from being interrupted.
+
 ## When Finished
 - Provide a clear summary of what you did.
 

--- a/packages/web/app/api/cron/agent-lifecycle/route.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/route.ts
@@ -28,7 +28,6 @@ export const maxDuration = 300
 // Timeouts
 // =============================================================================
 
-const INTERACTIVE_INACTIVITY_TIMEOUT =  10 // minutes
 const INTERACTIVE_HARD_TIMEOUT = 25 // minutes
 const SCHEDULED_HARD_TIMEOUT = 20 // minutes
 
@@ -183,7 +182,6 @@ export async function GET(req: Request) {
       results.monitoredInteractive++
 
       try {
-        const minutesSinceActive = differenceInMinutes(now, chat.lastActiveAt)
         // Get run start time from last assistant message (when agent started)
         const runStartedAt = chat.messages[0]?.createdAt ?? chat.lastActiveAt
         const totalMinutes = differenceInMinutes(now, runStartedAt)
@@ -192,14 +190,6 @@ export async function GET(req: Request) {
         if (totalMinutes > INTERACTIVE_HARD_TIMEOUT) {
           await stopAgent(chat.sandboxId!, chat.backgroundSessionId!, daytona)
           await markChatError(chat.id, "Run exceeded 25 minute limit")
-          results.timedOutInteractive++
-          continue
-        }
-
-        // Inactivity timeout: 10 minutes since browser activity
-        if (minutesSinceActive > INTERACTIVE_INACTIVITY_TIMEOUT) {
-          await stopAgent(chat.sandboxId!, chat.backgroundSessionId!, daytona)
-          await markChatError(chat.id, "No activity for 10 minutes")
           results.timedOutInteractive++
           continue
         }


### PR DESCRIPTION
## Summary

Interactive agent runs were killed after 10 minutes whenever a single command ran longer than that, such as a build, dependency install, test suite, or migration, even though the agent was actively working.

The cause was the `agent-lifecycle` cron's `INTERACTIVE_INACTIVITY_TIMEOUT`. It compared `now` against `chat.lastActiveAt`, but `lastActiveAt` is only written when the user sends a message and is never refreshed during a run.

As a result, any turn still working at the 10-minute mark was stopped with:

```txt
No activity for 10 minutes
```

After that, the sandbox auto-stopped.

## Changes

- **Remove the 10-minute inactivity timeout**  
  File: `packages/web/app/api/cron/agent-lifecycle/route.ts`

  Removed:
  - `INTERACTIVE_INACTIVITY_TIMEOUT`
  - Unused `minutesSinceActive`
  - The inactivity monitor block

  The 25-minute hard timeout still bounds interactive runs.

- **Add a "Running Long Commands" section to the agent system prompt**  
  File: `packages/common/src/session.ts`

  Added guidance instructing agents to background long-running commands with `nohup`, write output to a log file, and poll the log file for progress.

  Example:

  ```bash
  nohup <command> > <log-file> 2>&1 &
  ```

  This mirrors the existing "Running Web Servers" guidance.