### PR TITLE
Feat/mcp jobs

### DIFF
--- a/packages/mcp-providers/README.md
+++ b/packages/mcp-providers/README.md
@@ -82,7 +82,8 @@ const smithery = createSmitheryProvider({
   namespace: process.env.SMITHERY_NAMESPACE, // optional
 })
 
-const connectionId = getSmitheryConnectionId(chatId, "exa/exa")
+// The third argument is the owner-kind prefix, e.g. "chat" or "job".
+const connectionId = getSmitheryConnectionId(chatId, "exa/exa", "chat")
 
 const result = await smithery.createConnection(
   "https://server.smithery.ai/exa/exa/mcp",

--- a/packages/mcp-providers/src/smithery/provider.ts
+++ b/packages/mcp-providers/src/smithery/provider.ts
@@ -44,17 +44,22 @@ export function createSmitheryProvider(
 }
 
 /**
- * Deterministic connection id per (chat, qualifiedName) — safe to recreate.
+ * Deterministic connection id per (scope, qualifiedName) — safe to recreate.
  * Standalone function that doesn't require a provider instance.
+ *
+ * The `scopePrefix` distinguishes chat-scoped connections (`"chat"`) from
+ * job-scoped ones (`"job"`) so the two namespaces don't collide on Smithery's
+ * side. Defaults to `"chat"` for backward compatibility with existing rows.
  */
 export function getSmitheryConnectionId(
-  chatId: string,
-  qualifiedName: string
+  scopeId: string,
+  qualifiedName: string,
+  scopePrefix: string = "chat"
 ): string {
   // Slashes in qualifiedName (e.g. "exa/exa-search") would be parsed as path
   // segments by Smithery, so flatten them.
   const safeName = qualifiedName.replace(/\//g, "-")
-  return `chat-${chatId}-${safeName}`
+  return `${scopePrefix}-${scopeId}-${safeName}`
 }
 
 export class SmitheryProvider implements IConnectionProvider {

--- a/packages/web/app/api/chats/[chatId]/mcp-servers/[serverId]/route.ts
+++ b/packages/web/app/api/chats/[chatId]/mcp-servers/[serverId]/route.ts
@@ -1,17 +1,9 @@
 /**
  * DELETE /api/chats/<chatId>/mcp-servers/<serverId>
- *
- * Removes the connection both from our DB and (best-effort) from Smithery.
  */
-import { prisma } from "@/lib/db/prisma"
-import {
-  requireAuth,
-  isAuthError,
-  notFound,
-  internalError,
-  getChatWithAuth,
-} from "@/lib/db/api-helpers"
-import { createSmitheryProvider } from "@upstream/mcp-providers"
+import { requireAuth, isAuthError, notFound } from "@/lib/db/api-helpers"
+import { requireMcpOwnerAuth, type McpOwner } from "@/lib/mcp/owner"
+import { disconnectResponse } from "@/lib/mcp/connections"
 
 export async function DELETE(
   _req: Request,
@@ -19,33 +11,11 @@ export async function DELETE(
 ): Promise<Response> {
   const auth = await requireAuth()
   if (isAuthError(auth)) return auth
-  const { userId } = auth
   const { chatId, serverId } = await params
 
-  const chat = await getChatWithAuth(chatId, userId)
-  if (!chat) return notFound("Chat not found")
-
-  const server = await prisma.chatMcpServer.findUnique({
-    where: { id: serverId },
-  })
-  if (!server || server.chatId !== chatId) {
-    return notFound("Server not found")
+  const owner: McpOwner = { kind: "chat", id: chatId }
+  if (!(await requireMcpOwnerAuth(owner, auth.userId))) {
+    return notFound("Chat not found")
   }
-
-  try {
-    const apiKey = process.env.SMITHERY_API_KEY
-    if (apiKey && server.smitheryConnectionId) {
-      const smithery = createSmitheryProvider({
-        apiKey,
-        namespace: process.env.SMITHERY_NAMESPACE,
-      })
-      await smithery.deleteConnection(server.smitheryConnectionId)
-    }
-
-    await prisma.chatMcpServer.delete({ where: { id: serverId } })
-
-    return Response.json({ deleted: true })
-  } catch (err) {
-    return internalError(err)
-  }
+  return disconnectResponse(owner, serverId)
 }

--- a/packages/web/app/api/chats/[chatId]/mcp-servers/[serverId]/smithery-finalize/route.ts
+++ b/packages/web/app/api/chats/[chatId]/mcp-servers/[serverId]/smithery-finalize/route.ts
@@ -1,24 +1,11 @@
 /**
  * POST /api/chats/<chatId>/mcp-servers/<serverId>/smithery-finalize
  *
- * Called by the client after the Smithery OAuth popup closes. Polls Smithery
- * for `connected` state and persists the credentials on success.
- *
- * Returns { connected: true } on success, 400 otherwise so the modal can show
- * a "try again" message.
+ * Polls Smithery after the OAuth popup closes and persists credentials.
  */
-import { prisma } from "@/lib/db/prisma"
-import { encrypt } from "@/lib/db/encryption"
-import {
-  requireAuth,
-  isAuthError,
-  badRequest,
-  notFound,
-  serverConfigError,
-  internalError,
-  getChatWithAuth,
-} from "@/lib/db/api-helpers"
-import { createSmitheryProvider } from "@upstream/mcp-providers"
+import { requireAuth, isAuthError, notFound } from "@/lib/db/api-helpers"
+import { requireMcpOwnerAuth, type McpOwner } from "@/lib/mcp/owner"
+import { finalizeSmitheryResponse } from "@/lib/mcp/connections"
 
 export async function POST(
   _req: Request,
@@ -26,67 +13,11 @@ export async function POST(
 ): Promise<Response> {
   const auth = await requireAuth()
   if (isAuthError(auth)) return auth
-  const { userId } = auth
   const { chatId, serverId } = await params
 
-  const chat = await getChatWithAuth(chatId, userId)
-  if (!chat) return notFound("Chat not found")
-
-  const server = await prisma.chatMcpServer.findUnique({
-    where: { id: serverId },
-  })
-  if (!server || server.chatId !== chatId) return notFound("Server not found")
-
-  if (!server.smitheryConnectionId) {
-    return badRequest("Server has no Smithery connection id")
+  const owner: McpOwner = { kind: "chat", id: chatId }
+  if (!(await requireMcpOwnerAuth(owner, auth.userId))) {
+    return notFound("Chat not found")
   }
-
-  const apiKey = process.env.SMITHERY_API_KEY
-  if (!apiKey) return serverConfigError("SMITHERY_API_KEY")
-
-  try {
-    const smithery = createSmitheryProvider({
-      apiKey,
-      namespace: process.env.SMITHERY_NAMESPACE,
-    })
-
-    const status = await smithery.getConnectionStatus(
-      server.smitheryConnectionId
-    )
-
-    if (status.state === "connected") {
-      const namespace = await smithery.getNamespace()
-      if (!namespace) {
-        return Response.json(
-          { error: "Failed to resolve Smithery namespace" },
-          { status: 500 }
-        )
-      }
-
-      const mcpEndpoint = smithery.getMcpEndpointWithNamespace(
-        namespace,
-        server.smitheryConnectionId
-      )
-
-      await prisma.chatMcpServer.update({
-        where: { id: serverId },
-        data: {
-          mcpUrl: mcpEndpoint,
-          smitheryNamespace: namespace,
-          encryptedApiKey: encrypt(apiKey),
-          status: "connected",
-          lastError: null,
-        },
-      })
-
-      return Response.json({ connected: true })
-    }
-
-    return Response.json(
-      { error: "Connection not yet authorized. Please try again." },
-      { status: 400 }
-    )
-  } catch (err) {
-    return internalError(err)
-  }
+  return finalizeSmitheryResponse(owner, serverId)
 }

--- a/packages/web/app/api/chats/[chatId]/mcp-servers/github/route.ts
+++ b/packages/web/app/api/chats/[chatId]/mcp-servers/github/route.ts
@@ -1,23 +1,12 @@
 /**
  * POST /api/chats/<chatId>/mcp-servers/github
  *
- * Add a sentinel ChatMcpServer row that points at GitHub's hosted MCP
- * (api.githubcopilot.com/mcp/). No Smithery involved — the agent-side
- * loader detects the sentinel qualifiedName and mints a fresh installation
- * token on every turn.
- *
- * Requires the user to have completed the GitHub App install first
- * (User.githubAppInstallationId must be set).
+ * Add a sentinel row pointing at GitHub's hosted MCP. The runtime loader
+ * mints fresh installation tokens from the user's githubAppInstallationId.
  */
-import { prisma } from "@/lib/db/prisma"
-import {
-  requireAuth,
-  isAuthError,
-  notFound,
-  internalError,
-  getChatWithAuth,
-} from "@/lib/db/api-helpers"
-import { GITHUB_MCP_QUALIFIED_NAME, GITHUB_MCP_URL } from "@upstream/mcp-providers"
+import { requireAuth, isAuthError, notFound } from "@/lib/db/api-helpers"
+import { requireMcpOwnerAuth, type McpOwner } from "@/lib/mcp/owner"
+import { attachGithubResponse } from "@/lib/mcp/connections"
 
 export async function POST(
   _req: Request,
@@ -25,47 +14,11 @@ export async function POST(
 ): Promise<Response> {
   const auth = await requireAuth()
   if (isAuthError(auth)) return auth
-  const { userId } = auth
   const { chatId } = await params
 
-  const chat = await getChatWithAuth(chatId, userId)
-  if (!chat) return notFound("Chat not found")
-
-  const user = await prisma.user.findUnique({
-    where: { id: userId },
-    select: { githubAppInstallationId: true },
-  })
-  if (!user?.githubAppInstallationId) {
-    return Response.json(
-      { error: "GitHub App not installed for this user" },
-      { status: 409 }
-    )
+  const owner: McpOwner = { kind: "chat", id: chatId }
+  if (!(await requireMcpOwnerAuth(owner, auth.userId))) {
+    return notFound("Chat not found")
   }
-
-  try {
-    const { id: serverId } = await prisma.chatMcpServer.upsert({
-      where: {
-        chatId_qualifiedName: {
-          chatId,
-          qualifiedName: GITHUB_MCP_QUALIFIED_NAME,
-        },
-      },
-      create: {
-        chatId,
-        qualifiedName: GITHUB_MCP_QUALIFIED_NAME,
-        displayName: "GitHub",
-        iconUrl: null,
-        mcpUrl: GITHUB_MCP_URL,
-        status: "connected",
-      },
-      update: {
-        status: "connected",
-        lastError: null,
-      },
-      select: { id: true },
-    })
-    return Response.json({ connected: true, serverId })
-  } catch (err) {
-    return internalError(err)
-  }
+  return attachGithubResponse(owner, auth.userId)
 }

--- a/packages/web/app/api/chats/[chatId]/mcp-servers/route.ts
+++ b/packages/web/app/api/chats/[chatId]/mcp-servers/route.ts
@@ -2,41 +2,20 @@
  * GET  /api/chats/<chatId>/mcp-servers     list connections on this chat
  * POST /api/chats/<chatId>/mcp-servers     start a new connection via Smithery
  *
- * POST body: { slug, url?, name, iconUrl? }
- *   - slug          qualifiedName from the registry (e.g. "exa/exa-search")
- *   - url           remote MCP URL. If absent (non-deployed server), the client
- *                   should have fetched it from /api/mcp-registry/<slug> first.
- *   - name          display name
- *   - iconUrl       optional
- *
- * POST returns one of:
- *   { connected: true,  serverId }                    instant-connect succeeded
- *   { connected: false, serverId, authUrl }           open authUrl in a popup,
- *                                                     then POST /smithery-finalize
+ * Thin wrappers around the owner-parameterized handlers in lib/mcp/connections.
  */
-import { prisma } from "@/lib/db/prisma"
-import { encrypt } from "@/lib/db/encryption"
 import {
   requireAuth,
   isAuthError,
   badRequest,
   notFound,
-  serverConfigError,
-  internalError,
-  getChatWithAuth,
 } from "@/lib/db/api-helpers"
+import { requireMcpOwnerAuth, type McpOwner } from "@/lib/mcp/owner"
 import {
-  createSmitheryProvider,
-  getSmitheryConnectionId,
-  isSmitheryServer,
-} from "@upstream/mcp-providers"
-
-interface ConnectBody {
-  slug?: string
-  url?: string
-  name?: string
-  iconUrl?: string | null
-}
+  connectSmitheryResponse,
+  listConnectionsResponse,
+  type ConnectSmitheryBody,
+} from "@/lib/mcp/connections"
 
 export async function GET(
   _req: Request,
@@ -44,27 +23,13 @@ export async function GET(
 ): Promise<Response> {
   const auth = await requireAuth()
   if (isAuthError(auth)) return auth
-  const { userId } = auth
   const { chatId } = await params
 
-  const chat = await getChatWithAuth(chatId, userId)
-  if (!chat) return notFound("Chat not found")
-
-  const servers = await prisma.chatMcpServer.findMany({
-    where: { chatId },
-    orderBy: { createdAt: "desc" },
-    select: {
-      id: true,
-      qualifiedName: true,
-      displayName: true,
-      iconUrl: true,
-      status: true,
-      lastError: true,
-      createdAt: true,
-    },
-  })
-
-  return Response.json({ servers })
+  const owner: McpOwner = { kind: "chat", id: chatId }
+  if (!(await requireMcpOwnerAuth(owner, auth.userId))) {
+    return notFound("Chat not found")
+  }
+  return listConnectionsResponse(owner)
 }
 
 export async function POST(
@@ -73,86 +38,18 @@ export async function POST(
 ): Promise<Response> {
   const auth = await requireAuth()
   if (isAuthError(auth)) return auth
-  const { userId } = auth
   const { chatId } = await params
 
-  const chat = await getChatWithAuth(chatId, userId)
-  if (!chat) return notFound("Chat not found")
+  const owner: McpOwner = { kind: "chat", id: chatId }
+  if (!(await requireMcpOwnerAuth(owner, auth.userId))) {
+    return notFound("Chat not found")
+  }
 
-  const apiKey = process.env.SMITHERY_API_KEY
-  if (!apiKey) return serverConfigError("SMITHERY_API_KEY")
-
-  let body: ConnectBody
+  let body: ConnectSmitheryBody
   try {
     body = await req.json()
   } catch {
     return badRequest("Invalid JSON body")
   }
-
-  const { slug, url, name, iconUrl } = body
-  if (!slug || !url || !name) {
-    return badRequest("Missing required fields: slug, url, name")
-  }
-
-  // We only support Smithery-hosted servers in this PR. Standard MCP OAuth
-  // discovery is intentionally out of scope here.
-  if (!isSmitheryServer(url)) {
-    return badRequest(
-      "Only Smithery-hosted servers (server.smithery.ai) are supported"
-    )
-  }
-
-  try {
-    // Smithery's PUT is idempotent; safe to call before we touch our DB.
-    const smithery = createSmitheryProvider({
-      apiKey,
-      namespace: process.env.SMITHERY_NAMESPACE,
-    })
-    const connectionId = getSmitheryConnectionId(chatId, slug)
-    const result = await smithery.createConnection(url, connectionId, name)
-
-    if (result.status === "error") {
-      return Response.json(
-        { error: result.error ?? "Smithery connection failed" },
-        { status: 502 }
-      )
-    }
-
-    const isConnected = result.status === "connected"
-    const row = {
-      smitheryConnectionId: connectionId,
-      smitheryNamespace: result.namespace,
-      mcpUrl: result.mcpEndpoint,
-      status: isConnected ? "connected" : "pending",
-      encryptedApiKey: isConnected ? encrypt(apiKey) : null,
-      lastError: null,
-    }
-    const { id: serverId } = await prisma.chatMcpServer.upsert({
-      where: { chatId_qualifiedName: { chatId, qualifiedName: slug } },
-      create: {
-        chatId,
-        qualifiedName: slug,
-        displayName: name,
-        iconUrl: iconUrl ?? null,
-        ...row,
-      },
-      update: {
-        displayName: name,
-        iconUrl: iconUrl ?? null,
-        ...row,
-      },
-      select: { id: true },
-    })
-
-    if (isConnected) {
-      return Response.json({ connected: true, serverId })
-    }
-    return Response.json({
-      connected: false,
-      serverId,
-      authUrl: result.authorizationUrl,
-    })
-  } catch (err) {
-    return internalError(err)
-  }
+  return connectSmitheryResponse(owner, body)
 }

--- a/packages/web/app/api/chats/[chatId]/messages/route.ts
+++ b/packages/web/app/api/chats/[chatId]/messages/route.ts
@@ -19,7 +19,7 @@ import {
 import { logActivityAsync } from "@/lib/db/activity-log"
 import { checkSharedClaudeUsage } from "@/lib/db/usage-limit"
 import { createBackgroundAgentSession, type Agent } from "@/lib/agent-session"
-import { loadChatMcpServers } from "@/lib/mcp/agent-servers"
+import { loadMcpConnections } from "@/lib/mcp/agent-servers"
 import { getClaudeCredentials } from "@/lib/claude-credentials"
 import { getEnvForModel } from "@upstream/common"
 import { decrypt } from "@/lib/db/encryption"
@@ -477,11 +477,11 @@ export async function POST(
 
     // Fetch this chat's connected MCP servers so the agent sees them as tools.
     // Best-effort — a fetch error shouldn't block the turn.
-    let mcpServers: Awaited<ReturnType<typeof loadChatMcpServers>> = []
+    let mcpServers: Awaited<ReturnType<typeof loadMcpConnections>> = []
     try {
-      mcpServers = await loadChatMcpServers(chatId)
+      mcpServers = await loadMcpConnections({ kind: "chat", id: chatId })
     } catch (err) {
-      console.error("[messages] loadChatMcpServers failed:", err)
+      console.error("[messages] loadMcpConnections failed:", err)
     }
 
     // Debug: log planMode from payload

--- a/packages/web/app/api/cron/agent-lifecycle/route.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/route.ts
@@ -20,6 +20,7 @@ import {
   type AgentSnapshot,
 } from "@/lib/agent-session"
 import { createGitOperationMessage } from "@/lib/db/git-messages"
+import { loadJobMcpServers } from "@/lib/mcp/agent-servers"
 
 // Vercel Pro plan allows up to 5 minutes for cron jobs
 export const maxDuration = 300
@@ -430,12 +431,24 @@ async function startJobExecution(
   const repoPath = `${PATHS.SANDBOX_HOME}/project`
   const env = getEnvForModel(job.model ?? undefined, job.agent as Agent, credentials)
 
+  // Load job-scoped MCP servers. The loader marks rows with status="error" and
+  // a descriptive lastError if the GitHub App is gone or any other auth issue
+  // is found — best-effort, so the run proceeds without that MCP server rather
+  // than failing the whole job. Failure to load shouldn't tank the turn.
+  let mcpServers: Awaited<ReturnType<typeof loadJobMcpServers>> = []
+  try {
+    mcpServers = await loadJobMcpServers(job.id)
+  } catch (err) {
+    console.error(`[agent-lifecycle] loadJobMcpServers failed for ${job.id}:`, err)
+  }
+
   const bgSession = await createBackgroundAgentSession(sandbox, {
     repoPath,
     previewUrlPattern: previewUrlPattern ?? undefined,
     agent: job.agent as Agent,
     model: job.model ?? undefined,
     env: Object.keys(env).length > 0 ? env : undefined,
+    mcpServers,
   })
 
   // 8. Build the prompt (augment with trigger context for webhook-triggered runs)

--- a/packages/web/app/api/cron/agent-lifecycle/route.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/route.ts
@@ -20,7 +20,7 @@ import {
   type AgentSnapshot,
 } from "@/lib/agent-session"
 import { createGitOperationMessage } from "@/lib/db/git-messages"
-import { loadJobMcpServers } from "@/lib/mcp/agent-servers"
+import { loadMcpConnections } from "@/lib/mcp/agent-servers"
 
 // Vercel Pro plan allows up to 5 minutes for cron jobs
 export const maxDuration = 300
@@ -439,11 +439,11 @@ async function startJobExecution(
   // a descriptive lastError if the GitHub App is gone or any other auth issue
   // is found — best-effort, so the run proceeds without that MCP server rather
   // than failing the whole job. Failure to load shouldn't tank the turn.
-  let mcpServers: Awaited<ReturnType<typeof loadJobMcpServers>> = []
+  let mcpServers: Awaited<ReturnType<typeof loadMcpConnections>> = []
   try {
-    mcpServers = await loadJobMcpServers(job.id)
+    mcpServers = await loadMcpConnections({ kind: "job", id: job.id })
   } catch (err) {
-    console.error(`[agent-lifecycle] loadJobMcpServers failed for ${job.id}:`, err)
+    console.error(`[agent-lifecycle] loadMcpConnections failed for ${job.id}:`, err)
   }
 
   const bgSession = await createBackgroundAgentSession(sandbox, {

--- a/packages/web/app/api/cron/agent-lifecycle/route.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/route.ts
@@ -112,6 +112,7 @@ export async function GET(req: Request) {
     const dueJobs = await prisma.scheduledJob.findMany({
       where: {
         enabled: true,
+        isDraft: false,
         nextRunAt: { lte: now },
         runs: { none: { status: "running" } },
       },
@@ -145,8 +146,11 @@ export async function GET(req: Request) {
     // =========================================
     // 2. Start Pending Scheduled Runs
     // =========================================
+    // Drafts shouldn't have pending runs (the run-now endpoint blocks them),
+    // but filter here too so a stale row from before this guard can't sneak
+    // through the cron.
     const pendingRuns = await prisma.scheduledJobRun.findMany({
-      where: { status: "pending" },
+      where: { status: "pending", job: { isDraft: false } },
       include: { job: true },
     })
 

--- a/packages/web/app/api/mcp/connect/github/route.ts
+++ b/packages/web/app/api/mcp/connect/github/route.ts
@@ -110,11 +110,18 @@ export async function DELETE(_req: NextRequest): Promise<Response> {
     data: { githubAppInstallationId: null },
   })
 
-  // Also drop any per-chat GitHub MCP rows that point at this user's chats,
-  // so the modal stops showing GitHub as connected.
+  // Also drop any per-chat / per-job GitHub MCP rows that point at this
+  // user's resources, so the picker stops showing GitHub as connected and a
+  // scheduled run days later doesn't try to use a dead installation id.
   await prisma.chatMcpServer.deleteMany({
     where: {
       chat: { userId },
+      qualifiedName: "github/github",
+    },
+  })
+  await prisma.scheduledJobMcpServer.deleteMany({
+    where: {
+      job: { userId },
       qualifiedName: "github/github",
     },
   })

--- a/packages/web/app/api/mcp/connect/github/route.ts
+++ b/packages/web/app/api/mcp/connect/github/route.ts
@@ -110,19 +110,16 @@ export async function DELETE(_req: NextRequest): Promise<Response> {
     data: { githubAppInstallationId: null },
   })
 
-  // Also drop any per-chat / per-job GitHub MCP rows that point at this
-  // user's resources, so the picker stops showing GitHub as connected and a
+  // Also drop any GitHub MCP rows that point at this user's resources (chats
+  // or scheduled jobs), so the picker stops showing GitHub as connected and a
   // scheduled run days later doesn't try to use a dead installation id.
-  await prisma.chatMcpServer.deleteMany({
+  await prisma.mcpServerConnection.deleteMany({
     where: {
-      chat: { userId },
       qualifiedName: "github/github",
-    },
-  })
-  await prisma.scheduledJobMcpServer.deleteMany({
-    where: {
-      job: { userId },
-      qualifiedName: "github/github",
+      OR: [
+        { chat: { userId } },
+        { scheduledJob: { userId } },
+      ],
     },
   })
 

--- a/packages/web/app/api/scheduled-jobs/[id]/mcp-servers/[serverId]/route.ts
+++ b/packages/web/app/api/scheduled-jobs/[id]/mcp-servers/[serverId]/route.ts
@@ -1,17 +1,9 @@
 /**
  * DELETE /api/scheduled-jobs/<id>/mcp-servers/<serverId>
- *
- * Removes the connection from our DB and (best-effort) from Smithery.
  */
-import { prisma } from "@/lib/db/prisma"
-import {
-  requireAuth,
-  isAuthError,
-  notFound,
-  internalError,
-  getJobWithAuth,
-} from "@/lib/db/api-helpers"
-import { createSmitheryProvider } from "@upstream/mcp-providers"
+import { requireAuth, isAuthError, notFound } from "@/lib/db/api-helpers"
+import { requireMcpOwnerAuth, type McpOwner } from "@/lib/mcp/owner"
+import { disconnectResponse } from "@/lib/mcp/connections"
 
 export async function DELETE(
   _req: Request,
@@ -19,33 +11,11 @@ export async function DELETE(
 ): Promise<Response> {
   const auth = await requireAuth()
   if (isAuthError(auth)) return auth
-  const { userId } = auth
   const { id: jobId, serverId } = await params
 
-  const job = await getJobWithAuth(jobId, userId)
-  if (!job) return notFound("Scheduled job not found")
-
-  const server = await prisma.scheduledJobMcpServer.findUnique({
-    where: { id: serverId },
-  })
-  if (!server || server.jobId !== jobId) {
-    return notFound("Server not found")
+  const owner: McpOwner = { kind: "job", id: jobId }
+  if (!(await requireMcpOwnerAuth(owner, auth.userId))) {
+    return notFound("Scheduled job not found")
   }
-
-  try {
-    const apiKey = process.env.SMITHERY_API_KEY
-    if (apiKey && server.smitheryConnectionId) {
-      const smithery = createSmitheryProvider({
-        apiKey,
-        namespace: process.env.SMITHERY_NAMESPACE,
-      })
-      await smithery.deleteConnection(server.smitheryConnectionId)
-    }
-
-    await prisma.scheduledJobMcpServer.delete({ where: { id: serverId } })
-
-    return Response.json({ deleted: true })
-  } catch (err) {
-    return internalError(err)
-  }
+  return disconnectResponse(owner, serverId)
 }

--- a/packages/web/app/api/scheduled-jobs/[id]/mcp-servers/[serverId]/route.ts
+++ b/packages/web/app/api/scheduled-jobs/[id]/mcp-servers/[serverId]/route.ts
@@ -1,0 +1,51 @@
+/**
+ * DELETE /api/scheduled-jobs/<id>/mcp-servers/<serverId>
+ *
+ * Removes the connection from our DB and (best-effort) from Smithery.
+ */
+import { prisma } from "@/lib/db/prisma"
+import {
+  requireAuth,
+  isAuthError,
+  notFound,
+  internalError,
+  getJobWithAuth,
+} from "@/lib/db/api-helpers"
+import { createSmitheryProvider } from "@upstream/mcp-providers"
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Promise<{ id: string; serverId: string }> }
+): Promise<Response> {
+  const auth = await requireAuth()
+  if (isAuthError(auth)) return auth
+  const { userId } = auth
+  const { id: jobId, serverId } = await params
+
+  const job = await getJobWithAuth(jobId, userId)
+  if (!job) return notFound("Scheduled job not found")
+
+  const server = await prisma.scheduledJobMcpServer.findUnique({
+    where: { id: serverId },
+  })
+  if (!server || server.jobId !== jobId) {
+    return notFound("Server not found")
+  }
+
+  try {
+    const apiKey = process.env.SMITHERY_API_KEY
+    if (apiKey && server.smitheryConnectionId) {
+      const smithery = createSmitheryProvider({
+        apiKey,
+        namespace: process.env.SMITHERY_NAMESPACE,
+      })
+      await smithery.deleteConnection(server.smitheryConnectionId)
+    }
+
+    await prisma.scheduledJobMcpServer.delete({ where: { id: serverId } })
+
+    return Response.json({ deleted: true })
+  } catch (err) {
+    return internalError(err)
+  }
+}

--- a/packages/web/app/api/scheduled-jobs/[id]/mcp-servers/[serverId]/smithery-finalize/route.ts
+++ b/packages/web/app/api/scheduled-jobs/[id]/mcp-servers/[serverId]/smithery-finalize/route.ts
@@ -1,0 +1,91 @@
+/**
+ * POST /api/scheduled-jobs/<id>/mcp-servers/<serverId>/smithery-finalize
+ *
+ * Called by the client after the Smithery OAuth popup closes. Polls Smithery
+ * for `connected` state and persists the credentials on success.
+ *
+ * Returns { connected: true } on success, 400 otherwise.
+ */
+import { prisma } from "@/lib/db/prisma"
+import { encrypt } from "@/lib/db/encryption"
+import {
+  requireAuth,
+  isAuthError,
+  badRequest,
+  notFound,
+  serverConfigError,
+  internalError,
+  getJobWithAuth,
+} from "@/lib/db/api-helpers"
+import { createSmitheryProvider } from "@upstream/mcp-providers"
+
+export async function POST(
+  _req: Request,
+  { params }: { params: Promise<{ id: string; serverId: string }> }
+): Promise<Response> {
+  const auth = await requireAuth()
+  if (isAuthError(auth)) return auth
+  const { userId } = auth
+  const { id: jobId, serverId } = await params
+
+  const job = await getJobWithAuth(jobId, userId)
+  if (!job) return notFound("Scheduled job not found")
+
+  const server = await prisma.scheduledJobMcpServer.findUnique({
+    where: { id: serverId },
+  })
+  if (!server || server.jobId !== jobId) return notFound("Server not found")
+
+  if (!server.smitheryConnectionId) {
+    return badRequest("Server has no Smithery connection id")
+  }
+
+  const apiKey = process.env.SMITHERY_API_KEY
+  if (!apiKey) return serverConfigError("SMITHERY_API_KEY")
+
+  try {
+    const smithery = createSmitheryProvider({
+      apiKey,
+      namespace: process.env.SMITHERY_NAMESPACE,
+    })
+
+    const status = await smithery.getConnectionStatus(
+      server.smitheryConnectionId
+    )
+
+    if (status.state === "connected") {
+      const namespace = await smithery.getNamespace()
+      if (!namespace) {
+        return Response.json(
+          { error: "Failed to resolve Smithery namespace" },
+          { status: 500 }
+        )
+      }
+
+      const mcpEndpoint = smithery.getMcpEndpointWithNamespace(
+        namespace,
+        server.smitheryConnectionId
+      )
+
+      await prisma.scheduledJobMcpServer.update({
+        where: { id: serverId },
+        data: {
+          mcpUrl: mcpEndpoint,
+          smitheryNamespace: namespace,
+          encryptedApiKey: encrypt(apiKey),
+          status: "connected",
+          lastError: null,
+        },
+      })
+
+      return Response.json({ connected: true })
+    }
+
+    return Response.json(
+      { error: "Connection not yet authorized. Please try again." },
+      { status: 400 }
+    )
+  } catch (err) {
+    return internalError(err)
+  }
+}

--- a/packages/web/app/api/scheduled-jobs/[id]/mcp-servers/[serverId]/smithery-finalize/route.ts
+++ b/packages/web/app/api/scheduled-jobs/[id]/mcp-servers/[serverId]/smithery-finalize/route.ts
@@ -1,23 +1,11 @@
 /**
  * POST /api/scheduled-jobs/<id>/mcp-servers/<serverId>/smithery-finalize
  *
- * Called by the client after the Smithery OAuth popup closes. Polls Smithery
- * for `connected` state and persists the credentials on success.
- *
- * Returns { connected: true } on success, 400 otherwise.
+ * Polls Smithery after the OAuth popup closes and persists credentials.
  */
-import { prisma } from "@/lib/db/prisma"
-import { encrypt } from "@/lib/db/encryption"
-import {
-  requireAuth,
-  isAuthError,
-  badRequest,
-  notFound,
-  serverConfigError,
-  internalError,
-  getJobWithAuth,
-} from "@/lib/db/api-helpers"
-import { createSmitheryProvider } from "@upstream/mcp-providers"
+import { requireAuth, isAuthError, notFound } from "@/lib/db/api-helpers"
+import { requireMcpOwnerAuth, type McpOwner } from "@/lib/mcp/owner"
+import { finalizeSmitheryResponse } from "@/lib/mcp/connections"
 
 export async function POST(
   _req: Request,
@@ -25,67 +13,11 @@ export async function POST(
 ): Promise<Response> {
   const auth = await requireAuth()
   if (isAuthError(auth)) return auth
-  const { userId } = auth
   const { id: jobId, serverId } = await params
 
-  const job = await getJobWithAuth(jobId, userId)
-  if (!job) return notFound("Scheduled job not found")
-
-  const server = await prisma.scheduledJobMcpServer.findUnique({
-    where: { id: serverId },
-  })
-  if (!server || server.jobId !== jobId) return notFound("Server not found")
-
-  if (!server.smitheryConnectionId) {
-    return badRequest("Server has no Smithery connection id")
+  const owner: McpOwner = { kind: "job", id: jobId }
+  if (!(await requireMcpOwnerAuth(owner, auth.userId))) {
+    return notFound("Scheduled job not found")
   }
-
-  const apiKey = process.env.SMITHERY_API_KEY
-  if (!apiKey) return serverConfigError("SMITHERY_API_KEY")
-
-  try {
-    const smithery = createSmitheryProvider({
-      apiKey,
-      namespace: process.env.SMITHERY_NAMESPACE,
-    })
-
-    const status = await smithery.getConnectionStatus(
-      server.smitheryConnectionId
-    )
-
-    if (status.state === "connected") {
-      const namespace = await smithery.getNamespace()
-      if (!namespace) {
-        return Response.json(
-          { error: "Failed to resolve Smithery namespace" },
-          { status: 500 }
-        )
-      }
-
-      const mcpEndpoint = smithery.getMcpEndpointWithNamespace(
-        namespace,
-        server.smitheryConnectionId
-      )
-
-      await prisma.scheduledJobMcpServer.update({
-        where: { id: serverId },
-        data: {
-          mcpUrl: mcpEndpoint,
-          smitheryNamespace: namespace,
-          encryptedApiKey: encrypt(apiKey),
-          status: "connected",
-          lastError: null,
-        },
-      })
-
-      return Response.json({ connected: true })
-    }
-
-    return Response.json(
-      { error: "Connection not yet authorized. Please try again." },
-      { status: 400 }
-    )
-  } catch (err) {
-    return internalError(err)
-  }
+  return finalizeSmitheryResponse(owner, serverId)
 }

--- a/packages/web/app/api/scheduled-jobs/[id]/mcp-servers/github/route.ts
+++ b/packages/web/app/api/scheduled-jobs/[id]/mcp-servers/github/route.ts
@@ -1,22 +1,12 @@
 /**
  * POST /api/scheduled-jobs/<id>/mcp-servers/github
  *
- * Add a sentinel ScheduledJobMcpServer row that points at GitHub's hosted MCP.
- * The agent-side loader detects the sentinel qualifiedName and mints a fresh
- * installation token on every run from the owning user's
- * githubAppInstallationId.
- *
- * Requires the user to have completed the GitHub App install first.
+ * Add a sentinel row pointing at GitHub's hosted MCP. The runtime loader
+ * mints fresh installation tokens from the user's githubAppInstallationId.
  */
-import { prisma } from "@/lib/db/prisma"
-import {
-  requireAuth,
-  isAuthError,
-  notFound,
-  internalError,
-  getJobWithAuth,
-} from "@/lib/db/api-helpers"
-import { GITHUB_MCP_QUALIFIED_NAME, GITHUB_MCP_URL } from "@upstream/mcp-providers"
+import { requireAuth, isAuthError, notFound } from "@/lib/db/api-helpers"
+import { requireMcpOwnerAuth, type McpOwner } from "@/lib/mcp/owner"
+import { attachGithubResponse } from "@/lib/mcp/connections"
 
 export async function POST(
   _req: Request,
@@ -24,47 +14,11 @@ export async function POST(
 ): Promise<Response> {
   const auth = await requireAuth()
   if (isAuthError(auth)) return auth
-  const { userId } = auth
   const { id: jobId } = await params
 
-  const job = await getJobWithAuth(jobId, userId)
-  if (!job) return notFound("Scheduled job not found")
-
-  const user = await prisma.user.findUnique({
-    where: { id: userId },
-    select: { githubAppInstallationId: true },
-  })
-  if (!user?.githubAppInstallationId) {
-    return Response.json(
-      { error: "GitHub App not installed for this user" },
-      { status: 409 }
-    )
+  const owner: McpOwner = { kind: "job", id: jobId }
+  if (!(await requireMcpOwnerAuth(owner, auth.userId))) {
+    return notFound("Scheduled job not found")
   }
-
-  try {
-    const { id: serverId } = await prisma.scheduledJobMcpServer.upsert({
-      where: {
-        jobId_qualifiedName: {
-          jobId,
-          qualifiedName: GITHUB_MCP_QUALIFIED_NAME,
-        },
-      },
-      create: {
-        jobId,
-        qualifiedName: GITHUB_MCP_QUALIFIED_NAME,
-        displayName: "GitHub",
-        iconUrl: null,
-        mcpUrl: GITHUB_MCP_URL,
-        status: "connected",
-      },
-      update: {
-        status: "connected",
-        lastError: null,
-      },
-      select: { id: true },
-    })
-    return Response.json({ connected: true, serverId })
-  } catch (err) {
-    return internalError(err)
-  }
+  return attachGithubResponse(owner, auth.userId)
 }

--- a/packages/web/app/api/scheduled-jobs/[id]/mcp-servers/github/route.ts
+++ b/packages/web/app/api/scheduled-jobs/[id]/mcp-servers/github/route.ts
@@ -1,0 +1,70 @@
+/**
+ * POST /api/scheduled-jobs/<id>/mcp-servers/github
+ *
+ * Add a sentinel ScheduledJobMcpServer row that points at GitHub's hosted MCP.
+ * The agent-side loader detects the sentinel qualifiedName and mints a fresh
+ * installation token on every run from the owning user's
+ * githubAppInstallationId.
+ *
+ * Requires the user to have completed the GitHub App install first.
+ */
+import { prisma } from "@/lib/db/prisma"
+import {
+  requireAuth,
+  isAuthError,
+  notFound,
+  internalError,
+  getJobWithAuth,
+} from "@/lib/db/api-helpers"
+import { GITHUB_MCP_QUALIFIED_NAME, GITHUB_MCP_URL } from "@upstream/mcp-providers"
+
+export async function POST(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<Response> {
+  const auth = await requireAuth()
+  if (isAuthError(auth)) return auth
+  const { userId } = auth
+  const { id: jobId } = await params
+
+  const job = await getJobWithAuth(jobId, userId)
+  if (!job) return notFound("Scheduled job not found")
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { githubAppInstallationId: true },
+  })
+  if (!user?.githubAppInstallationId) {
+    return Response.json(
+      { error: "GitHub App not installed for this user" },
+      { status: 409 }
+    )
+  }
+
+  try {
+    const { id: serverId } = await prisma.scheduledJobMcpServer.upsert({
+      where: {
+        jobId_qualifiedName: {
+          jobId,
+          qualifiedName: GITHUB_MCP_QUALIFIED_NAME,
+        },
+      },
+      create: {
+        jobId,
+        qualifiedName: GITHUB_MCP_QUALIFIED_NAME,
+        displayName: "GitHub",
+        iconUrl: null,
+        mcpUrl: GITHUB_MCP_URL,
+        status: "connected",
+      },
+      update: {
+        status: "connected",
+        lastError: null,
+      },
+      select: { id: true },
+    })
+    return Response.json({ connected: true, serverId })
+  } catch (err) {
+    return internalError(err)
+  }
+}

--- a/packages/web/app/api/scheduled-jobs/[id]/mcp-servers/route.ts
+++ b/packages/web/app/api/scheduled-jobs/[id]/mcp-servers/route.ts
@@ -2,32 +2,20 @@
  * GET  /api/scheduled-jobs/<id>/mcp-servers     list connections on this job
  * POST /api/scheduled-jobs/<id>/mcp-servers     start a new connection via Smithery
  *
- * Mirror of /api/chats/<chatId>/mcp-servers, scoped to a ScheduledJob.
- * Connections persist on the job; each run loads them via loadJobMcpServers.
+ * Thin wrappers around the owner-parameterized handlers in lib/mcp/connections.
  */
-import { prisma } from "@/lib/db/prisma"
-import { encrypt } from "@/lib/db/encryption"
 import {
   requireAuth,
   isAuthError,
   badRequest,
   notFound,
-  serverConfigError,
-  internalError,
-  getJobWithAuth,
 } from "@/lib/db/api-helpers"
+import { requireMcpOwnerAuth, type McpOwner } from "@/lib/mcp/owner"
 import {
-  createSmitheryProvider,
-  getSmitheryConnectionId,
-  isSmitheryServer,
-} from "@upstream/mcp-providers"
-
-interface ConnectBody {
-  slug?: string
-  url?: string
-  name?: string
-  iconUrl?: string | null
-}
+  connectSmitheryResponse,
+  listConnectionsResponse,
+  type ConnectSmitheryBody,
+} from "@/lib/mcp/connections"
 
 export async function GET(
   _req: Request,
@@ -35,27 +23,13 @@ export async function GET(
 ): Promise<Response> {
   const auth = await requireAuth()
   if (isAuthError(auth)) return auth
-  const { userId } = auth
   const { id: jobId } = await params
 
-  const job = await getJobWithAuth(jobId, userId)
-  if (!job) return notFound("Scheduled job not found")
-
-  const servers = await prisma.scheduledJobMcpServer.findMany({
-    where: { jobId },
-    orderBy: { createdAt: "desc" },
-    select: {
-      id: true,
-      qualifiedName: true,
-      displayName: true,
-      iconUrl: true,
-      status: true,
-      lastError: true,
-      createdAt: true,
-    },
-  })
-
-  return Response.json({ servers })
+  const owner: McpOwner = { kind: "job", id: jobId }
+  if (!(await requireMcpOwnerAuth(owner, auth.userId))) {
+    return notFound("Scheduled job not found")
+  }
+  return listConnectionsResponse(owner)
 }
 
 export async function POST(
@@ -64,84 +38,18 @@ export async function POST(
 ): Promise<Response> {
   const auth = await requireAuth()
   if (isAuthError(auth)) return auth
-  const { userId } = auth
   const { id: jobId } = await params
 
-  const job = await getJobWithAuth(jobId, userId)
-  if (!job) return notFound("Scheduled job not found")
+  const owner: McpOwner = { kind: "job", id: jobId }
+  if (!(await requireMcpOwnerAuth(owner, auth.userId))) {
+    return notFound("Scheduled job not found")
+  }
 
-  const apiKey = process.env.SMITHERY_API_KEY
-  if (!apiKey) return serverConfigError("SMITHERY_API_KEY")
-
-  let body: ConnectBody
+  let body: ConnectSmitheryBody
   try {
     body = await req.json()
   } catch {
     return badRequest("Invalid JSON body")
   }
-
-  const { slug, url, name, iconUrl } = body
-  if (!slug || !url || !name) {
-    return badRequest("Missing required fields: slug, url, name")
-  }
-
-  if (!isSmitheryServer(url)) {
-    return badRequest(
-      "Only Smithery-hosted servers (server.smithery.ai) are supported"
-    )
-  }
-
-  try {
-    const smithery = createSmitheryProvider({
-      apiKey,
-      namespace: process.env.SMITHERY_NAMESPACE,
-    })
-    // "job" prefix keeps the namespace distinct from chat-scoped ids.
-    const connectionId = getSmitheryConnectionId(jobId, slug, "job")
-    const result = await smithery.createConnection(url, connectionId, name)
-
-    if (result.status === "error") {
-      return Response.json(
-        { error: result.error ?? "Smithery connection failed" },
-        { status: 502 }
-      )
-    }
-
-    const isConnected = result.status === "connected"
-    const row = {
-      smitheryConnectionId: connectionId,
-      smitheryNamespace: result.namespace,
-      mcpUrl: result.mcpEndpoint,
-      status: isConnected ? "connected" : "pending",
-      encryptedApiKey: isConnected ? encrypt(apiKey) : null,
-      lastError: null,
-    }
-    const { id: serverId } = await prisma.scheduledJobMcpServer.upsert({
-      where: { jobId_qualifiedName: { jobId, qualifiedName: slug } },
-      create: {
-        jobId,
-        qualifiedName: slug,
-        displayName: name,
-        iconUrl: iconUrl ?? null,
-        ...row,
-      },
-      update: {
-        displayName: name,
-        iconUrl: iconUrl ?? null,
-        ...row,
-      },
-      select: { id: true },
-    })
-
-    if (isConnected) {
-      return Response.json({ connected: true, serverId })
-    }
-    return Response.json({
-      connected: false,
-      serverId,
-      authUrl: result.authorizationUrl,
-    })
-  } catch (err) {
-    return internalError(err)
-  }
+  return connectSmitheryResponse(owner, body)
 }

--- a/packages/web/app/api/scheduled-jobs/[id]/mcp-servers/route.ts
+++ b/packages/web/app/api/scheduled-jobs/[id]/mcp-servers/route.ts
@@ -1,0 +1,147 @@
+/**
+ * GET  /api/scheduled-jobs/<id>/mcp-servers     list connections on this job
+ * POST /api/scheduled-jobs/<id>/mcp-servers     start a new connection via Smithery
+ *
+ * Mirror of /api/chats/<chatId>/mcp-servers, scoped to a ScheduledJob.
+ * Connections persist on the job; each run loads them via loadJobMcpServers.
+ */
+import { prisma } from "@/lib/db/prisma"
+import { encrypt } from "@/lib/db/encryption"
+import {
+  requireAuth,
+  isAuthError,
+  badRequest,
+  notFound,
+  serverConfigError,
+  internalError,
+  getJobWithAuth,
+} from "@/lib/db/api-helpers"
+import {
+  createSmitheryProvider,
+  getSmitheryConnectionId,
+  isSmitheryServer,
+} from "@upstream/mcp-providers"
+
+interface ConnectBody {
+  slug?: string
+  url?: string
+  name?: string
+  iconUrl?: string | null
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<Response> {
+  const auth = await requireAuth()
+  if (isAuthError(auth)) return auth
+  const { userId } = auth
+  const { id: jobId } = await params
+
+  const job = await getJobWithAuth(jobId, userId)
+  if (!job) return notFound("Scheduled job not found")
+
+  const servers = await prisma.scheduledJobMcpServer.findMany({
+    where: { jobId },
+    orderBy: { createdAt: "desc" },
+    select: {
+      id: true,
+      qualifiedName: true,
+      displayName: true,
+      iconUrl: true,
+      status: true,
+      lastError: true,
+      createdAt: true,
+    },
+  })
+
+  return Response.json({ servers })
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<Response> {
+  const auth = await requireAuth()
+  if (isAuthError(auth)) return auth
+  const { userId } = auth
+  const { id: jobId } = await params
+
+  const job = await getJobWithAuth(jobId, userId)
+  if (!job) return notFound("Scheduled job not found")
+
+  const apiKey = process.env.SMITHERY_API_KEY
+  if (!apiKey) return serverConfigError("SMITHERY_API_KEY")
+
+  let body: ConnectBody
+  try {
+    body = await req.json()
+  } catch {
+    return badRequest("Invalid JSON body")
+  }
+
+  const { slug, url, name, iconUrl } = body
+  if (!slug || !url || !name) {
+    return badRequest("Missing required fields: slug, url, name")
+  }
+
+  if (!isSmitheryServer(url)) {
+    return badRequest(
+      "Only Smithery-hosted servers (server.smithery.ai) are supported"
+    )
+  }
+
+  try {
+    const smithery = createSmitheryProvider({
+      apiKey,
+      namespace: process.env.SMITHERY_NAMESPACE,
+    })
+    // "job" prefix keeps the namespace distinct from chat-scoped ids.
+    const connectionId = getSmitheryConnectionId(jobId, slug, "job")
+    const result = await smithery.createConnection(url, connectionId, name)
+
+    if (result.status === "error") {
+      return Response.json(
+        { error: result.error ?? "Smithery connection failed" },
+        { status: 502 }
+      )
+    }
+
+    const isConnected = result.status === "connected"
+    const row = {
+      smitheryConnectionId: connectionId,
+      smitheryNamespace: result.namespace,
+      mcpUrl: result.mcpEndpoint,
+      status: isConnected ? "connected" : "pending",
+      encryptedApiKey: isConnected ? encrypt(apiKey) : null,
+      lastError: null,
+    }
+    const { id: serverId } = await prisma.scheduledJobMcpServer.upsert({
+      where: { jobId_qualifiedName: { jobId, qualifiedName: slug } },
+      create: {
+        jobId,
+        qualifiedName: slug,
+        displayName: name,
+        iconUrl: iconUrl ?? null,
+        ...row,
+      },
+      update: {
+        displayName: name,
+        iconUrl: iconUrl ?? null,
+        ...row,
+      },
+      select: { id: true },
+    })
+
+    if (isConnected) {
+      return Response.json({ connected: true, serverId })
+    }
+    return Response.json({
+      connected: false,
+      serverId,
+      authUrl: result.authorizationUrl,
+    })
+  } catch (err) {
+    return internalError(err)
+  }
+}

--- a/packages/web/app/api/scheduled-jobs/[id]/route.ts
+++ b/packages/web/app/api/scheduled-jobs/[id]/route.ts
@@ -12,6 +12,7 @@ import {
 import { addMinutes } from "date-fns"
 import { toScheduledJobResponse } from "@/lib/scheduled-jobs/types"
 import { deleteWebhook } from "@upstream/common"
+import { createSmitheryProvider } from "@upstream/mcp-providers"
 
 // =============================================================================
 // Helper: Get job with auth check
@@ -206,8 +207,36 @@ export async function DELETE(
       }
     }
 
-    // Delete job (cascades to runs, but runs' chats need manual cleanup)
-    // First, delete linked chats
+    // Best-effort Smithery cleanup before we drop the DB rows. The MCP rows
+    // themselves cascade with the job; Smithery's side has to be told
+    // explicitly or the connection lingers and counts against quota.
+    const smitheryApiKey = process.env.SMITHERY_API_KEY
+    if (smitheryApiKey) {
+      const mcpRows = await prisma.scheduledJobMcpServer.findMany({
+        where: { jobId: id, smitheryConnectionId: { not: null } },
+        select: { smitheryConnectionId: true },
+      })
+      if (mcpRows.length > 0) {
+        const smithery = createSmitheryProvider({
+          apiKey: smitheryApiKey,
+          namespace: process.env.SMITHERY_NAMESPACE,
+        })
+        for (const row of mcpRows) {
+          if (!row.smitheryConnectionId) continue
+          try {
+            await smithery.deleteConnection(row.smitheryConnectionId)
+          } catch (err) {
+            console.error(
+              "[scheduled-jobs] Smithery cleanup failed (non-fatal):",
+              err
+            )
+          }
+        }
+      }
+    }
+
+    // Delete job (cascades to runs and mcpServers, but runs' chats need
+    // manual cleanup).
     const runs = await prisma.scheduledJobRun.findMany({
       where: { jobId: id },
       select: { chatId: true },
@@ -220,7 +249,7 @@ export async function DELETE(
       })
     }
 
-    // Then delete the job (cascades to runs)
+    // Then delete the job (cascades to runs and ScheduledJobMcpServer)
     await prisma.scheduledJob.delete({
       where: { id },
     })

--- a/packages/web/app/api/scheduled-jobs/[id]/route.ts
+++ b/packages/web/app/api/scheduled-jobs/[id]/route.ts
@@ -77,6 +77,8 @@ interface UpdateScheduledJobBody {
   autoPR?: boolean
   continueFromLastRun?: boolean
   enabled?: boolean
+  /** Flip from true → false when the user clicks Create on a materialized draft. */
+  isDraft?: boolean
 }
 
 export async function PATCH(
@@ -122,6 +124,7 @@ export async function PATCH(
       enabled?: boolean
       nextRunAt?: Date
       consecutiveFailures?: number
+      isDraft?: boolean
     } = {}
 
     if (body.name !== undefined) updateData.name = body.name.trim()
@@ -137,6 +140,15 @@ export async function PATCH(
     }
      if (body.autoPR !== undefined) updateData.autoPR = body.autoPR
      if (body.continueFromLastRun !== undefined) updateData.continueFromLastRun = body.continueFromLastRun
+     if (body.isDraft !== undefined) {
+      updateData.isDraft = body.isDraft
+      // Reset the schedule when promoting a draft so the first run lands a
+      // full interval after the user finishes creating, not at the placeholder
+      // nextRunAt the materialize POST originally wrote.
+      if (body.isDraft === false) {
+        updateData.nextRunAt = addMinutes(new Date(), body.intervalMinutes ?? job.intervalMinutes)
+      }
+    }
      if (body.enabled !== undefined) {
       updateData.enabled = body.enabled
       // Reset failure count when re-enabling

--- a/packages/web/app/api/scheduled-jobs/[id]/route.ts
+++ b/packages/web/app/api/scheduled-jobs/[id]/route.ts
@@ -12,7 +12,7 @@ import {
 import { addMinutes } from "date-fns"
 import { toScheduledJobResponse } from "@/lib/scheduled-jobs/types"
 import { deleteWebhook } from "@upstream/common"
-import { createSmitheryProvider } from "@upstream/mcp-providers"
+import { cleanupSmitheryConnections } from "@/lib/mcp/connections"
 
 // =============================================================================
 // Helper: Get job with auth check
@@ -222,30 +222,7 @@ export async function DELETE(
     // Best-effort Smithery cleanup before we drop the DB rows. The MCP rows
     // themselves cascade with the job; Smithery's side has to be told
     // explicitly or the connection lingers and counts against quota.
-    const smitheryApiKey = process.env.SMITHERY_API_KEY
-    if (smitheryApiKey) {
-      const mcpRows = await prisma.scheduledJobMcpServer.findMany({
-        where: { jobId: id, smitheryConnectionId: { not: null } },
-        select: { smitheryConnectionId: true },
-      })
-      if (mcpRows.length > 0) {
-        const smithery = createSmitheryProvider({
-          apiKey: smitheryApiKey,
-          namespace: process.env.SMITHERY_NAMESPACE,
-        })
-        for (const row of mcpRows) {
-          if (!row.smitheryConnectionId) continue
-          try {
-            await smithery.deleteConnection(row.smitheryConnectionId)
-          } catch (err) {
-            console.error(
-              "[scheduled-jobs] Smithery cleanup failed (non-fatal):",
-              err
-            )
-          }
-        }
-      }
-    }
+    await cleanupSmitheryConnections({ kind: "job", id })
 
     // Delete job (cascades to runs and mcpServers, but runs' chats need
     // manual cleanup).

--- a/packages/web/app/api/scheduled-jobs/[id]/run/route.ts
+++ b/packages/web/app/api/scheduled-jobs/[id]/run/route.ts
@@ -38,6 +38,11 @@ export async function POST(
       return notFound("Scheduled job not found")
     }
 
+    // Drafts haven't been saved yet from the user's POV — refuse to start one.
+    if (job.isDraft) {
+      return badRequest("Job is a draft — finish creating it first")
+    }
+
     // Check if already running
     if (job.runs.length > 0) {
       return badRequest("Job is already running")

--- a/packages/web/app/api/scheduled-jobs/route.ts
+++ b/packages/web/app/api/scheduled-jobs/route.ts
@@ -30,7 +30,7 @@ export async function GET(): Promise<Response> {
 
   try {
     const jobs = await prisma.scheduledJob.findMany({
-      where: { userId },
+      where: { userId, isDraft: false },
       include: {
         runs: {
           orderBy: { startedAt: "desc" },
@@ -61,6 +61,10 @@ interface CreateScheduledJobBody {
   intervalMinutes?: number // Required for interval trigger
   autoPR?: boolean
   continueFromLastRun?: boolean
+  /** True when materializing via the MCP picker before the form is finished. */
+  isDraft?: boolean
+  /** Lets the form-side materialize keep the row inert until final submit. */
+  enabled?: boolean
 }
 
 export async function POST(req: NextRequest): Promise<Response> {
@@ -96,9 +100,10 @@ export async function POST(req: NextRequest): Promise<Response> {
       }
     }
 
-    // Check job limit
+    // Check job limit (drafts don't count — they're transient until the user
+    // finishes the create flow).
     const existingCount = await prisma.scheduledJob.count({
-      where: { userId },
+      where: { userId, isDraft: false },
     })
     if (existingCount >= MAX_JOBS_PER_USER) {
       return badRequest(`Maximum ${MAX_JOBS_PER_USER} scheduled jobs allowed`)
@@ -179,6 +184,8 @@ export async function POST(req: NextRequest): Promise<Response> {
         autoPR: body.autoPR ?? true,
         continueFromLastRun: body.continueFromLastRun ?? false,
         nextRunAt: addMinutes(now, body.intervalMinutes!),
+        isDraft: body.isDraft ?? false,
+        enabled: body.enabled ?? true,
       },
     })
 

--- a/packages/web/components/chat/ChatInput.tsx
+++ b/packages/web/components/chat/ChatInput.tsx
@@ -397,8 +397,9 @@ export function ChatInput({
             {/* MCP servers picker */}
             {showMcpButton && (
               <McpServersCombobox
-                chatId={chat.id}
-                isDraftChat={isDraftChat}
+                entityId={chat.id}
+                apiBase="/api/chats"
+                isDraft={isDraftChat}
                 onMaterializeDraft={onMaterializeDraftForMcp}
                 open={modals.mcpServersModalOpen}
                 onOpenChange={modals.setMcpServersModalOpen}

--- a/packages/web/components/chat/McpServersCombobox.tsx
+++ b/packages/web/components/chat/McpServersCombobox.tsx
@@ -64,9 +64,24 @@ interface RegistryServer {
 const GITHUB_QUALIFIED_NAME = "github/github"
 
 interface McpServersComboboxProps {
-  chatId: string
-  isDraftChat: boolean
-  onMaterializeDraft: (draftId: string) => Promise<string | null>
+  /** Stable id of the owning entity (chat id or scheduled job id). */
+  entityId: string
+  /**
+   * API path prefix for the owning entity, without trailing slash and without
+   * the entity id, e.g. `"/api/chats"` or `"/api/scheduled-jobs"`. The
+   * component appends `/{entityId}/mcp-servers/...` to this for all calls.
+   */
+  apiBase: string
+  /**
+   * True if `entityId` is a not-yet-persisted draft. Only the chat flow uses
+   * this; scheduled jobs are edit-only so default is false.
+   */
+  isDraft?: boolean
+  /**
+   * Called when a draft needs to be materialized before the first MCP write.
+   * Returns the real id (or null on failure). Only used when `isDraft` is true.
+   */
+  onMaterializeDraft?: (draftId: string) => Promise<string | null>
   disabled?: boolean
   isMobile?: boolean
   /** Optional controlled open state (e.g. from the command palette). */
@@ -75,8 +90,9 @@ interface McpServersComboboxProps {
 }
 
 export function McpServersCombobox({
-  chatId,
-  isDraftChat,
+  entityId,
+  apiBase,
+  isDraft: isDraftProp = false,
   onMaterializeDraft,
   disabled = false,
   isMobile = false,
@@ -93,25 +109,26 @@ export function McpServersCombobox({
     [onOpenChange]
   )
 
-  // Effective chat id used for all chat-scoped API calls. Starts as the
-  // (possibly draft) chatId and is replaced with the real id once we
-  // materialize on first commit.
-  const [effectiveChatId, setEffectiveChatId] = useState(chatId)
-  const [isDraft, setIsDraft] = useState(isDraftChat)
+  // Effective id used for all entity-scoped API calls. Starts as the
+  // (possibly draft) entityId and is replaced with the real id once we
+  // materialize on first commit (chat flow only).
+  const [effectiveId, setEffectiveId] = useState(entityId)
+  const [isDraft, setIsDraft] = useState(isDraftProp)
 
   useEffect(() => {
-    setEffectiveChatId(chatId)
-    setIsDraft(isDraftChat)
-  }, [chatId, isDraftChat])
+    setEffectiveId(entityId)
+    setIsDraft(isDraftProp)
+  }, [entityId, isDraftProp])
 
-  const resolveChatId = useCallback(async (): Promise<string | null> => {
-    if (!isDraft) return effectiveChatId
-    const realId = await onMaterializeDraft(effectiveChatId)
+  const resolveEntityId = useCallback(async (): Promise<string | null> => {
+    if (!isDraft) return effectiveId
+    if (!onMaterializeDraft) return effectiveId
+    const realId = await onMaterializeDraft(effectiveId)
     if (!realId) return null
-    setEffectiveChatId(realId)
+    setEffectiveId(realId)
     setIsDraft(false)
     return realId
-  }, [isDraft, effectiveChatId, onMaterializeDraft])
+  }, [isDraft, effectiveId, onMaterializeDraft])
 
   const [connected, setConnected] = useState<ConnectedServer[]>([])
   const [registry, setRegistry] = useState<RegistryServer[]>([])
@@ -134,7 +151,7 @@ export function McpServersCombobox({
 
   const loadConnectedFor = useCallback(async (id: string) => {
     try {
-      const res = await fetch(`/api/chats/${id}/mcp-servers`)
+      const res = await fetch(`${apiBase}/${id}/mcp-servers`)
       if (res.ok) {
         const data = await res.json()
         setConnected(data.servers || [])
@@ -142,15 +159,15 @@ export function McpServersCombobox({
     } catch (err) {
       console.error("[McpServersCombobox] loadConnected failed:", err)
     }
-  }, [])
+  }, [apiBase])
 
   const loadConnected = useCallback(async () => {
     if (isDraft) {
       setConnected([])
       return
     }
-    await loadConnectedFor(effectiveChatId)
-  }, [isDraft, effectiveChatId, loadConnectedFor])
+    await loadConnectedFor(effectiveId)
+  }, [isDraft, effectiveId, loadConnectedFor])
 
   const loadGithubStatus = useCallback(async () => {
     try {
@@ -220,7 +237,7 @@ export function McpServersCombobox({
     if (isDraft) return
     try {
       const res = await fetch(
-        `/api/chats/${effectiveChatId}/mcp-servers/${serverId}`,
+        `${apiBase}/${effectiveId}/mcp-servers/${serverId}`,
         { method: "DELETE" }
       )
       if (res.ok) {
@@ -231,10 +248,10 @@ export function McpServersCombobox({
     }
   }
 
-  async function addGithubToChat() {
-    const id = await resolveChatId()
+  async function addGithubToEntity() {
+    const id = await resolveEntityId()
     if (!id) return
-    const res = await fetch(`/api/chats/${id}/mcp-servers/github`, {
+    const res = await fetch(`${apiBase}/${id}/mcp-servers/github`, {
       method: "POST",
     })
     if (res.ok) await loadConnectedFor(id)
@@ -259,7 +276,7 @@ export function McpServersCombobox({
       const status = await statusRes.json()
 
       if (status.connected) {
-        await addGithubToChat()
+        await addGithubToEntity()
         return
       }
 
@@ -291,7 +308,7 @@ export function McpServersCombobox({
       const after = await fetch("/api/mcp/connect/github")
       const afterData = after.ok ? await after.json() : { connected: false }
       setGithubInstallationId(afterData.installationId ?? null)
-      if (afterData.connected) await addGithubToChat()
+      if (afterData.connected) await addGithubToEntity()
     } catch (err) {
       console.error("[McpServersCombobox] handleToggleGithub failed:", err)
     } finally {
@@ -307,7 +324,7 @@ export function McpServersCombobox({
   async function handleUninstallGithubApp() {
     if (
       !confirm(
-        "Uninstall the GitHub App for your account? This removes GitHub MCP from every chat."
+        "Uninstall the GitHub App for your account? This removes GitHub MCP from every chat and scheduled job."
       )
     ) {
       return
@@ -347,13 +364,13 @@ export function McpServersCombobox({
         if (!url) throw new Error("Server does not expose a remote URL")
       }
 
-      const id = await resolveChatId()
+      const id = await resolveEntityId()
       if (!id) {
         setBusySlug(null)
         return
       }
 
-      const res = await fetch(`/api/chats/${id}/mcp-servers`, {
+      const res = await fetch(`${apiBase}/${id}/mcp-servers`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -398,7 +415,7 @@ export function McpServersCombobox({
         }
         try {
           await fetch(
-            `/api/chats/${id}/mcp-servers/${data.serverId}/smithery-finalize`,
+            `${apiBase}/${id}/mcp-servers/${data.serverId}/smithery-finalize`,
             { method: "POST" }
           )
         } catch (err) {

--- a/packages/web/components/scheduled-jobs/ScheduledJobForm.tsx
+++ b/packages/web/components/scheduled-jobs/ScheduledJobForm.tsx
@@ -508,9 +508,13 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
             {/* Prompt Field - styled like ChatInput */}
             <div>
               <label className="block text-sm font-medium mb-1">Prompt</label>
-              <div className="rounded-xl border border-border bg-card focus-within:border-primary/50 focus-within:ring-1 focus-within:ring-primary/20">
+              <div className={cn(
+                "relative flex flex-col border shadow-sm bg-card border-border",
+                isMobile ? "rounded-xl" : "rounded-2xl",
+                "focus-within:border-primary/50 focus-within:ring-1 focus-within:ring-primary/20"
+              )}>
                 {/* Textarea */}
-                <div className="px-3 py-2">
+                <div className={cn(isMobile ? "px-3 py-2" : "px-4 py-3")}>
                   <textarea
                     value={prompt}
                     onChange={(e) => setPrompt(e.target.value)}
@@ -520,42 +524,54 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
                   />
                 </div>
 
-                {/* Bottom bar with selectors */}
-                <div className="flex items-center gap-2 px-3 py-2 border-t border-border">
-                  {/* Repo selector */}
-                  <RepoCombobox
-                    value={repo || null}
-                    onChange={(newRepo, defaultBranch) => {
-                      setRepo(newRepo)
-                      setBaseBranch(defaultBranch)
-                    }}
-                    disabled={isEditing}
-                    isMobile={isMobile}
-                    showLabel
-                  />
-
-                  {/* Branch selector */}
-                  {repo && (
-                    <BranchCombobox
-                      repo={repo}
-                      value={baseBranch}
-                      onChange={setBaseBranch}
-                      defaultBranch={baseBranch}
+                {/* Bottom bar with selectors. The container wrappers mirror
+                    ChatInput so the inner pickers can reveal labels and counts
+                    at the right widths via container queries. */}
+                <div className={cn(
+                  "@container flex items-center",
+                  isMobile ? "gap-2 px-3 py-2" : "gap-3 px-4 py-2"
+                )}>
+                  {/* Left side items (repo / branch / MCP) */}
+                  <div className={cn(
+                    "flex items-center gap-2",
+                    isMobile ? "w-full @container/row1" : "flex-1"
+                  )}>
+                    {/* Repo selector */}
+                    <RepoCombobox
+                      value={repo || null}
+                      onChange={(newRepo, defaultBranch) => {
+                        setRepo(newRepo)
+                        setBaseBranch(defaultBranch)
+                      }}
+                      disabled={isEditing}
                       isMobile={isMobile}
                       showLabel
                     />
-                  )}
 
-                  {/* MCP servers picker — inline alongside repo/branch like the
-                      chat input. In create mode the first click materializes
-                      the job so the picker has a real id; cancel cleans up. */}
-                  <McpServersCombobox
-                    entityId={materializedJobId ?? job?.id ?? "draft"}
-                    apiBase="/api/scheduled-jobs"
-                    isDraft={!isEditing && !materializedJobId}
-                    onMaterializeDraft={materializeJob}
-                    isMobile={isMobile}
-                  />
+                    {/* Branch selector */}
+                    {repo && (
+                      <BranchCombobox
+                        repo={repo}
+                        value={baseBranch}
+                        onChange={setBaseBranch}
+                        defaultBranch={baseBranch}
+                        isMobile={isMobile}
+                        showLabel
+                      />
+                    )}
+
+                    {/* MCP servers picker — inline alongside repo/branch like
+                        the chat input. In create mode the first click
+                        materializes the job so the picker has a real id;
+                        cancel cleans up. */}
+                    <McpServersCombobox
+                      entityId={materializedJobId ?? job?.id ?? "draft"}
+                      apiBase="/api/scheduled-jobs"
+                      isDraft={!isEditing && !materializedJobId}
+                      onMaterializeDraft={materializeJob}
+                      isMobile={isMobile}
+                    />
+                  </div>
 
                   {/* Spacer */}
                   <div className="flex-1" />

--- a/packages/web/components/scheduled-jobs/ScheduledJobForm.tsx
+++ b/packages/web/components/scheduled-jobs/ScheduledJobForm.tsx
@@ -394,6 +394,24 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
               </div>
             )}
 
+            {/* MCP servers — edit-only. Saving the job materializes the id we
+                need to scope the connections, so we hide the picker until the
+                job exists. */}
+            <div className="flex items-center gap-3">
+              <label className="text-sm font-medium">MCP Servers</label>
+              {isEditing && job ? (
+                <McpServersCombobox
+                  entityId={job.id}
+                  apiBase="/api/scheduled-jobs"
+                  isMobile={isMobile}
+                />
+              ) : (
+                <p className="text-xs text-muted-foreground">
+                  Save the job first, then re-open it to attach MCP servers.
+                </p>
+              )}
+            </div>
+
             {/* Prompt Field - styled like ChatInput */}
             <div>
               <label className="block text-sm font-medium mb-1">Prompt</label>
@@ -510,24 +528,6 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
                   </div>
                 </div>
               </div>
-            </div>
-
-            {/* MCP servers — edit-only. Saving the job materializes the id we
-                need to scope the connections, so we hide the picker until the
-                job exists. */}
-            <div>
-              <label className="block text-sm font-medium mb-2">MCP Servers</label>
-              {isEditing && job ? (
-                <McpServersCombobox
-                  entityId={job.id}
-                  apiBase="/api/scheduled-jobs"
-                  isMobile={isMobile}
-                />
-              ) : (
-                <p className="text-xs text-muted-foreground">
-                  Save the job first, then re-open it to attach MCP servers.
-                </p>
-              )}
             </div>
 
             {/* Options Section */}

--- a/packages/web/components/scheduled-jobs/ScheduledJobForm.tsx
+++ b/packages/web/components/scheduled-jobs/ScheduledJobForm.tsx
@@ -505,21 +505,6 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
               </div>
             )}
 
-            {/* MCP servers. In create mode we materialize the job on first
-                click so the picker has a real id to attach connections to;
-                cancel cleans up. After materialize the trigger/schedule fields
-                lock since the PATCH endpoint can't update those. */}
-            <div className="flex items-center gap-3">
-              <label className="text-sm font-medium">MCP Servers</label>
-              <McpServersCombobox
-                entityId={materializedJobId ?? job?.id ?? "draft"}
-                apiBase="/api/scheduled-jobs"
-                isDraft={!isEditing && !materializedJobId}
-                onMaterializeDraft={materializeJob}
-                isMobile={isMobile}
-              />
-            </div>
-
             {/* Prompt Field - styled like ChatInput */}
             <div>
               <label className="block text-sm font-medium mb-1">Prompt</label>
@@ -560,6 +545,17 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
                       showLabel
                     />
                   )}
+
+                  {/* MCP servers picker — inline alongside repo/branch like the
+                      chat input. In create mode the first click materializes
+                      the job so the picker has a real id; cancel cleans up. */}
+                  <McpServersCombobox
+                    entityId={materializedJobId ?? job?.id ?? "draft"}
+                    apiBase="/api/scheduled-jobs"
+                    isDraft={!isEditing && !materializedJobId}
+                    onMaterializeDraft={materializeJob}
+                    isMobile={isMobile}
+                  />
 
                   {/* Spacer */}
                   <div className="flex-1" />

--- a/packages/web/components/scheduled-jobs/ScheduledJobForm.tsx
+++ b/packages/web/components/scheduled-jobs/ScheduledJobForm.tsx
@@ -144,6 +144,20 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
+  // In create mode, the form may "materialize" the job into the DB the first
+  // time the user clicks the MCP picker, so MCP server connections have a real
+  // job id to hang off of. If the user then cancels, we DELETE the row so we
+  // don't leave a half-configured job behind. On final submit this id is what
+  // we PATCH (instead of POSTing again).
+  // Materialized rows are created with enabled: false so the cron doesn't pick
+  // them up before the user finishes; the final submit flips enabled back on.
+  const [materializedJobId, setMaterializedJobId] = useState<string | null>(null)
+
+  // Once we materialize, the trigger/schedule fields lock — the PATCH endpoint
+  // doesn't accept triggerType / runAtHour / runAtDay, so allowing edits after
+  // materialize would silently drop changes. Cancelling resets via DELETE.
+  const isLocked = isEditing || !!materializedJobId
+
   // Dropdown state
   const [showAgentDropdown, setShowAgentDropdown] = useState(false)
   const [showModelDropdown, setShowModelDropdown] = useState(false)
@@ -172,6 +186,7 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
       setAutoPR(job?.autoPR ?? true)
       setContinueFromLastRun(job?.continueFromLastRun ?? false)
       setError(null)
+      setMaterializedJobId(null)
     }
   }, [open, job])
 
@@ -196,51 +211,126 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
     return () => document.removeEventListener('click', handleClickOutside)
   }, [])
 
+  /**
+   * Build the request body for create/update from current form state.
+   * Returns `null` and sets the visible error if required fields are missing.
+   */
+  function buildPayload(): Record<string, unknown> | null {
+    if (!name.trim()) {
+      setError("Name is required")
+      return null
+    }
+    if (!prompt.trim()) {
+      setError("Prompt is required")
+      return null
+    }
+    if (!repo) {
+      setError("Repository is required")
+      return null
+    }
+    const runAtHourUtc = localHourToUtc(runAtHourLocal)
+    return {
+      name: name.trim(),
+      prompt: prompt.trim(),
+      repo,
+      baseBranch,
+      agent,
+      model: model || null,
+      triggerType,
+      intervalMinutes: triggerType === "interval" ? intervalMinutes : undefined,
+      runAtHour: triggerType === "interval" && intervalMinutes >= 1440 ? runAtHourUtc : undefined,
+      runAtDay: triggerType === "interval" && intervalMinutes === 10080 ? runAtDay : undefined,
+      autoPR,
+      continueFromLastRun,
+    }
+  }
+
+  /**
+   * Materialize callback for the MCP picker — fired on the first MCP click
+   * during create mode. POSTs the job (with enabled: false so the cron won't
+   * pick it up mid-config) and returns the new id to the picker. Uses
+   * placeholders for name/prompt if the user hasn't typed them yet; the
+   * final-submit validation in handleSubmit enforces real values before the
+   * row goes live. The form stays open and continues acting like create mode
+   * until the user hits "Create" (PATCH to flip enabled on) or "Cancel"
+   * (DELETE the row).
+   *
+   * Only allowed for interval-triggered jobs — webhook jobs require a real
+   * GitHub webhook setup at create time, which can't be deferred.
+   */
+  async function materializeJob(_draftId: string): Promise<string | null> {
+    setError(null)
+    if (triggerType === "webhook") {
+      setError("Save the job first to attach MCP servers to webhook-triggered jobs.")
+      return null
+    }
+    try {
+      const res = await fetch("/api/scheduled-jobs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          // Placeholders only exist on disk while isDraft = true. They're never
+          // shown in the UI list (the GET filters drafts out) and the cron
+          // skips drafts. The final submit PATCH replaces them with real
+          // values before flipping isDraft to false.
+          name: name.trim() || "(draft)",
+          prompt: prompt.trim() || "(draft)",
+          repo: repo || "__draft__",
+          baseBranch: baseBranch || "main",
+          agent,
+          model: model || null,
+          triggerType: "interval",
+          intervalMinutes,
+          autoPR,
+          continueFromLastRun,
+          enabled: false,
+          isDraft: true,
+        }),
+      })
+      if (!res.ok) {
+        const data = await res.json()
+        setError(data.error || "Failed to save job")
+        return null
+      }
+      const created = await res.json()
+      setMaterializedJobId(created.id)
+      return created.id
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save job")
+      return null
+    }
+  }
+
   // Handle form submit
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setError(null)
 
-    // Validate
-    if (!name.trim()) {
-      setError("Name is required")
-      return
-    }
-    if (!prompt.trim()) {
-      setError("Prompt is required")
-      return
-    }
-    if (!repo) {
-      setError("Repository is required")
-      return
-    }
+    const payload = buildPayload()
+    if (!payload) return
 
     setLoading(true)
 
-    // Convert local hour to UTC for storage
-    const runAtHourUtc = localHourToUtc(runAtHourLocal)
-
     try {
-      const url = isEditing ? `/api/scheduled-jobs/${job.id}` : "/api/scheduled-jobs"
-      const method = isEditing ? "PATCH" : "POST"
+      const targetId = materializedJobId ?? job?.id
+      const isUpdate = !!targetId
+      const url = isUpdate
+        ? `/api/scheduled-jobs/${targetId}`
+        : "/api/scheduled-jobs"
+      const method = isUpdate ? "PATCH" : "POST"
+
+      // For materialized rows we created with enabled: false + isDraft: true;
+      // promote both on final Create. For real edits, we leave existing state
+      // alone.
+      const body =
+        materializedJobId && !isEditing
+          ? { ...payload, enabled: true, isDraft: false }
+          : payload
 
       const res = await fetch(url, {
         method,
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          name: name.trim(),
-          prompt: prompt.trim(),
-          repo,
-          baseBranch,
-          agent,
-          model: model || null,
-          triggerType,
-          intervalMinutes: triggerType === "interval" ? intervalMinutes : undefined,
-          runAtHour: triggerType === "interval" && intervalMinutes >= 1440 ? runAtHourUtc : undefined,
-          runAtDay: triggerType === "interval" && intervalMinutes === 10080 ? runAtDay : undefined,
-          autoPR,
-          continueFromLastRun,
-        }),
+        body: JSON.stringify(body),
       })
 
       if (!res.ok) {
@@ -249,12 +339,33 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
       }
 
       const savedJob = await res.json()
+      // Clear the materialized marker so the close handler doesn't try to
+      // delete what we just successfully saved.
+      setMaterializedJobId(null)
       onSuccess(savedJob)
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to save job")
     } finally {
       setLoading(false)
     }
+  }
+
+  /**
+   * Close handler: if we materialized a job in create mode and the user is
+   * walking away without saving, drop the row so we don't leak draft jobs.
+   * Best-effort — even if cleanup fails we still close the modal.
+   */
+  const handleClose = async () => {
+    if (materializedJobId && !isEditing) {
+      const idToDelete = materializedJobId
+      setMaterializedJobId(null)
+      try {
+        await fetch(`/api/scheduled-jobs/${idToDelete}`, { method: "DELETE" })
+      } catch (err) {
+        console.error("[ScheduledJobForm] cleanup delete failed:", err)
+      }
+    }
+    onClose()
   }
 
   const handleAgentChange = (newAgent: Agent) => {
@@ -268,7 +379,7 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
   }
 
   return (
-    <Dialog.Root open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+    <Dialog.Root open={open} onOpenChange={(isOpen) => !isOpen && handleClose()}>
       <Dialog.Portal>
         <Dialog.Overlay className={cn(
           "fixed inset-0 z-50 transition-opacity duration-300 bg-black/15 backdrop-blur-[1px]",
@@ -318,14 +429,14 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
               <label className="block text-sm font-medium mb-2">Trigger</label>
               <div className={cn(
                 "inline-flex rounded-md bg-muted p-0.5",
-                isEditing && "opacity-50"
+                isLocked && "opacity-50"
               )}>
                 {TRIGGER_TYPES.map((t) => (
                   <button
                     key={t.value}
                     type="button"
-                    onClick={() => !isEditing && setTriggerType(t.value)}
-                    disabled={isEditing}
+                    onClick={() => !isLocked && setTriggerType(t.value)}
+                    disabled={isLocked}
                     className={cn(
                       "px-3 py-1 text-sm rounded-md transition-colors cursor-pointer",
                       triggerType === t.value
@@ -394,22 +505,19 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
               </div>
             )}
 
-            {/* MCP servers — edit-only. Saving the job materializes the id we
-                need to scope the connections, so we hide the picker until the
-                job exists. */}
+            {/* MCP servers. In create mode we materialize the job on first
+                click so the picker has a real id to attach connections to;
+                cancel cleans up. After materialize the trigger/schedule fields
+                lock since the PATCH endpoint can't update those. */}
             <div className="flex items-center gap-3">
               <label className="text-sm font-medium">MCP Servers</label>
-              {isEditing && job ? (
-                <McpServersCombobox
-                  entityId={job.id}
-                  apiBase="/api/scheduled-jobs"
-                  isMobile={isMobile}
-                />
-              ) : (
-                <p className="text-xs text-muted-foreground">
-                  Save the job first, then re-open it to attach MCP servers.
-                </p>
-              )}
+              <McpServersCombobox
+                entityId={materializedJobId ?? job?.id ?? "draft"}
+                apiBase="/api/scheduled-jobs"
+                isDraft={!isEditing && !materializedJobId}
+                onMaterializeDraft={materializeJob}
+                isMobile={isMobile}
+              />
             </div>
 
             {/* Prompt Field - styled like ChatInput */}
@@ -571,7 +679,7 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
           <div className="flex justify-end gap-2 px-4 py-3 border-t border-border flex-shrink-0">
             <button
               type="button"
-              onClick={onClose}
+              onClick={handleClose}
               className="px-4 py-2 text-sm rounded-md hover:bg-accent transition-colors cursor-pointer"
             >
               Cancel

--- a/packages/web/components/scheduled-jobs/ScheduledJobForm.tsx
+++ b/packages/web/components/scheduled-jobs/ScheduledJobForm.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils"
 import { ModalHeader, focusChatPrompt } from "@/components/ui/modal-header"
 import { RepoCombobox } from "@/components/chat/RepoCombobox"
 import { BranchCombobox } from "@/components/chat/BranchCombobox"
+import { McpServersCombobox } from "@/components/chat/McpServersCombobox"
 import { type ScheduledJob } from "@/lib/scheduled-jobs/types"
 import { agentModels, agentLabels, getModelLabel, type Agent } from "@/lib/types"
 import { AgentIcon } from "@/components/icons/agent-icons"
@@ -509,6 +510,24 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
                   </div>
                 </div>
               </div>
+            </div>
+
+            {/* MCP servers — edit-only. Saving the job materializes the id we
+                need to scope the connections, so we hide the picker until the
+                job exists. */}
+            <div>
+              <label className="block text-sm font-medium mb-2">MCP Servers</label>
+              {isEditing && job ? (
+                <McpServersCombobox
+                  entityId={job.id}
+                  apiBase="/api/scheduled-jobs"
+                  isMobile={isMobile}
+                />
+              ) : (
+                <p className="text-xs text-muted-foreground">
+                  Save the job first, then re-open it to attach MCP servers.
+                </p>
+              )}
             </div>
 
             {/* Options Section */}

--- a/packages/web/lib/db/api-helpers.ts
+++ b/packages/web/lib/db/api-helpers.ts
@@ -255,22 +255,6 @@ export async function getUserCredentials(userId: string): Promise<Credentials> {
 // =============================================================================
 
 /**
- * Fetches a scheduled job by ID and verifies ownership.
- * Returns null if not found or not owned by user.
- */
-export async function getJobWithAuth(
-  jobId: string,
-  userId: string
-): Promise<{ id: string; userId: string } | null> {
-  const job = await prisma.scheduledJob.findUnique({
-    where: { id: jobId },
-    select: { id: true, userId: true },
-  })
-  if (!job || job.userId !== userId) return null
-  return job
-}
-
-/**
  * Fetches a chat by ID and verifies ownership
  * Returns null if not found or not owned by user
  */

--- a/packages/web/lib/db/api-helpers.ts
+++ b/packages/web/lib/db/api-helpers.ts
@@ -255,6 +255,22 @@ export async function getUserCredentials(userId: string): Promise<Credentials> {
 // =============================================================================
 
 /**
+ * Fetches a scheduled job by ID and verifies ownership.
+ * Returns null if not found or not owned by user.
+ */
+export async function getJobWithAuth(
+  jobId: string,
+  userId: string
+): Promise<{ id: string; userId: string } | null> {
+  const job = await prisma.scheduledJob.findUnique({
+    where: { id: jobId },
+    select: { id: true, userId: true },
+  })
+  if (!job || job.userId !== userId) return null
+  return job
+}
+
+/**
  * Fetches a chat by ID and verifies ownership
  * Returns null if not found or not owned by user
  */

--- a/packages/web/lib/mcp/agent-servers.ts
+++ b/packages/web/lib/mcp/agent-servers.ts
@@ -1,6 +1,5 @@
 /**
- * Load a chat's or scheduled job's connected MCP servers in the shape
- * `setupMcpForAgent` wants.
+ * Load an owner's connected MCP servers in the shape `setupMcpForAgent` wants.
  *
  * Two kinds of rows:
  *   - Smithery rows  → decrypt the stored Smithery API key for the bearer.
@@ -8,11 +7,11 @@
  *                      (tokens are 1-hour, so we re-mint on every turn instead
  *                      of trying to keep them in sync with the DB).
  *
- * Both ChatMcpServer and ScheduledJobMcpServer share a row shape; the shared
- * translator below handles either. On GitHub token mint failure we update the
- * row's `lastError`/`status` so the UI can surface "GitHub App uninstalled" on
- * the next form open — important for scheduled jobs that may run days after
- * being configured.
+ * Chats and scheduled jobs share the same McpServerConnection table; the
+ * loader takes an `McpOwner` and filters on the right FK column. On GitHub
+ * token mint failure we update the row's `lastError`/`status` so the UI can
+ * surface "GitHub App uninstalled" on the next form open — important for
+ * scheduled jobs that may run days after being configured.
  */
 import { prisma } from "@/lib/db/prisma"
 import { decrypt } from "@/lib/db/encryption"
@@ -22,6 +21,7 @@ import {
   safeServerName,
 } from "@upstream/mcp-providers"
 import type { AgentMcpServer } from "@upstream/agent-configuration/mcp"
+import { type McpOwner, ownerWhere } from "./owner"
 
 // Lazily-initialized GitHub provider
 let githubProvider: ReturnType<typeof createGitHubMcpProvider> | null = null
@@ -42,28 +42,12 @@ function getGitHubProvider() {
 }
 
 /**
- * Row shape common to ChatMcpServer and ScheduledJobMcpServer.
- */
-interface McpRow {
-  id: string
-  qualifiedName: string
-  mcpUrl: string | null
-  encryptedApiKey: string | null
-}
-
-/**
- * Update the row's lastError/status. Tries the chat table first, falls back to
- * the job table. Best-effort — failure to record a warning shouldn't tank the
- * turn.
+ * Update the row's lastError/status. Best-effort — failure to record a
+ * warning shouldn't tank the turn.
  */
 async function markRowError(rowId: string, message: string): Promise<void> {
   try {
-    const updated = await prisma.chatMcpServer.updateMany({
-      where: { id: rowId },
-      data: { status: "error", lastError: message },
-    })
-    if (updated.count > 0) return
-    await prisma.scheduledJobMcpServer.updateMany({
+    await prisma.mcpServerConnection.update({
       where: { id: rowId },
       data: { status: "error", lastError: message },
     })
@@ -72,14 +56,16 @@ async function markRowError(rowId: string, message: string): Promise<void> {
   }
 }
 
+interface McpRow {
+  id: string
+  qualifiedName: string
+  mcpUrl: string | null
+  encryptedApiKey: string | null
+}
+
 /**
  * Translate one DB row to the AgentMcpServer shape the sandbox loader expects.
- * For Smithery rows: decrypt the stored bearer. For the GitHub sentinel: mint
- * a fresh installation token from the owning user's `githubAppInstallationId`.
- *
- * Returns null when the row can't produce a usable connection (e.g. App
- * uninstalled). On GitHub mint failure, the row's `lastError` is updated so
- * the user sees it on next form open.
+ * Returns null when the row can't produce a usable connection.
  */
 async function translateRow(
   row: McpRow,
@@ -123,53 +109,49 @@ async function translateRow(
   }
 }
 
-export async function loadChatMcpServers(
-  chatId: string
+/**
+ * Load the MCP servers attached to either a chat or a scheduled job. The
+ * GitHub installation id is read off the owner's user relation regardless of
+ * the owner kind.
+ */
+export async function loadMcpConnections(
+  owner: McpOwner
 ): Promise<AgentMcpServer[]> {
-  const rows = await prisma.chatMcpServer.findMany({
-    where: { chatId, status: "connected" },
+  const rows = await prisma.mcpServerConnection.findMany({
+    where: { ...ownerWhere(owner), status: "connected" },
     select: {
       id: true,
       qualifiedName: true,
       mcpUrl: true,
       encryptedApiKey: true,
       chat: { select: { user: { select: { githubAppInstallationId: true } } } },
+      scheduledJob: {
+        select: { user: { select: { githubAppInstallationId: true } } },
+      },
     },
   })
 
   const out: AgentMcpServer[] = []
   for (const row of rows) {
-    const installationId = row.chat.user.githubAppInstallationId
+    const installationId =
+      row.chat?.user.githubAppInstallationId ??
+      row.scheduledJob?.user.githubAppInstallationId ??
+      null
     const translated = await translateRow(row, installationId)
     if (translated) out.push(translated)
   }
   return out
 }
 
-/**
- * Load the MCP servers attached to a scheduled job. Same translation as for
- * chats; the difference is the FK column and the relation traversal up to the
- * owning user (for the GitHub installationId).
- */
-export async function loadJobMcpServers(
-  jobId: string
-): Promise<AgentMcpServer[]> {
-  const rows = await prisma.scheduledJobMcpServer.findMany({
-    where: { jobId, status: "connected" },
-    select: {
-      id: true,
-      qualifiedName: true,
-      mcpUrl: true,
-      encryptedApiKey: true,
-      job: { select: { user: { select: { githubAppInstallationId: true } } } },
-    },
-  })
+// =============================================================================
+// Thin wrappers preserved so existing callsites don't need to change. New code
+// should call loadMcpConnections directly.
+// =============================================================================
 
-  const out: AgentMcpServer[] = []
-  for (const row of rows) {
-    const installationId = row.job.user.githubAppInstallationId
-    const translated = await translateRow(row, installationId)
-    if (translated) out.push(translated)
-  }
-  return out
+export function loadChatMcpServers(chatId: string): Promise<AgentMcpServer[]> {
+  return loadMcpConnections({ kind: "chat", id: chatId })
+}
+
+export function loadJobMcpServers(jobId: string): Promise<AgentMcpServer[]> {
+  return loadMcpConnections({ kind: "job", id: jobId })
 }

--- a/packages/web/lib/mcp/agent-servers.ts
+++ b/packages/web/lib/mcp/agent-servers.ts
@@ -1,11 +1,18 @@
 /**
- * Load a chat's connected MCP servers in the shape `setupMcpForAgent` wants.
+ * Load a chat's or scheduled job's connected MCP servers in the shape
+ * `setupMcpForAgent` wants.
  *
  * Two kinds of rows:
  *   - Smithery rows  → decrypt the stored Smithery API key for the bearer.
  *   - GitHub row     → mint a fresh installation token via getInstallationToken
  *                      (tokens are 1-hour, so we re-mint on every turn instead
  *                      of trying to keep them in sync with the DB).
+ *
+ * Both ChatMcpServer and ScheduledJobMcpServer share a row shape; the shared
+ * translator below handles either. On GitHub token mint failure we update the
+ * row's `lastError`/`status` so the UI can surface "GitHub App uninstalled" on
+ * the next form open — important for scheduled jobs that may run days after
+ * being configured.
  */
 import { prisma } from "@/lib/db/prisma"
 import { decrypt } from "@/lib/db/encryption"
@@ -34,12 +41,95 @@ function getGitHubProvider() {
   return githubProvider
 }
 
+/**
+ * Row shape common to ChatMcpServer and ScheduledJobMcpServer.
+ */
+interface McpRow {
+  id: string
+  qualifiedName: string
+  mcpUrl: string | null
+  encryptedApiKey: string | null
+}
+
+/**
+ * Update the row's lastError/status. Tries the chat table first, falls back to
+ * the job table. Best-effort — failure to record a warning shouldn't tank the
+ * turn.
+ */
+async function markRowError(rowId: string, message: string): Promise<void> {
+  try {
+    const updated = await prisma.chatMcpServer.updateMany({
+      where: { id: rowId },
+      data: { status: "error", lastError: message },
+    })
+    if (updated.count > 0) return
+    await prisma.scheduledJobMcpServer.updateMany({
+      where: { id: rowId },
+      data: { status: "error", lastError: message },
+    })
+  } catch (err) {
+    console.error("[agent-servers] failed to mark row error:", err)
+  }
+}
+
+/**
+ * Translate one DB row to the AgentMcpServer shape the sandbox loader expects.
+ * For Smithery rows: decrypt the stored bearer. For the GitHub sentinel: mint
+ * a fresh installation token from the owning user's `githubAppInstallationId`.
+ *
+ * Returns null when the row can't produce a usable connection (e.g. App
+ * uninstalled). On GitHub mint failure, the row's `lastError` is updated so
+ * the user sees it on next form open.
+ */
+async function translateRow(
+  row: McpRow,
+  githubAppInstallationId: string | null
+): Promise<AgentMcpServer | null> {
+  if (!row.mcpUrl) return null
+
+  if (row.qualifiedName === GITHUB_MCP_QUALIFIED_NAME) {
+    const github = getGitHubProvider()
+    if (!github) {
+      await markRowError(row.id, "GitHub App not configured on server")
+      return null
+    }
+    if (!githubAppInstallationId) {
+      await markRowError(row.id, "GitHub App not installed for this user")
+      return null
+    }
+    try {
+      const token = await github.getToken(githubAppInstallationId)
+      return {
+        name: safeServerName(row.qualifiedName),
+        url: row.mcpUrl,
+        bearerToken: token,
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to mint token"
+      console.error(
+        "[agent-servers] failed to mint GitHub installation token:",
+        err
+      )
+      await markRowError(row.id, `GitHub token mint failed: ${msg}`)
+      return null
+    }
+  }
+
+  if (!row.encryptedApiKey) return null
+  return {
+    name: safeServerName(row.qualifiedName),
+    url: row.mcpUrl,
+    bearerToken: decrypt(row.encryptedApiKey),
+  }
+}
+
 export async function loadChatMcpServers(
   chatId: string
 ): Promise<AgentMcpServer[]> {
   const rows = await prisma.chatMcpServer.findMany({
     where: { chatId, status: "connected" },
     select: {
+      id: true,
       qualifiedName: true,
       mcpUrl: true,
       encryptedApiKey: true,
@@ -49,38 +139,37 @@ export async function loadChatMcpServers(
 
   const out: AgentMcpServer[] = []
   for (const row of rows) {
-    if (!row.mcpUrl) continue
+    const installationId = row.chat.user.githubAppInstallationId
+    const translated = await translateRow(row, installationId)
+    if (translated) out.push(translated)
+  }
+  return out
+}
 
-    if (row.qualifiedName === GITHUB_MCP_QUALIFIED_NAME) {
-      const installationId = row.chat.user.githubAppInstallationId
-      const github = getGitHubProvider()
-      if (!installationId || !github) {
-        // Row exists but App has been uninstalled or not configured — skip
-        // silently so the agent doesn't get a row with no usable auth.
-        continue
-      }
-      try {
-        const token = await github.getToken(installationId)
-        out.push({
-          name: safeServerName(row.qualifiedName),
-          url: row.mcpUrl,
-          bearerToken: token,
-        })
-      } catch (err) {
-        console.error(
-          "[agent-servers] failed to mint GitHub installation token:",
-          err
-        )
-      }
-      continue
-    }
+/**
+ * Load the MCP servers attached to a scheduled job. Same translation as for
+ * chats; the difference is the FK column and the relation traversal up to the
+ * owning user (for the GitHub installationId).
+ */
+export async function loadJobMcpServers(
+  jobId: string
+): Promise<AgentMcpServer[]> {
+  const rows = await prisma.scheduledJobMcpServer.findMany({
+    where: { jobId, status: "connected" },
+    select: {
+      id: true,
+      qualifiedName: true,
+      mcpUrl: true,
+      encryptedApiKey: true,
+      job: { select: { user: { select: { githubAppInstallationId: true } } } },
+    },
+  })
 
-    if (!row.encryptedApiKey) continue
-    out.push({
-      name: safeServerName(row.qualifiedName),
-      url: row.mcpUrl,
-      bearerToken: decrypt(row.encryptedApiKey),
-    })
+  const out: AgentMcpServer[] = []
+  for (const row of rows) {
+    const installationId = row.job.user.githubAppInstallationId
+    const translated = await translateRow(row, installationId)
+    if (translated) out.push(translated)
   }
   return out
 }

--- a/packages/web/lib/mcp/agent-servers.ts
+++ b/packages/web/lib/mcp/agent-servers.ts
@@ -143,15 +143,3 @@ export async function loadMcpConnections(
   return out
 }
 
-// =============================================================================
-// Thin wrappers preserved so existing callsites don't need to change. New code
-// should call loadMcpConnections directly.
-// =============================================================================
-
-export function loadChatMcpServers(chatId: string): Promise<AgentMcpServer[]> {
-  return loadMcpConnections({ kind: "chat", id: chatId })
-}
-
-export function loadJobMcpServers(jobId: string): Promise<AgentMcpServer[]> {
-  return loadMcpConnections({ kind: "job", id: jobId })
-}

--- a/packages/web/lib/mcp/connections.ts
+++ b/packages/web/lib/mcp/connections.ts
@@ -1,0 +1,327 @@
+/**
+ * Owner-parameterized handlers for MCP connection CRUD + GitHub sentinel +
+ * Smithery finalize. The per-owner Next.js route files are thin wrappers that
+ * do auth, build the McpOwner, then delegate here.
+ */
+import { prisma } from "@/lib/db/prisma"
+import { encrypt } from "@/lib/db/encryption"
+import {
+  badRequest,
+  internalError,
+  notFound,
+  serverConfigError,
+} from "@/lib/db/api-helpers"
+import {
+  createSmitheryProvider,
+  getSmitheryConnectionId,
+  isSmitheryServer,
+  GITHUB_MCP_QUALIFIED_NAME,
+  GITHUB_MCP_URL,
+} from "@upstream/mcp-providers"
+import {
+  type McpOwner,
+  ownerCreateData,
+  ownerUniqueWhere,
+  ownerWhere,
+} from "./owner"
+
+// =============================================================================
+// Smithery connection-id prefix per owner kind. Keeps chat-scoped and
+// job-scoped Smithery connections in separate namespaces on Smithery's side.
+// =============================================================================
+
+function smitheryPrefix(owner: McpOwner): "chat" | "job" {
+  return owner.kind === "chat" ? "chat" : "job"
+}
+
+// =============================================================================
+// List
+// =============================================================================
+
+export async function listConnectionsResponse(owner: McpOwner): Promise<Response> {
+  const servers = await prisma.mcpServerConnection.findMany({
+    where: ownerWhere(owner),
+    orderBy: { createdAt: "desc" },
+    select: {
+      id: true,
+      qualifiedName: true,
+      displayName: true,
+      iconUrl: true,
+      status: true,
+      lastError: true,
+      createdAt: true,
+    },
+  })
+  return Response.json({ servers })
+}
+
+// =============================================================================
+// Connect (Smithery)
+// =============================================================================
+
+export interface ConnectSmitheryBody {
+  slug?: string
+  url?: string
+  name?: string
+  iconUrl?: string | null
+}
+
+export async function connectSmitheryResponse(
+  owner: McpOwner,
+  body: ConnectSmitheryBody
+): Promise<Response> {
+  const apiKey = process.env.SMITHERY_API_KEY
+  if (!apiKey) return serverConfigError("SMITHERY_API_KEY")
+
+  const { slug, url, name, iconUrl } = body
+  if (!slug || !url || !name) {
+    return badRequest("Missing required fields: slug, url, name")
+  }
+
+  if (!isSmitheryServer(url)) {
+    return badRequest(
+      "Only Smithery-hosted servers (server.smithery.ai) are supported"
+    )
+  }
+
+  try {
+    const smithery = createSmitheryProvider({
+      apiKey,
+      namespace: process.env.SMITHERY_NAMESPACE,
+    })
+    const connectionId = getSmitheryConnectionId(
+      owner.id,
+      slug,
+      smitheryPrefix(owner)
+    )
+    const result = await smithery.createConnection(url, connectionId, name)
+
+    if (result.status === "error") {
+      return Response.json(
+        { error: result.error ?? "Smithery connection failed" },
+        { status: 502 }
+      )
+    }
+
+    const isConnected = result.status === "connected"
+    const row = {
+      smitheryConnectionId: connectionId,
+      smitheryNamespace: result.namespace,
+      mcpUrl: result.mcpEndpoint,
+      status: isConnected ? "connected" : "pending",
+      encryptedApiKey: isConnected ? encrypt(apiKey) : null,
+      lastError: null,
+    }
+    const { id: serverId } = await prisma.mcpServerConnection.upsert({
+      where: ownerUniqueWhere(owner, slug),
+      create: {
+        ...ownerCreateData(owner),
+        qualifiedName: slug,
+        displayName: name,
+        iconUrl: iconUrl ?? null,
+        ...row,
+      },
+      update: {
+        displayName: name,
+        iconUrl: iconUrl ?? null,
+        ...row,
+      },
+      select: { id: true },
+    })
+
+    if (isConnected) {
+      return Response.json({ connected: true, serverId })
+    }
+    return Response.json({
+      connected: false,
+      serverId,
+      authUrl: result.authorizationUrl,
+    })
+  } catch (err) {
+    return internalError(err)
+  }
+}
+
+// =============================================================================
+// Disconnect (any kind — Smithery or GitHub sentinel)
+// =============================================================================
+
+export async function disconnectResponse(
+  owner: McpOwner,
+  serverId: string
+): Promise<Response> {
+  const server = await prisma.mcpServerConnection.findUnique({
+    where: { id: serverId },
+  })
+  if (!server || !rowMatchesOwner(server, owner)) {
+    return notFound("Server not found")
+  }
+
+  try {
+    const apiKey = process.env.SMITHERY_API_KEY
+    if (apiKey && server.smitheryConnectionId) {
+      const smithery = createSmitheryProvider({
+        apiKey,
+        namespace: process.env.SMITHERY_NAMESPACE,
+      })
+      await smithery.deleteConnection(server.smitheryConnectionId)
+    }
+
+    await prisma.mcpServerConnection.delete({ where: { id: serverId } })
+    return Response.json({ deleted: true })
+  } catch (err) {
+    return internalError(err)
+  }
+}
+
+// =============================================================================
+// GitHub sentinel attach
+// =============================================================================
+
+export async function attachGithubResponse(
+  owner: McpOwner,
+  userId: string
+): Promise<Response> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { githubAppInstallationId: true },
+  })
+  if (!user?.githubAppInstallationId) {
+    return Response.json(
+      { error: "GitHub App not installed for this user" },
+      { status: 409 }
+    )
+  }
+
+  try {
+    const { id: serverId } = await prisma.mcpServerConnection.upsert({
+      where: ownerUniqueWhere(owner, GITHUB_MCP_QUALIFIED_NAME),
+      create: {
+        ...ownerCreateData(owner),
+        qualifiedName: GITHUB_MCP_QUALIFIED_NAME,
+        displayName: "GitHub",
+        iconUrl: null,
+        mcpUrl: GITHUB_MCP_URL,
+        status: "connected",
+      },
+      update: {
+        status: "connected",
+        lastError: null,
+      },
+      select: { id: true },
+    })
+    return Response.json({ connected: true, serverId })
+  } catch (err) {
+    return internalError(err)
+  }
+}
+
+// =============================================================================
+// Smithery finalize (poll after OAuth popup closes)
+// =============================================================================
+
+export async function finalizeSmitheryResponse(
+  owner: McpOwner,
+  serverId: string
+): Promise<Response> {
+  const server = await prisma.mcpServerConnection.findUnique({
+    where: { id: serverId },
+  })
+  if (!server || !rowMatchesOwner(server, owner)) {
+    return notFound("Server not found")
+  }
+  if (!server.smitheryConnectionId) {
+    return badRequest("Server has no Smithery connection id")
+  }
+
+  const apiKey = process.env.SMITHERY_API_KEY
+  if (!apiKey) return serverConfigError("SMITHERY_API_KEY")
+
+  try {
+    const smithery = createSmitheryProvider({
+      apiKey,
+      namespace: process.env.SMITHERY_NAMESPACE,
+    })
+
+    const status = await smithery.getConnectionStatus(
+      server.smitheryConnectionId
+    )
+
+    if (status.state === "connected") {
+      const namespace = await smithery.getNamespace()
+      if (!namespace) {
+        return Response.json(
+          { error: "Failed to resolve Smithery namespace" },
+          { status: 500 }
+        )
+      }
+
+      const mcpEndpoint = smithery.getMcpEndpointWithNamespace(
+        namespace,
+        server.smitheryConnectionId
+      )
+
+      await prisma.mcpServerConnection.update({
+        where: { id: serverId },
+        data: {
+          mcpUrl: mcpEndpoint,
+          smitheryNamespace: namespace,
+          encryptedApiKey: encrypt(apiKey),
+          status: "connected",
+          lastError: null,
+        },
+      })
+
+      return Response.json({ connected: true })
+    }
+
+    return Response.json(
+      { error: "Connection not yet authorized. Please try again." },
+      { status: 400 }
+    )
+  } catch (err) {
+    return internalError(err)
+  }
+}
+
+// =============================================================================
+// Smithery cleanup on owner delete. Cascade handles our DB rows; Smithery has
+// to be told explicitly or its connection lingers and counts against quota.
+// =============================================================================
+
+export async function cleanupSmitheryConnections(owner: McpOwner): Promise<void> {
+  const apiKey = process.env.SMITHERY_API_KEY
+  if (!apiKey) return
+
+  const rows = await prisma.mcpServerConnection.findMany({
+    where: { ...ownerWhere(owner), smitheryConnectionId: { not: null } },
+    select: { smitheryConnectionId: true },
+  })
+  if (rows.length === 0) return
+
+  const smithery = createSmitheryProvider({
+    apiKey,
+    namespace: process.env.SMITHERY_NAMESPACE,
+  })
+  for (const row of rows) {
+    if (!row.smitheryConnectionId) continue
+    try {
+      await smithery.deleteConnection(row.smitheryConnectionId)
+    } catch (err) {
+      console.error("[mcp] Smithery cleanup failed (non-fatal):", err)
+    }
+  }
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function rowMatchesOwner(
+  row: { chatId: string | null; scheduledJobId: string | null },
+  owner: McpOwner
+): boolean {
+  return owner.kind === "chat"
+    ? row.chatId === owner.id
+    : row.scheduledJobId === owner.id
+}

--- a/packages/web/lib/mcp/owner.ts
+++ b/packages/web/lib/mcp/owner.ts
@@ -1,0 +1,77 @@
+/**
+ * Owner abstraction for MCP server connections.
+ *
+ * Every McpServerConnection row belongs to exactly one owner — currently a
+ * Chat or a ScheduledJob, modeled on the row as two nullable FKs. Code that
+ * needs to read or mutate connections is parameterized by this discriminated
+ * union so the chat- and job-side surfaces share one implementation.
+ */
+import { prisma } from "@/lib/db/prisma"
+import type { Prisma } from "@prisma/client"
+
+export type McpOwner =
+  | { kind: "chat"; id: string }
+  | { kind: "job"; id: string }
+
+/**
+ * Where-clause fragment that selects rows belonging to the given owner.
+ * Use it inline in any prisma.mcpServerConnection.find/update/delete call.
+ */
+export function ownerWhere(
+  owner: McpOwner
+): Prisma.McpServerConnectionWhereInput {
+  return owner.kind === "chat"
+    ? { chatId: owner.id }
+    : { scheduledJobId: owner.id }
+}
+
+/**
+ * Unique-where fragment for upserts keyed on (owner, qualifiedName).
+ */
+export function ownerUniqueWhere(
+  owner: McpOwner,
+  qualifiedName: string
+): Prisma.McpServerConnectionWhereUniqueInput {
+  return owner.kind === "chat"
+    ? { chatId_qualifiedName: { chatId: owner.id, qualifiedName } }
+    : {
+        scheduledJobId_qualifiedName: {
+          scheduledJobId: owner.id,
+          qualifiedName,
+        },
+      }
+}
+
+/**
+ * Create-data fragment for inserting a row with the right owner FK populated
+ * and the other left null.
+ */
+export function ownerCreateData(
+  owner: McpOwner
+): Pick<Prisma.McpServerConnectionUncheckedCreateInput, "chatId" | "scheduledJobId"> {
+  return owner.kind === "chat"
+    ? { chatId: owner.id, scheduledJobId: null }
+    : { chatId: null, scheduledJobId: owner.id }
+}
+
+/**
+ * Verify the caller owns the underlying chat or scheduled job. Returns true
+ * on success, false if the entity doesn't exist or belongs to someone else.
+ */
+export async function requireMcpOwnerAuth(
+  owner: McpOwner,
+  userId: string
+): Promise<boolean> {
+  if (owner.kind === "chat") {
+    const row = await prisma.chat.findUnique({
+      where: { id: owner.id },
+      select: { userId: true },
+    })
+    return !!row && row.userId === userId
+  }
+  const row = await prisma.scheduledJob.findUnique({
+    where: { id: owner.id },
+    select: { userId: true },
+  })
+  return !!row && row.userId === userId
+}

--- a/packages/web/prisma/migrations/20260523000000_add_scheduled_job_mcp_server/migration.sql
+++ b/packages/web/prisma/migrations/20260523000000_add_scheduled_job_mcp_server/migration.sql
@@ -1,0 +1,27 @@
+-- CreateTable
+CREATE TABLE "ScheduledJobMcpServer" (
+    "id" TEXT NOT NULL,
+    "jobId" TEXT NOT NULL,
+    "qualifiedName" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "iconUrl" TEXT,
+    "smitheryConnectionId" TEXT,
+    "smitheryNamespace" TEXT,
+    "mcpUrl" TEXT NOT NULL,
+    "encryptedApiKey" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "lastError" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ScheduledJobMcpServer_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ScheduledJobMcpServer_jobId_idx" ON "ScheduledJobMcpServer"("jobId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ScheduledJobMcpServer_jobId_qualifiedName_key" ON "ScheduledJobMcpServer"("jobId", "qualifiedName");
+
+-- AddForeignKey
+ALTER TABLE "ScheduledJobMcpServer" ADD CONSTRAINT "ScheduledJobMcpServer_jobId_fkey" FOREIGN KEY ("jobId") REFERENCES "ScheduledJob"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/web/prisma/migrations/20260523200000_add_scheduled_job_is_draft/migration.sql
+++ b/packages/web/prisma/migrations/20260523200000_add_scheduled_job_is_draft/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "ScheduledJob" ADD COLUMN     "isDraft" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/web/prisma/migrations/20260524000000_unify_mcp_server_connection/migration.sql
+++ b/packages/web/prisma/migrations/20260524000000_unify_mcp_server_connection/migration.sql
@@ -1,0 +1,82 @@
+-- Unify ChatMcpServer + ScheduledJobMcpServer into a single
+-- McpServerConnection table with two nullable FKs. Each FK keeps its own
+-- ON DELETE CASCADE so deleting a chat or a job still drops its connections.
+-- A CHECK constraint enforces that exactly one of (chatId, scheduledJobId)
+-- is set per row, since Prisma can't model that.
+
+-- 1. Create the new table.
+CREATE TABLE "McpServerConnection" (
+    "id" TEXT NOT NULL,
+    "chatId" TEXT,
+    "scheduledJobId" TEXT,
+    "qualifiedName" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "iconUrl" TEXT,
+    "smitheryConnectionId" TEXT,
+    "smitheryNamespace" TEXT,
+    "mcpUrl" TEXT NOT NULL,
+    "encryptedApiKey" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "lastError" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "McpServerConnection_pkey" PRIMARY KEY ("id")
+);
+
+-- 2. CHECK: exactly one owner. (X XOR Y) expressed via inequality of nullness.
+ALTER TABLE "McpServerConnection"
+    ADD CONSTRAINT "McpServerConnection_exactly_one_owner"
+    CHECK (("chatId" IS NULL) <> ("scheduledJobId" IS NULL));
+
+-- 3. Indexes and unique constraints.
+CREATE INDEX "McpServerConnection_chatId_idx" ON "McpServerConnection"("chatId");
+CREATE INDEX "McpServerConnection_scheduledJobId_idx" ON "McpServerConnection"("scheduledJobId");
+CREATE UNIQUE INDEX "McpServerConnection_chatId_qualifiedName_key" ON "McpServerConnection"("chatId", "qualifiedName");
+CREATE UNIQUE INDEX "McpServerConnection_scheduledJobId_qualifiedName_key" ON "McpServerConnection"("scheduledJobId", "qualifiedName");
+
+-- 4. Foreign keys with cascade. Each side stands on its own — the row dies
+--    when its owner dies, regardless of whether the other column is set.
+ALTER TABLE "McpServerConnection"
+    ADD CONSTRAINT "McpServerConnection_chatId_fkey"
+    FOREIGN KEY ("chatId") REFERENCES "Chat"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "McpServerConnection"
+    ADD CONSTRAINT "McpServerConnection_scheduledJobId_fkey"
+    FOREIGN KEY ("scheduledJobId") REFERENCES "ScheduledJob"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- 5. Backfill from ChatMcpServer.
+INSERT INTO "McpServerConnection" (
+    "id", "chatId", "scheduledJobId",
+    "qualifiedName", "displayName", "iconUrl",
+    "smitheryConnectionId", "smitheryNamespace", "mcpUrl",
+    "encryptedApiKey", "status", "lastError",
+    "createdAt", "updatedAt"
+)
+SELECT
+    "id", "chatId", NULL,
+    "qualifiedName", "displayName", "iconUrl",
+    "smitheryConnectionId", "smitheryNamespace", "mcpUrl",
+    "encryptedApiKey", "status", "lastError",
+    "createdAt", "updatedAt"
+FROM "ChatMcpServer";
+
+-- 6. Backfill from ScheduledJobMcpServer.
+INSERT INTO "McpServerConnection" (
+    "id", "chatId", "scheduledJobId",
+    "qualifiedName", "displayName", "iconUrl",
+    "smitheryConnectionId", "smitheryNamespace", "mcpUrl",
+    "encryptedApiKey", "status", "lastError",
+    "createdAt", "updatedAt"
+)
+SELECT
+    "id", NULL, "jobId",
+    "qualifiedName", "displayName", "iconUrl",
+    "smitheryConnectionId", "smitheryNamespace", "mcpUrl",
+    "encryptedApiKey", "status", "lastError",
+    "createdAt", "updatedAt"
+FROM "ScheduledJobMcpServer";
+
+-- 7. Drop old tables (FK constraints come with them).
+DROP TABLE "ChatMcpServer";
+DROP TABLE "ScheduledJobMcpServer";

--- a/packages/web/prisma/schema.prisma
+++ b/packages/web/prisma/schema.prisma
@@ -138,9 +138,9 @@ model Chat {
   environmentVariables Json?
 
   // Relations
-  user       User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user       User                  @relation(fields: [userId], references: [id], onDelete: Cascade)
   messages   Message[]
-  mcpServers ChatMcpServer[]
+  mcpServers McpServerConnection[]
 
   // Link back to scheduled run (if this chat belongs to one)
   scheduledJobRun ScheduledJobRun?
@@ -150,15 +150,17 @@ model Chat {
 }
 
 // =============================================================================
-// ChatMcpServer - per-chat MCP connections (via Smithery Connect)
+// McpServerConnection - per-owner MCP connections (via Smithery Connect)
 // =============================================================================
-// Each row is one connected MCP server for a specific chat. The agent in the
-// sandbox will get a config entry pointing at `mcpUrl` with `encryptedApiKey`
-// decrypted into an Authorization header.
+// One row per attached MCP server. Owners are either Chat or ScheduledJob —
+// modelled as two nullable FKs so each side keeps its own CASCADE on delete.
+// Exactly one of (chatId, scheduledJobId) is set; the CHECK constraint added
+// in the migration enforces that at the DB level since Prisma can't model it.
 
-model ChatMcpServer {
-  id     String @id @default(cuid())
-  chatId String
+model McpServerConnection {
+  id             String  @id @default(cuid())
+  chatId         String?
+  scheduledJobId String?
 
   // Identity from Smithery's registry
   qualifiedName String // e.g. "exa/exa-search" — stable handle
@@ -182,10 +184,13 @@ model ChatMcpServer {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  chat Chat @relation(fields: [chatId], references: [id], onDelete: Cascade)
+  chat         Chat?         @relation(fields: [chatId], references: [id], onDelete: Cascade)
+  scheduledJob ScheduledJob? @relation(fields: [scheduledJobId], references: [id], onDelete: Cascade)
 
   @@unique([chatId, qualifiedName])
+  @@unique([scheduledJobId, qualifiedName])
   @@index([chatId])
+  @@index([scheduledJobId])
 }
 
 // =============================================================================
@@ -306,44 +311,12 @@ model ScheduledJob {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  user       User                    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user       User                  @relation(fields: [userId], references: [id], onDelete: Cascade)
   runs       ScheduledJobRun[]
-  mcpServers ScheduledJobMcpServer[]
+  mcpServers McpServerConnection[]
 
   @@index([userId])
   @@index([enabled, nextRunAt])
-}
-
-// =============================================================================
-// ScheduledJobMcpServer - per-job MCP connections
-// =============================================================================
-// Mirrors ChatMcpServer but scoped to a ScheduledJob. The cron loader fetches
-// these at run time and writes the per-agent MCP config into the sandbox.
-
-model ScheduledJobMcpServer {
-  id    String @id @default(cuid())
-  jobId String
-
-  qualifiedName String
-  displayName   String
-  iconUrl       String?
-
-  smitheryConnectionId String?
-  smitheryNamespace    String?
-  mcpUrl               String
-
-  encryptedApiKey String? @db.Text
-
-  status    String  @default("pending") // pending | connected | error
-  lastError String?
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  job ScheduledJob @relation(fields: [jobId], references: [id], onDelete: Cascade)
-
-  @@unique([jobId, qualifiedName])
-  @@index([jobId])
 }
 
 // =============================================================================

--- a/packages/web/prisma/schema.prisma
+++ b/packages/web/prisma/schema.prisma
@@ -300,11 +300,44 @@ model ScheduledJob {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  user User             @relation(fields: [userId], references: [id], onDelete: Cascade)
-  runs ScheduledJobRun[]
+  user       User                    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  runs       ScheduledJobRun[]
+  mcpServers ScheduledJobMcpServer[]
 
   @@index([userId])
   @@index([enabled, nextRunAt])
+}
+
+// =============================================================================
+// ScheduledJobMcpServer - per-job MCP connections
+// =============================================================================
+// Mirrors ChatMcpServer but scoped to a ScheduledJob. The cron loader fetches
+// these at run time and writes the per-agent MCP config into the sandbox.
+
+model ScheduledJobMcpServer {
+  id    String @id @default(cuid())
+  jobId String
+
+  qualifiedName String
+  displayName   String
+  iconUrl       String?
+
+  smitheryConnectionId String?
+  smitheryNamespace    String?
+  mcpUrl               String
+
+  encryptedApiKey String? @db.Text
+
+  status    String  @default("pending") // pending | connected | error
+  lastError String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  job ScheduledJob @relation(fields: [jobId], references: [id], onDelete: Cascade)
+
+  @@unique([jobId, qualifiedName])
+  @@index([jobId])
 }
 
 // =============================================================================

--- a/packages/web/prisma/schema.prisma
+++ b/packages/web/prisma/schema.prisma
@@ -293,6 +293,12 @@ model ScheduledJob {
   // Continue from last run
   continueFromLastRun Boolean @default(false)
 
+  // Draft state — true while the user is still in the create-job modal after
+  // materializing the row to attach MCP servers. Drafts are filtered out of
+  // the list, the cron, and the Run Now endpoint. Flipped to false on the
+  // final Create submit; DELETEd on Cancel.
+  isDraft Boolean @default(false)
+
   // Failure tracking
   consecutiveFailures Int @default(0)
 


### PR DESCRIPTION
## Summary
 
Lets users attach MCP servers (Smithery + GitHub App) to a scheduled job from inside the job form. Each run loads the job's connections and exposes them to the agent — same plumbing the chat flow uses today, scoped per-job instead of per-chat.
 
Connections are **job-scoped**, not user-scoped: attaching Notion to one job doesn't attach it to another. Each run of the job picks up whatever's currently connected.
 
## Why
 
`ChatMcpServer` already exists for chat-attached MCP. Scheduled jobs had no equivalent — the picker wasn't surfaced in the job form, and nothing at run time read MCP servers off the job. This PR mirrors the chat-side machinery for jobs and wires it into the cron lifecycle.
 
## Architecture
 
Foundation → server-side → UI → UX polish, in that order:
 
1. **`getSmitheryConnectionId` accepts a scope prefix** (`"chat"` default, `"job"` for new rows) so chat and job Smithery connections don't collide on Smithery's side. Backward compatible.
2. **`ScheduledJobMcpServer` model** mirrors `ChatMcpServer` shape, FK to `ScheduledJob`, cascade-on-delete. New migration.
3. **`loadJobMcpServers(jobId)`** in `packages/web/lib/mcp/agent-servers.ts`. The row → `AgentMcpServer` translator is extracted and shared with `loadChatMcpServers`. On GitHub token mint failure the row's `lastError` / `status` is now written back so the picker surfaces "GitHub App not installed" on the next form open — important for jobs that may run days after they were configured.
4. **Job-scoped API routes** mirror the chat-scoped ones one-for-one:
   - `GET/POST /api/scheduled-jobs/:id/mcp-servers`
   - `DELETE /api/scheduled-jobs/:id/mcp-servers/:serverId`
   - `POST /api/scheduled-jobs/:id/mcp-servers/github`
   - `POST /api/scheduled-jobs/:id/mcp-servers/:serverId/smithery-finalize`
   - New `getJobWithAuth` ownership helper in `api-helpers.ts`.
5. **Cron wiring**: `startJobExecution` in `agent-lifecycle/route.ts` calls `loadJobMcpServers(job.id)` before `createBackgroundAgentSession`. Best-effort — failure degrades to a no-MCP run rather than failing the turn.
6. **Cascade cleanup**:
   - Job DELETE iterates Smithery rows and calls `smithery.deleteConnection` before the DB cascade drops the rows. Without this, deleted jobs leak Smithery connections that count against quota.
   - GitHub App uninstall (`DELETE /api/mcp/connect/github`) now also drops job-level GitHub MCP rows in addition to chat-level — so a scheduled run days after uninstall doesn't try to use a dead installation id.
7. **UI**: `McpServersCombobox` is now entity-agnostic — `entityId` + `apiBase` props replace hard-coded chat paths. Chat callers pass `apiBase="/api/chats"`; scheduled jobs pass `apiBase="/api/scheduled-jobs"`. Picker is rendered above Prompt in the job form.
8. **Draft materialization for in-form MCP attach.** Saving the job to attach MCP would be terrible UX, so the form materializes the row on the first MCP click. The row carries an `isDraft` flag that keeps it out of the list, the cron, the `MAX_JOBS_PER_USER` count, and the Run Now endpoint. Final Create flips `isDraft → false` via PATCH; Cancel / close DELETEs the draft (cascading through `ScheduledJobMcpServer` and Smithery cleanup). Trigger/schedule fields lock after materialize because the PATCH endpoint doesn't accept those.
## Auth lifecycle
 
Worth understanding because jobs can run days/weeks after configuration:
 
| Credential | Where it lives | Refresh |
|---|---|---|
| Smithery API key (bearer to `mcpUrl`) | Encrypted on the row at connect time | Snapshot — no refresh; survives until Smithery's global key actually rotates |
| Smithery → 3rd-party OAuth (Notion, Linear, etc.) | On Smithery's side | Smithery refreshes; we never see those tokens |
| GitHub MCP installation token | Not stored — minted at run time | Fresh ~1h token via `github.getToken(installationId)` on every run |
 
What can fail days later:
 
- **GitHub App uninstall** — token mint throws → row gets `status: "error", lastError: "GitHub App not installed for this user"`, run proceeds without GitHub MCP. Re-installing + re-attaching clears it.
- **GitHub App repo access revoked** — token mints but tool calls 404; agent sees the error in-transcript.
- **Smithery 3rd-party OAuth revoked / Smithery connection deleted** — tool calls fail; agent sees the error in-transcript.
## Schema changes
 
```prisma
model ScheduledJob {
  ...
  isDraft    Boolean                 @default(false)
  mcpServers ScheduledJobMcpServer[]
}
 
model ScheduledJobMcpServer {
  // same shape as ChatMcpServer, FK to ScheduledJob, @@unique([jobId, qualifiedName])
}
```
 
Two migrations:
 
- `20260523000000_add_scheduled_job_mcp_server`
- `20260523200000_add_scheduled_job_is_draft`
Both are additive — safe to run on a populated DB.
