### PR TITLE
custom Daytona snapshot with all agent CLIs pre-installed

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -42,7 +42,7 @@ export const ENV_VARS = {
 
 export const SANDBOX_CONFIG = {
   /** Default snapshot for sandbox creation */
-  DEFAULT_SNAPSHOT: "daytona-medium",
+  DEFAULT_SNAPSHOT: "background-agents",
   /** Label key for identifying upstream-agents sandboxes */
   LABEL_KEY: "upstream-agents",
   /** Default preview port */

--- a/packages/sandbox-image/package.json
+++ b/packages/sandbox-image/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@upstream/sandbox-image",
+  "version": "0.1.0",
+  "description": "Custom Daytona sandbox image with pre-installed agent CLIs",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "dependencies": {
+    "@daytonaio/sdk": "^0.170.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22",
+    "typescript": "5.7.3"
+  }
+}

--- a/packages/sandbox-image/src/image.ts
+++ b/packages/sandbox-image/src/image.ts
@@ -25,7 +25,7 @@ export const SNAPSHOT_RESOURCES = {
 export const AGENT_PACKAGES = {
   claude: "@anthropic-ai/claude-code",
   codex: "@openai/codex",
-  // opencode: "opencode", // Package doesn't exist on npm - skipped
+  opencode: "opencode-ai",
   gemini: "@google/gemini-cli",
   pi: "@mariozechner/pi-coding-agent",
 } as const
@@ -50,12 +50,12 @@ const GOOSE_INSTALL_CMD = `
  * Pre-installed agents:
  * - Claude (@anthropic-ai/claude-code)
  * - Codex (@openai/codex)
+ * - OpenCode (opencode-ai)
  * - Gemini (@google/gemini-cli)
  * - Pi (@mariozechner/pi-coding-agent)
  * - Goose (binary from GitHub releases)
  *
  * Note: Eliza is built-in to the agents package (no CLI installation needed).
- * Note: OpenCode is skipped as the npm package doesn't exist.
  */
 export function getAgentSandboxImage(): Image {
   const npmPackages = Object.values(AGENT_PACKAGES).join(" ")
@@ -78,6 +78,10 @@ export function getAgentSandboxImage(): Image {
     .runCommands(
       // Install Gemini CLI
       "npm install -g @google/gemini-cli"
+    )
+    .runCommands(
+      // Install OpenCode CLI
+      "npm install -g opencode-ai"
     )
     .runCommands(
       // Install Pi CLI

--- a/packages/sandbox-image/src/image.ts
+++ b/packages/sandbox-image/src/image.ts
@@ -58,43 +58,58 @@ const GOOSE_INSTALL_CMD = `
  * Note: Eliza is built-in to the agents package (no CLI installation needed).
  */
 export function getAgentSandboxImage(): Image {
-  const npmPackages = Object.values(AGENT_PACKAGES).join(" ")
-
-  return Image.base("node:22-bookworm")
-    .runCommands(
-      // Install system dependencies (curl for Goose download, git for agents)
-      "apt-get update && apt-get install -y --no-install-recommends " +
-        "curl ca-certificates git bzip2 " +
-        "&& rm -rf /var/lib/apt/lists/*"
-    )
-    .runCommands(
-      // Install Claude Code CLI
-      "npm install -g @anthropic-ai/claude-code"
-    )
-    .runCommands(
-      // Install Codex CLI
-      "npm install -g @openai/codex"
-    )
-    .runCommands(
-      // Install Gemini CLI
-      "npm install -g @google/gemini-cli"
-    )
-    .runCommands(
-      // Install OpenCode CLI
-      "npm install -g opencode-ai"
-    )
-    .runCommands(
-      // Install Pi CLI
-      "npm install -g @mariozechner/pi-coding-agent"
-    )
-    .runCommands(
+  return (
+    Image.base("node:22-bookworm")
+      .runCommands(
+        // Install system dependencies (curl for Goose download, git for agents, sudo for user)
+        "apt-get update && apt-get install -y --no-install-recommends " +
+          "curl ca-certificates git bzip2 sudo " +
+          "&& rm -rf /var/lib/apt/lists/*"
+      )
+      .runCommands(
+        // Install Claude Code CLI
+        "npm install -g @anthropic-ai/claude-code"
+      )
+      .runCommands(
+        // Install Codex CLI
+        "npm install -g @openai/codex"
+      )
+      .runCommands(
+        // Install Gemini CLI
+        "npm install -g @google/gemini-cli"
+      )
+      .runCommands(
+        // Install OpenCode CLI
+        "npm install -g opencode-ai"
+      )
+      .runCommands(
+        // Install Pi CLI
+        "npm install -g @mariozechner/pi-coding-agent"
+      )
+      // Create daytona user (non-root) - Claude Code refuses to run as root
+      .runCommands(
+        "useradd -m -s /bin/bash daytona || true && " +
+          "echo 'daytona ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers"
+      )
       // Install Goose binary
-      GOOSE_INSTALL_CMD
-    )
-    .runCommands(
-      // Create required directories and add ~/.local/bin to PATH
-      "mkdir -p ~/.gemini ~/.config/goose /home/daytona && " +
-        'echo \'export PATH="$HOME/.local/bin:$PATH"\' >> ~/.bashrc'
-    )
-    .workdir("/home/daytona")
+      .runCommands(
+        "mkdir -p /home/daytona/.local/bin /tmp/goose_tmp && " +
+          'curl -fsSL "https://github.com/block/goose/releases/download/stable/goose-x86_64-unknown-linux-gnu.tar.bz2" | ' +
+          "tar -xjf - --no-same-owner --no-same-permissions -C /tmp/goose_tmp && " +
+          "mv /tmp/goose_tmp/goose /home/daytona/.local/bin/goose && " +
+          "chmod +x /home/daytona/.local/bin/goose && " +
+          "rm -rf /tmp/goose_tmp"
+      )
+      // Create required directories and set up PATH for daytona user
+      .runCommands(
+        "mkdir -p /home/daytona/.gemini /home/daytona/.config/goose /home/daytona/project && " +
+          "chown -R daytona:daytona /home/daytona"
+      )
+      .runCommands(
+        'echo \'export PATH="$HOME/.local/bin:$PATH"\' >> /home/daytona/.bashrc'
+      )
+      // Set the default user to daytona
+      .dockerfileCommands(["USER daytona"])
+      .workdir("/home/daytona/project")
+  )
 }

--- a/packages/sandbox-image/src/image.ts
+++ b/packages/sandbox-image/src/image.ts
@@ -1,0 +1,84 @@
+import { Image } from "@daytonaio/sdk"
+
+/**
+ * Snapshot name used for sandbox creation.
+ * Must match what's registered with Daytona.
+ */
+export const SNAPSHOT_NAME = "background-agents"
+
+/**
+ * Resource limits for the snapshot.
+ * - cpu: vCPUs
+ * - memory: GB of RAM
+ * - disk: GB of disk
+ */
+export const SNAPSHOT_RESOURCES = {
+  cpu: 1,
+  memory: 3, // 3GB RAM
+  disk: 5, // 5GB disk
+} as const
+
+/**
+ * NPM packages to pre-install for each agent CLI.
+ * Goose uses a binary download, not npm.
+ */
+export const AGENT_PACKAGES = {
+  claude: "@anthropic-ai/claude-code",
+  codex: "@openai/codex",
+  opencode: "opencode",
+  gemini: "@google/gemini-cli",
+  pi: "@mariozechner/pi-coding-agent",
+} as const
+
+/**
+ * Shell command to install Goose binary (not available via npm).
+ */
+const GOOSE_INSTALL_CMD = `
+  mkdir -p ~/.local/bin ~/.goose_tmp &&
+  curl -fsSL "https://github.com/block/goose/releases/download/stable/goose-x86_64-unknown-linux-gnu.tar.bz2" |
+  tar -xjf - --no-same-owner --no-same-permissions -C ~/.goose_tmp &&
+  mv ~/.goose_tmp/goose ~/.local/bin/goose &&
+  chmod +x ~/.local/bin/goose &&
+  rm -rf ~/.goose_tmp
+`
+  .trim()
+  .replace(/\n\s*/g, " ")
+
+/**
+ * Builds the Daytona Image spec with all agent CLIs pre-installed.
+ *
+ * Pre-installed agents:
+ * - Claude (@anthropic-ai/claude-code)
+ * - Codex (@openai/codex)
+ * - OpenCode (opencode)
+ * - Gemini (@google/gemini-cli)
+ * - Pi (@mariozechner/pi-coding-agent)
+ * - Goose (binary from GitHub releases)
+ *
+ * Note: Eliza is built-in to the agents package (no CLI installation needed).
+ */
+export function getAgentSandboxImage(): Image {
+  const npmPackages = Object.values(AGENT_PACKAGES).join(" ")
+
+  return Image.debianSlim("3.12")
+    .runCommands(
+      // Install system dependencies (curl for Goose download, Node.js for npm)
+      "apt-get update && apt-get install -y --no-install-recommends " +
+        "curl ca-certificates nodejs npm git " +
+        "&& rm -rf /var/lib/apt/lists/*"
+    )
+    .runCommands(
+      // Install all npm-based agent CLIs globally
+      `npm install -g ${npmPackages}`
+    )
+    .runCommands(
+      // Install Goose binary
+      GOOSE_INSTALL_CMD
+    )
+    .runCommands(
+      // Create required directories and add ~/.local/bin to PATH
+      "mkdir -p ~/.gemini ~/.config/goose && " +
+        'echo \'export PATH="$HOME/.local/bin:$PATH"\' >> ~/.bashrc'
+    )
+    .workdir("/home/daytona")
+}

--- a/packages/sandbox-image/src/image.ts
+++ b/packages/sandbox-image/src/image.ts
@@ -25,7 +25,7 @@ export const SNAPSHOT_RESOURCES = {
 export const AGENT_PACKAGES = {
   claude: "@anthropic-ai/claude-code",
   codex: "@openai/codex",
-  opencode: "opencode",
+  // opencode: "opencode", // Package doesn't exist on npm - skipped
   gemini: "@google/gemini-cli",
   pi: "@mariozechner/pi-coding-agent",
 } as const
@@ -50,26 +50,38 @@ const GOOSE_INSTALL_CMD = `
  * Pre-installed agents:
  * - Claude (@anthropic-ai/claude-code)
  * - Codex (@openai/codex)
- * - OpenCode (opencode)
  * - Gemini (@google/gemini-cli)
  * - Pi (@mariozechner/pi-coding-agent)
  * - Goose (binary from GitHub releases)
  *
  * Note: Eliza is built-in to the agents package (no CLI installation needed).
+ * Note: OpenCode is skipped as the npm package doesn't exist.
  */
 export function getAgentSandboxImage(): Image {
   const npmPackages = Object.values(AGENT_PACKAGES).join(" ")
 
-  return Image.debianSlim("3.12")
+  return Image.base("node:22-bookworm")
     .runCommands(
-      // Install system dependencies (curl for Goose download, Node.js for npm)
+      // Install system dependencies (curl for Goose download, git for agents)
       "apt-get update && apt-get install -y --no-install-recommends " +
-        "curl ca-certificates nodejs npm git " +
+        "curl ca-certificates git bzip2 " +
         "&& rm -rf /var/lib/apt/lists/*"
     )
     .runCommands(
-      // Install all npm-based agent CLIs globally
-      `npm install -g ${npmPackages}`
+      // Install Claude Code CLI
+      "npm install -g @anthropic-ai/claude-code"
+    )
+    .runCommands(
+      // Install Codex CLI
+      "npm install -g @openai/codex"
+    )
+    .runCommands(
+      // Install Gemini CLI
+      "npm install -g @google/gemini-cli"
+    )
+    .runCommands(
+      // Install Pi CLI
+      "npm install -g @mariozechner/pi-coding-agent"
     )
     .runCommands(
       // Install Goose binary
@@ -77,7 +89,7 @@ export function getAgentSandboxImage(): Image {
     )
     .runCommands(
       // Create required directories and add ~/.local/bin to PATH
-      "mkdir -p ~/.gemini ~/.config/goose && " +
+      "mkdir -p ~/.gemini ~/.config/goose /home/daytona && " +
         'echo \'export PATH="$HOME/.local/bin:$PATH"\' >> ~/.bashrc'
     )
     .workdir("/home/daytona")

--- a/packages/sandbox-image/src/index.ts
+++ b/packages/sandbox-image/src/index.ts
@@ -1,0 +1,6 @@
+export {
+  getAgentSandboxImage,
+  AGENT_PACKAGES,
+  SNAPSHOT_NAME,
+  SNAPSHOT_RESOURCES,
+} from "./image"

--- a/packages/sandbox-image/tsconfig.json
+++ b/packages/sandbox-image/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/web/app/api/cron/rebuild-snapshot/route.ts
+++ b/packages/web/app/api/cron/rebuild-snapshot/route.ts
@@ -1,0 +1,54 @@
+import { Daytona } from "@daytonaio/sdk"
+import {
+  getAgentSandboxImage,
+  SNAPSHOT_NAME,
+  SNAPSHOT_RESOURCES,
+} from "@upstream/sandbox-image"
+
+// Building the snapshot can take several minutes
+export const maxDuration = 300
+
+export async function GET(req: Request) {
+  // Verify cron secret
+  const cronSecret = process.env.CRON_SECRET
+  if (
+    cronSecret &&
+    req.headers.get("authorization") !== `Bearer ${cronSecret}`
+  ) {
+    return new Response("Unauthorized", { status: 401 })
+  }
+
+  const apiKey = process.env.DAYTONA_API_KEY
+  if (!apiKey) {
+    return Response.json(
+      { error: "DAYTONA_API_KEY not configured" },
+      { status: 500 }
+    )
+  }
+
+  const daytona = new Daytona({ apiKey })
+
+  try {
+    const snapshot = await daytona.snapshot.create({
+      name: SNAPSHOT_NAME,
+      image: getAgentSandboxImage(),
+      resources: SNAPSHOT_RESOURCES,
+    })
+
+    return Response.json({
+      success: true,
+      message: "Snapshot rebuilt successfully",
+      snapshotName: snapshot.name,
+      timestamp: new Date().toISOString(),
+    })
+  } catch (err) {
+    console.error("[cron/rebuild-snapshot] failed:", err)
+    return Response.json(
+      {
+        error: "SNAPSHOT_BUILD_FAILED",
+        message: err instanceof Error ? err.message : String(err),
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/packages/web/vercel.json
+++ b/packages/web/vercel.json
@@ -10,6 +10,10 @@
     {
       "path": "/api/cron/agent-lifecycle",
       "schedule": "* * * * *"
+    },
+    {
+      "path": "/api/cron/rebuild-snapshot",
+      "schedule": "0 3 * * 0"
     }
   ]
 }


### PR DESCRIPTION
## Changes

- Add custom Daytona sandbox image with pre-installed agents

Create @upstream/sandbox-image package that defines a custom Daytona
snapshot with all agent CLIs pre-installed (Claude, Codex, OpenCode,
Gemini, Pi, Goose). This reduces sandbox startup time by eliminating
dynamic installation.

Resources: 1 vCPU, 3GB RAM, 5GB disk

Also adds a weekly cron job (/api/cron/rebuild-snapshot) that rebuilds
the snapshot every Sunday at 3:00 AM UTC to pick up latest agent versions.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>