### PR TITLE
Add Support for Kilo CLI Agent

### DIFF
--- a/packages/agents/scripts/generate-jsonl-references.ts
+++ b/packages/agents/scripts/generate-jsonl-references.ts
@@ -103,6 +103,12 @@ const providers: ProviderConfig[] = [
     model: "anthropic/claude-sonnet-4-6",
   },
   {
+    name: "kilo",
+    apiKeyEnvVar: "ANTHROPIC_API_KEY",
+    apiKey: ANTHROPIC_API_KEY,
+    model: "anthropic/claude-sonnet-4-6",
+  },
+  {
     name: "pi",
     apiKeyEnvVar: "ANTHROPIC_API_KEY",
     apiKey: ANTHROPIC_API_KEY,

--- a/packages/agents/src/agents/index.ts
+++ b/packages/agents/src/agents/index.ts
@@ -10,6 +10,7 @@ import { codexAgent } from "./codex/index"
 import { elizaAgent } from "./eliza/index"
 import { geminiAgent } from "./gemini/index"
 import { gooseAgent } from "./goose/index"
+import { kiloAgent } from "./kilo/index"
 import { opencodeAgent } from "./opencode/index"
 import { piAgent } from "./pi/index"
 
@@ -19,6 +20,7 @@ registry.register(codexAgent)
 registry.register(elizaAgent)
 registry.register(geminiAgent)
 registry.register(gooseAgent)
+registry.register(kiloAgent)
 registry.register(opencodeAgent)
 registry.register(piAgent)
 
@@ -28,6 +30,7 @@ export { codexAgent } from "./codex/index"
 export { elizaAgent } from "./eliza/index"
 export { geminiAgent } from "./gemini/index"
 export { gooseAgent } from "./goose/index"
+export { kiloAgent } from "./kilo/index"
 export { opencodeAgent } from "./opencode/index"
 export { piAgent } from "./pi/index"
 
@@ -37,6 +40,7 @@ export { CODEX_TOOL_MAPPINGS } from "./codex/tools"
 export { ELIZA_TOOL_MAPPINGS } from "./eliza/tools"
 export { GEMINI_TOOL_MAPPINGS } from "./gemini/tools"
 export { GOOSE_TOOL_MAPPINGS } from "./goose/tools"
+export { KILO_TOOL_MAPPINGS } from "./kilo/tools"
 export { OPENCODE_TOOL_MAPPINGS } from "./opencode/tools"
 export { PI_TOOL_MAPPINGS } from "./pi/tools"
 
@@ -46,5 +50,6 @@ export { parseCodexLine } from "./codex/parser"
 export { parseElizaLine } from "./eliza/parser"
 export { parseGeminiLine } from "./gemini/parser"
 export { parseGooseLine } from "./goose/parser"
+export { parseKiloLine } from "./kilo/parser"
 export { parseOpencodeLine } from "./opencode/parser"
 export { parsePiLine } from "./pi/parser"

--- a/packages/agents/src/agents/kilo/index.ts
+++ b/packages/agents/src/agents/kilo/index.ts
@@ -1,0 +1,78 @@
+/**
+ * Kilo CLI Agent Definition
+ *
+ * Kilo is a fork of OpenCode with its own gateway and model catalog.
+ * Uses --auto flag for fully autonomous runs in sandbox environments.
+ */
+
+import type {
+  AgentDefinition,
+  CommandSpec,
+  ParseContext,
+  RunOptions,
+} from "../../core/agent"
+import type { Event } from "../../types/events"
+import { parseKiloLine } from "./parser"
+import { KILO_TOOL_MAPPINGS } from "./tools"
+
+/**
+ * Quote a string for bash
+ */
+function quote(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`
+}
+
+/**
+ * Kilo CLI agent definition.
+ *
+ * Interacts with the Kilo CLI tool which outputs JSON lines.
+ * Uses --auto to auto-approve all permissions (safe in sandbox).
+ * Wraps command in bash to capture stderr.
+ */
+export const kiloAgent: AgentDefinition = {
+  name: "kilo",
+
+  toolMappings: KILO_TOOL_MAPPINGS,
+
+  capabilities: {
+    supportsSystemPrompt: false,
+    supportsResume: true,
+  },
+
+  buildCommand(options: RunOptions): CommandSpec {
+    // Kilo sometimes writes JSON events to stderr; run under bash and redirect 2>&1
+    const parts: string[] = ["kilo", "run", "--format", "json", "--auto"]
+
+    if (options.model) {
+      parts.push("-m", quote(options.model))
+    }
+
+    if (options.sessionId) {
+      parts.push("-s", quote(options.sessionId))
+    }
+
+    // The "--" sentinel signals end-of-options to Kilo's argument parser
+    if (options.prompt) {
+      parts.push("--")
+      parts.push(quote(options.prompt))
+    }
+
+    const command = `${parts.join(" ")} 2>&1`
+
+    // Build environment variables
+    const env: Record<string, string> = {
+      ...options.env,
+    }
+
+    return {
+      cmd: "bash",
+      args: ["-lc", command],
+      env,
+      wrapInBash: false, // Already wrapped
+    }
+  },
+
+  parse(line: string, context: ParseContext): Event | Event[] | null {
+    return parseKiloLine(line, this.toolMappings, context)
+  },
+}

--- a/packages/agents/src/agents/kilo/parser.ts
+++ b/packages/agents/src/agents/kilo/parser.ts
@@ -1,0 +1,192 @@
+/**
+ * Kilo CLI output parser
+ *
+ * Pure function for parsing Kilo CLI JSON output.
+ * Kilo is a fork of OpenCode with an identical JSONL schema today,
+ * but this parser is kept separate so it can evolve independently.
+ *
+ * Note: Kilo emits "reasoning" events for thinking blocks; these are
+ * internal and must NOT be forwarded to the UI.
+ */
+
+import type { Event } from "../../types/events"
+import type { ParseContext } from "../../core/agent"
+import { createToolStartEvent, normalizeToolName } from "../../core/tools"
+import { safeJsonParse } from "../../utils/json"
+
+/**
+ * Raw event types from Kilo's JSON stream
+ */
+interface KiloStepStart {
+  type: "step_start"
+  sessionID: string
+  part?: {
+    id: string
+    sessionID: string
+    messageID: string
+    type: "step-start"
+  }
+}
+
+interface KiloText {
+  type: "text"
+  sessionID: string
+  part?: {
+    id: string
+    sessionID: string
+    messageID: string
+    type: "text"
+    text?: string
+  }
+}
+
+interface KiloToolCall {
+  type: "tool_call"
+  sessionID: string
+  part?: {
+    id: string
+    type: "tool-call"
+    tool?: string
+    args?: unknown
+  }
+}
+
+interface KiloToolUse {
+  type: "tool_use"
+  sessionID: string
+  part?: {
+    id: string
+    tool?: string
+    state?: { status: string; input?: unknown }
+  }
+}
+
+interface KiloToolResult {
+  type: "tool_result"
+  sessionID: string
+  part?: {
+    id: string
+    type: "tool-result"
+  }
+}
+
+interface KiloStepFinish {
+  type: "step_finish"
+  sessionID: string
+  part?: {
+    id: string
+    type: "step-finish"
+    reason: string
+  }
+}
+
+interface KiloError {
+  type: "error"
+  sessionID: string
+  error?: {
+    name: string
+    data?: {
+      message: string
+    }
+  }
+}
+
+interface KiloReasoning {
+  type: "reasoning"
+  sessionID: string
+  part?: {
+    type: "reasoning"
+    text?: string
+  }
+}
+
+type KiloEvent =
+  | KiloStepStart
+  | KiloText
+  | KiloToolCall
+  | KiloToolUse
+  | KiloToolResult
+  | KiloStepFinish
+  | KiloError
+  | KiloReasoning
+
+/**
+ * Parse a line of Kilo CLI output into event(s).
+ *
+ * Uses context.sessionId to track if session event was already emitted.
+ * Reasoning events are intentionally dropped — only user-visible text is forwarded.
+ */
+export function parseKiloLine(
+  line: string,
+  toolMappings: Record<string, string>,
+  context: ParseContext
+): Event | Event[] | null {
+  const json = safeJsonParse<KiloEvent>(line)
+  if (!json) {
+    return null
+  }
+
+  // Step start - session initialization
+  if (json.type === "step_start") {
+    // Kilo can emit multiple step_start lines for the same session; only emit once
+    if (context.sessionId === json.sessionID) return null
+    context.sessionId = json.sessionID
+    return { type: "session", id: json.sessionID }
+  }
+
+  // Text content - the actual response
+  if (json.type === "text") {
+    if (json.part?.type === "text" && json.part.text) {
+      return { type: "token", text: json.part.text }
+    }
+    return null
+  }
+
+  // Reasoning - internal thinking blocks, never surface to user
+  if (json.type === "reasoning") {
+    return null
+  }
+
+  // Tool call start
+  if (json.type === "tool_call") {
+    const toolName = (json.part?.tool || "unknown").toLowerCase()
+    const normalized = normalizeToolName(toolName, toolMappings)
+    return createToolStartEvent(normalized, json.part?.args, toolMappings)
+  }
+
+  // Tool use (stream-json: emitted when tool completes with full state)
+  if (json.type === "tool_use") {
+    const toolName = (json.part?.tool || "unknown").toLowerCase()
+    const normalized = normalizeToolName(toolName, toolMappings)
+    const raw = json.part as { state?: { status?: string; input?: unknown; output?: string } } | undefined
+    const startEvent = createToolStartEvent(normalized, raw?.state?.input, toolMappings)
+
+    // If the tool already completed (state.output is present), emit tool_end inline.
+    // This is the common case for Kilo: tool_use carries the full result.
+    const rawOutput = raw?.state?.output
+    if (typeof rawOutput === "string" && rawOutput.trim()) {
+      return [startEvent, { type: "tool_end", output: rawOutput.trim() }]
+    }
+    return startEvent
+  }
+
+  // Tool result - tool completed (streaming / in-progress path, no output here)
+  if (json.type === "tool_result") {
+    return { type: "tool_end" }
+  }
+
+  // Step finish - emit end only when run actually stops
+  if (json.type === "step_finish") {
+    if (json.part?.reason === "stop") return { type: "end" }
+    return null
+  }
+
+  // Error event - emit as end with error
+  if (json.type === "error") {
+    const errorMsg =
+      json.error?.data?.message || json.error?.name || "Unknown error"
+    return { type: "end", error: errorMsg }
+  }
+
+  return null
+}

--- a/packages/agents/src/agents/kilo/tools.ts
+++ b/packages/agents/src/agents/kilo/tools.ts
@@ -1,0 +1,11 @@
+/**
+ * Kilo tool name mappings
+ *
+ * Maps Kilo tool names to canonical tool names.
+ * Kilo is a fork of OpenCode, so tool names are identical.
+ */
+
+export const KILO_TOOL_MAPPINGS: Record<string, string> = {
+  bash: "shell",
+  // Most Kilo tools use canonical names already (read, write, edit, glob, grep)
+}

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -133,6 +133,7 @@ export {
   elizaAgent,
   geminiAgent,
   gooseAgent,
+  kiloAgent,
   opencodeAgent,
   piAgent,
 } from "./agents/index"

--- a/packages/agents/src/types/provider.ts
+++ b/packages/agents/src/types/provider.ts
@@ -6,7 +6,7 @@
  * Supported agent names.
  * Used by ensureProvider() to install the correct CLI.
  */
-export type ProviderName = "claude" | "codex" | "eliza" | "goose" | "opencode" | "gemini" | "pi"
+export type ProviderName = "claude" | "codex" | "eliza" | "goose" | "kilo" | "opencode" | "gemini" | "pi"
 
 /**
  * Options for starting a background command that writes to a log file.

--- a/packages/agents/src/utils/install.ts
+++ b/packages/agents/src/utils/install.ts
@@ -10,6 +10,7 @@ const PROVIDER_PACKAGES: Record<ProviderName, string> = {
   codex: "@openai/codex",
   eliza: "", // eliza is built-in, no installation needed
   goose: "", // goose uses shell script installer, not npm
+  kilo: "@kilocode/cli",
   opencode: "opencode",
   gemini: "@google/gemini-cli",
   pi: "@mariozechner/pi-coding-agent",
@@ -132,7 +133,7 @@ export function ensureCliInstalled(
  * Check installation status of all providers
  */
 export function getInstallationStatus(): Record<ProviderName, boolean> {
-  const providers: ProviderName[] = ["claude", "codex", "eliza", "goose", "opencode", "gemini", "pi"]
+  const providers: ProviderName[] = ["claude", "codex", "eliza", "goose", "kilo", "opencode", "gemini", "pi"]
   const status: Record<string, boolean> = {}
 
   for (const provider of providers) {

--- a/packages/agents/tests/parsers.test.ts
+++ b/packages/agents/tests/parsers.test.ts
@@ -9,6 +9,7 @@ import {
   parseElizaLine,
   parseGeminiLine,
   parseGooseLine,
+  parseKiloLine,
   parseOpencodeLine,
   parsePiLine,
   CLAUDE_TOOL_MAPPINGS,
@@ -16,6 +17,7 @@ import {
   ELIZA_TOOL_MAPPINGS,
   GEMINI_TOOL_MAPPINGS,
   GOOSE_TOOL_MAPPINGS,
+  KILO_TOOL_MAPPINGS,
   OPENCODE_TOOL_MAPPINGS,
   PI_TOOL_MAPPINGS,
 } from "../src/agents/index.js"
@@ -1272,5 +1274,208 @@ describe("parseElizaLine", () => {
 
   it("returns null for unknown event types", () => {
     expect(parseElizaLine('{"type": "unknown_event"}', mappings)).toBeNull()
+  })
+})
+
+describe("parseKiloLine", () => {
+  const mappings = KILO_TOOL_MAPPINGS
+
+  it("returns null for invalid JSON", () => {
+    const ctx = createContext()
+    expect(parseKiloLine("not json", mappings, ctx)).toBeNull()
+    expect(parseKiloLine("", mappings, ctx)).toBeNull()
+  })
+
+  it("parses step_start event", () => {
+    const ctx = createContext()
+    const event = parseKiloLine(
+      '{"type": "step_start", "sessionID": "ses_kilo123"}',
+      mappings,
+      ctx
+    )
+    expect(event).toEqual({ type: "session", id: "ses_kilo123" })
+  })
+
+  it("deduplicates step_start for same session", () => {
+    const ctx = createContext()
+    parseKiloLine('{"type": "step_start", "sessionID": "ses_kilo123"}', mappings, ctx)
+    const event = parseKiloLine('{"type": "step_start", "sessionID": "ses_kilo123"}', mappings, ctx)
+    expect(event).toBeNull()
+  })
+
+  it("parses text event with content", () => {
+    const ctx = createContext()
+    const event = parseKiloLine(
+      '{"type": "text", "sessionID": "ses_kilo123", "part": {"type": "text", "text": "Hello from Kilo!"}}',
+      mappings,
+      ctx
+    )
+    expect(event).toEqual({ type: "token", text: "Hello from Kilo!" })
+  })
+
+  it("returns null for text event without text type", () => {
+    const ctx = createContext()
+    const event = parseKiloLine(
+      '{"type": "text", "sessionID": "ses_kilo123", "part": {"type": "image"}}',
+      mappings,
+      ctx
+    )
+    expect(event).toBeNull()
+  })
+
+  it("returns null for text event without text content", () => {
+    const ctx = createContext()
+    const event = parseKiloLine(
+      '{"type": "text", "sessionID": "ses_kilo123", "part": {"type": "text"}}',
+      mappings,
+      ctx
+    )
+    expect(event).toBeNull()
+  })
+
+  it("drops reasoning events (internal thinking)", () => {
+    const ctx = createContext()
+    const event = parseKiloLine(
+      JSON.stringify({
+        type: "reasoning",
+        sessionID: "ses_kilo123",
+        part: { type: "reasoning", text: "Let me think about this..." },
+      }),
+      mappings,
+      ctx
+    )
+    expect(event).toBeNull()
+  })
+
+  it("parses tool_call event", () => {
+    const ctx = createContext()
+    const event = parseKiloLine(
+      '{"type": "tool_call", "sessionID": "ses_kilo123", "part": {"type": "tool-call", "tool": "write"}}',
+      mappings,
+      ctx
+    )
+    expect(event).toEqual({ type: "tool_start", name: "write", input: {} })
+  })
+
+  it("normalizes bash tool to shell", () => {
+    const ctx = createContext()
+    const event = parseKiloLine(
+      JSON.stringify({
+        type: "tool_call",
+        sessionID: "ses_kilo123",
+        part: { type: "tool-call", tool: "bash", args: { command: "ls" } },
+      }),
+      mappings,
+      ctx
+    )
+    expect(event).toMatchObject({ type: "tool_start", name: "shell" })
+  })
+
+  it("handles tool_call with missing tool name", () => {
+    const ctx = createContext()
+    const event = parseKiloLine(
+      '{"type": "tool_call", "sessionID": "ses_kilo123", "part": {"type": "tool-call"}}',
+      mappings,
+      ctx
+    )
+    expect(event).toEqual({ type: "tool_start", name: "unknown", input: {} })
+  })
+
+  it("parses tool_use event with output as [tool_start, tool_end]", () => {
+    const ctx = createContext()
+    const events = parseKiloLine(
+      JSON.stringify({
+        type: "tool_use",
+        sessionID: "ses_kilo123",
+        part: {
+          id: "prt_123",
+          tool: "read",
+          state: {
+            status: "completed",
+            input: { filePath: "/tmp/test.txt" },
+            output: "file contents here",
+          },
+        },
+      }),
+      mappings,
+      ctx
+    )
+    expect(Array.isArray(events)).toBe(true)
+    const arr = events as any[]
+    expect(arr[0]).toMatchObject({ type: "tool_start", name: "read" })
+    expect(arr[1]).toEqual({ type: "tool_end", output: "file contents here" })
+  })
+
+  it("parses tool_use event without output as tool_start only", () => {
+    const ctx = createContext()
+    const event = parseKiloLine(
+      JSON.stringify({
+        type: "tool_use",
+        sessionID: "ses_kilo123",
+        part: {
+          id: "prt_123",
+          tool: "write",
+          state: { status: "running", input: { filePath: "/tmp/out.txt" } },
+        },
+      }),
+      mappings,
+      ctx
+    )
+    expect(event).toMatchObject({ type: "tool_start", name: "write" })
+  })
+
+  it("parses tool_result event", () => {
+    const ctx = createContext()
+    const event = parseKiloLine(
+      '{"type": "tool_result", "sessionID": "ses_kilo123"}',
+      mappings,
+      ctx
+    )
+    expect(event).toEqual({ type: "tool_end" })
+  })
+
+  it("parses step_finish with reason stop as end", () => {
+    const ctx = createContext()
+    const event = parseKiloLine(
+      '{"type": "step_finish", "sessionID": "ses_kilo123", "part": {"reason": "stop"}}',
+      mappings,
+      ctx
+    )
+    expect(event).toEqual({ type: "end" })
+  })
+
+  it("returns null for step_finish with non-stop reason", () => {
+    const ctx = createContext()
+    const event = parseKiloLine(
+      '{"type": "step_finish", "sessionID": "ses_kilo123", "part": {"reason": "tool-calls"}}',
+      mappings,
+      ctx
+    )
+    expect(event).toBeNull()
+  })
+
+  it("parses error event with error message", () => {
+    const ctx = createContext()
+    const event = parseKiloLine(
+      '{"type": "error", "sessionID": "ses_kilo123", "error": {"name": "APIError", "data": {"message": "Rate limit exceeded"}}}',
+      mappings,
+      ctx
+    )
+    expect(event).toEqual({ type: "end", error: "Rate limit exceeded" })
+  })
+
+  it("parses error event falling back to error name", () => {
+    const ctx = createContext()
+    const event = parseKiloLine(
+      '{"type": "error", "sessionID": "ses_kilo123", "error": {"name": "APIError"}}',
+      mappings,
+      ctx
+    )
+    expect(event).toEqual({ type: "end", error: "APIError" })
+  })
+
+  it("returns null for unknown event types", () => {
+    const ctx = createContext()
+    expect(parseKiloLine('{"type": "unknown"}', mappings, ctx)).toBeNull()
   })
 })

--- a/packages/common/src/agent-icons.tsx
+++ b/packages/common/src/agent-icons.tsx
@@ -192,6 +192,39 @@ export function ElizaIcon({ className }: AgentIconProps) {
   )
 }
 
+// Kilo icon - Kilo Code agent logo
+// Stylized "K" representing the Kilo brand
+export function KiloIcon({ className }: AgentIconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={cn("h-4 w-4", className)}
+    >
+      {/* Rounded square background */}
+      <rect
+        x="2"
+        y="2"
+        width="20"
+        height="20"
+        rx="4"
+        fill="currentColor"
+      />
+      {/* K letterform */}
+      <path
+        d="M8 6v12M8 12l6-6M8 12l6 6"
+        stroke="currentColor"
+        className="stroke-background"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
+    </svg>
+  )
+}
+
 // Pi icon - Official Pi Coding Agent logo
 // Source: https://shittycodingagent.ai/logo.svg
 export function PiIcon({ className }: AgentIconProps) {
@@ -232,6 +265,8 @@ export function AgentIcon({ agent, className }: { agent: Agent; className?: stri
       return <GeminiIcon className={className} />
     case "goose":
       return <GooseIcon className={className} />
+    case "kilo":
+      return <KiloIcon className={className} />
     case "pi":
       return <PiIcon className={className} />
     default:

--- a/packages/common/src/agents.ts
+++ b/packages/common/src/agents.ts
@@ -7,13 +7,13 @@
 // Agent Types
 // =============================================================================
 
-export type Agent = "claude-code" | "opencode" | "codex" | "eliza" | "gemini" | "goose" | "pi"
+export type Agent = "claude-code" | "opencode" | "codex" | "eliza" | "gemini" | "goose" | "kilo" | "pi"
 
 /** All agent ids, in display order. */
-export const ALL_AGENTS: Agent[] = ["claude-code", "opencode", "codex", "gemini", "goose", "pi", "eliza"]
+export const ALL_AGENTS: Agent[] = ["claude-code", "opencode", "codex", "gemini", "goose", "kilo", "pi", "eliza"]
 
 /** SDK provider names (must match ProviderName from SDK) */
-export type ProviderName = "claude" | "codex" | "eliza" | "opencode" | "gemini" | "goose" | "pi"
+export type ProviderName = "claude" | "codex" | "eliza" | "opencode" | "gemini" | "goose" | "kilo" | "pi"
 
 /** Display labels for each agent */
 export const agentLabels: Record<Agent, string> = {
@@ -23,6 +23,7 @@ export const agentLabels: Record<Agent, string> = {
   "eliza": "Eliza",
   "gemini": "Gemini",
   "goose": "Goose",
+  "kilo": "Kilo",
   "pi": "Pi",
 }
 
@@ -34,6 +35,7 @@ export const agentToProvider: Record<Agent, ProviderName> = {
   "eliza": "eliza",
   "gemini": "gemini",
   "goose": "goose",
+  "kilo": "kilo",
   "pi": "pi",
 }
 
@@ -42,7 +44,7 @@ export const agentToProvider: Record<Agent, ProviderName> = {
 // =============================================================================
 
 /** Provider an API key is associated with. */
-export type ProviderId = "anthropic" | "openai" | "opencode" | "gemini"
+export type ProviderId = "anthropic" | "openai" | "opencode" | "gemini" | "kilo"
 
 /**
  * Credential identifiers. The id doubles as the env var name we inject
@@ -54,6 +56,7 @@ export type CredentialId =
   | "OPENAI_API_KEY"
   | "OPENCODE_API_KEY"
   | "GEMINI_API_KEY"
+  | "KILO_API_KEY"
 
 export type CredentialFlags = Partial<Record<CredentialId, boolean>> & {
   // Server has a shared Claude credential pool (e.g. the rotating row written
@@ -73,6 +76,7 @@ const PROVIDER_ENV: Record<ProviderId, CredentialId[]> = {
   openai: ["OPENAI_API_KEY"],
   opencode: ["OPENCODE_API_KEY"],
   gemini: ["GEMINI_API_KEY"],
+  kilo: ["KILO_API_KEY"],
 }
 
 // =============================================================================
@@ -169,6 +173,38 @@ export const agentModels: Record<Agent, ModelOption[]> = {
     { value: "claude-opus-4-5", label: "Claude Opus 4.5", requiresKey: "anthropic" },
     { value: "claude-opus-4-7", label: "Claude Opus 4.7", requiresKey: "anthropic" },
   ],
+  "kilo": [
+    // Auto-routers
+    { value: "kilo/kilo-auto/free", label: "Auto Free", requiresKey: "none" },
+    { value: "kilo/kilo-auto/balanced", label: "Auto Balanced", requiresKey: "kilo" },
+    { value: "kilo/kilo-auto/frontier", label: "Auto Frontier", requiresKey: "kilo" },
+    { value: "kilo/kilo-auto/small", label: "Auto Small", requiresKey: "kilo" },
+    // Free models
+    { value: "kilo/deepseek/deepseek-v4-flash:free", label: "DeepSeek V4 Flash (Free)", requiresKey: "none" },
+    { value: "kilo/nvidia/nemotron-3-super-120b-a12b:free", label: "Nemotron 3 Super (Free)", requiresKey: "none" },
+    { value: "kilo/stepfun/step-3.5-flash:free", label: "Step 3.5 Flash (Free)", requiresKey: "none" },
+    // Anthropic via Kilo gateway
+    { value: "kilo/anthropic/claude-opus-4.7", label: "Claude Opus 4.7", requiresKey: "kilo" },
+    { value: "kilo/anthropic/claude-sonnet-4.6", label: "Claude Sonnet 4.6", requiresKey: "kilo" },
+    { value: "kilo/anthropic/claude-haiku-4.5", label: "Claude Haiku 4.5", requiresKey: "kilo" },
+    // OpenAI via Kilo gateway
+    { value: "kilo/openai/gpt-5.5", label: "GPT-5.5", requiresKey: "kilo" },
+    { value: "kilo/openai/gpt-5.4", label: "GPT-5.4", requiresKey: "kilo" },
+    { value: "kilo/openai/o3", label: "o3", requiresKey: "kilo" },
+    { value: "kilo/openai/o4-mini", label: "o4 Mini", requiresKey: "kilo" },
+    // Google via Kilo gateway
+    { value: "kilo/google/gemini-3.1-pro-preview", label: "Gemini 3.1 Pro", requiresKey: "kilo" },
+    { value: "kilo/google/gemini-2.5-pro", label: "Gemini 2.5 Pro", requiresKey: "kilo" },
+    { value: "kilo/google/gemini-2.5-flash", label: "Gemini 2.5 Flash", requiresKey: "kilo" },
+    // DeepSeek via Kilo gateway
+    { value: "kilo/deepseek/deepseek-v4-pro", label: "DeepSeek V4 Pro", requiresKey: "kilo" },
+    { value: "kilo/deepseek/deepseek-r1-0528", label: "DeepSeek R1", requiresKey: "kilo" },
+    // Other notable models
+    { value: "kilo/moonshotai/kimi-k2.6", label: "Kimi K2.6", requiresKey: "kilo" },
+    { value: "kilo/qwen/qwen3-coder", label: "Qwen3 Coder", requiresKey: "kilo" },
+    { value: "kilo/mistralai/devstral-medium", label: "Devstral Medium", requiresKey: "kilo" },
+    { value: "kilo/x-ai/grok-4.20", label: "Grok 4.20", requiresKey: "kilo" },
+  ],
   "pi": [
     // Anthropic models (default provider)
     { value: "claude-sonnet-4-5", label: "Claude Sonnet 4.5 (Recommended)", requiresKey: "anthropic" },
@@ -195,6 +231,7 @@ export const defaultAgentModel: Record<Agent, string> = {
   "eliza": "eliza-classic-1.0", // Fake agent, no API key needed
   "gemini": "gemini-2.5-flash",
   "goose": "gpt-4o",
+  "kilo": "kilo/kilo-auto/free", // Free auto-router, no API key needed
   "pi": "claude-sonnet-4-5",
 }
 
@@ -206,6 +243,7 @@ export const agentSupportsPlanMode: Record<Agent, boolean> = {
   "eliza": false,
   "gemini": true,
   "goose": true,
+  "kilo": false,
   "pi": false,
 }
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -126,6 +126,7 @@ export {
   OpenCodeIcon,
   GeminiIcon,
   GooseIcon,
+  KiloIcon,
   ElizaIcon,
   PiIcon,
   AgentIcon,

--- a/packages/web/components/chat/AgentModelSelector.tsx
+++ b/packages/web/components/chat/AgentModelSelector.tsx
@@ -28,7 +28,7 @@ interface AgentModelSelectorProps {
   closeDropdowns?: boolean
 }
 
-const agents: Agent[] = ["claude-code", "opencode", "codex", "gemini", "goose", "pi", "eliza"]
+const agents: Agent[] = ["claude-code", "opencode", "codex", "gemini", "goose", "kilo", "pi", "eliza"]
 
 export function AgentModelSelector({
   chat,

--- a/packages/web/components/icons/agent-icons.tsx
+++ b/packages/web/components/icons/agent-icons.tsx
@@ -9,6 +9,7 @@ export {
   OpenCodeIcon,
   GeminiIcon,
   GooseIcon,
+  KiloIcon,
   ElizaIcon,
   PiIcon,
   AgentIcon,

--- a/packages/web/lib/credentials.ts
+++ b/packages/web/lib/credentials.ts
@@ -58,6 +58,13 @@ export const CREDENTIAL_KEYS: readonly CredentialField[] = [
     helpUrl: "https://opencode.ai/auth",
   },
   {
+    id: "KILO_API_KEY",
+    provider: "kilo",
+    label: "Kilo",
+    helpUrl: "https://app.kilo.ai",
+    placeholder: "kilo-...",
+  },
+  {
     id: "GEMINI_API_KEY",
     provider: "gemini",
     label: "Google AI (Gemini)",


### PR DESCRIPTION
## Summary

Adds Kilo Code CLI (`@kilocode/cli`) as a new agent provider, fully integrated across the SDK, UI, and credential system.

Kilo is a fork of OpenCode with its own model gateway supporting 500+ models. This PR curates 25 models for the dropdown (4 free, 21 paid via Kilo gateway) and wires up session continuity, JSONL parsing, and API key management.

## Changes

### SDK (`packages/agents`)
- **New agent module** (`src/agents/kilo/`) — `buildCommand` with `--format json --auto`, session resume via `-s <sessionId>`
- **JSONL parser** — Handles `step_start`, `text`, `tool_use`, `tool_call`, `tool_result`, `step_finish`, `error`. Explicitly drops `reasoning` events (internal thinking blocks)
- **Tool mappings** — `bash` → `shell` (same as OpenCode)
- **Registration** — Added across provider types, install config (`@kilocode/cli`), and exports
- **18 parser tests** — All passing

### UI (`packages/common` + `packages/web`)
- **Agent type** — Added `"kilo"` to `Agent` union, `ALL_AGENTS`, `agentLabels`, `agentToProvider`
- **Model dropdown** — 25 curated models organized by category:
  - Auto-routers: Auto Free (default), Auto Balanced, Auto Frontier, Auto Small
  - Free: DeepSeek V4 Flash, Nemotron 3 Super, Step 3.5 Flash
  - Paid (via gateway): Claude, GPT, Gemini, DeepSeek, Kimi, Qwen, Devstral, Grok
- **Credentials** — `KILO_API_KEY` added as a new credential with settings UI field linking to `app.kilo.ai`
- **Icon** — Stylized "K" in a rounded square
- **Default model** — `kilo/kilo-auto/free` (no API key required)

### Key Design Decisions
- **`--auto` flag** instead of `--dangerously-skip-permissions` — auto-approves all tool permissions since we run in sandboxed environments
- **Parser is a copy** of OpenCode's, not a reuse — allows independent evolution as Kilo diverges
- **Single credential** (`KILO_API_KEY`) for all paid models — avoids the complexity of per-provider BYOK keys for 500+ models. Users wanting BYOK can configure `kilo.jsonc` in their project root.

## Testing
- `npx vitest run tests/parsers.test.ts` — 18/18 Kilo tests pass
- `tsc --noEmit` clean across `packages/agents`, `packages/common`, `packages/web`
- Verified JSONL output with live `kilo run --format json --auto "what is 2+2"` matches parser expectations