### PR TITLE
feat: add loading state and right slot support to McpServersCombobox and CommandInput

### DIFF
--- a/packages/web/components/chat/McpServersCombobox.tsx
+++ b/packages/web/components/chat/McpServersCombobox.tsx
@@ -133,6 +133,7 @@ export function McpServersCombobox({
   const [connected, setConnected] = useState<ConnectedServer[]>([])
   const [registry, setRegistry] = useState<RegistryServer[]>([])
   const [loadingRegistry, setLoadingRegistry] = useState(false)
+  const [hasLoadedRegistry, setHasLoadedRegistry] = useState(false)
   const [search, setSearch] = useState("")
   const [busySlug, setBusySlug] = useState<string | null>(null)
   const [githubBusy, setGithubBusy] = useState(false)
@@ -197,6 +198,7 @@ export function McpServersCombobox({
       console.error("[McpServersCombobox] loadRegistry failed:", err)
     } finally {
       setLoadingRegistry(false)
+      setHasLoadedRegistry(true)
     }
   }, [])
 
@@ -528,18 +530,28 @@ export function McpServersCombobox({
             placeholder="Search MCP servers..."
             value={search}
             onValueChange={setSearch}
+            rightSlot={
+              hasLoadedRegistry && loadingRegistry ? (
+                <Loader2
+                  className="h-4 w-4 animate-spin text-muted-foreground shrink-0"
+                  aria-label="Searching"
+                />
+              ) : null
+            }
           />
-          <CommandList>
-            {loadingRegistry && allServers.length === 0 ? (
+          <CommandList className="h-[252px] max-h-[252px]">
+            {!hasLoadedRegistry ? (
               <div
-                className="flex items-center justify-center py-6"
+                className="flex items-center justify-center h-[252px]"
                 role="status"
                 aria-label="Loading MCP servers"
               >
                 <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
               </div>
-            ) : allServers.length === 0 ? (
-              <CommandEmpty>No servers found</CommandEmpty>
+            ) : allServers.length === 0 && !loadingRegistry ? (
+              <CommandEmpty className="flex items-center justify-center h-[252px] py-0">
+                No servers found
+              </CommandEmpty>
             ) : (
               allServers.map((s) => {
                 const isGitHub = s.slug === GITHUB_QUALIFIED_NAME

--- a/packages/web/components/ui/command.tsx
+++ b/packages/web/components/ui/command.tsx
@@ -103,8 +103,11 @@ function CommandDialog({
 
 function CommandInput({
   className,
+  rightSlot,
   ...props
-}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+}: React.ComponentProps<typeof CommandPrimitive.Input> & {
+  rightSlot?: React.ReactNode
+}) {
   return (
     <div
       data-slot="command-input-wrapper"
@@ -119,6 +122,7 @@ function CommandInput({
         )}
         {...props}
       />
+      {rightSlot}
     </div>
   )
 }
@@ -140,12 +144,13 @@ function CommandList({
 }
 
 function CommandEmpty({
+  className,
   ...props
 }: React.ComponentProps<typeof CommandPrimitive.Empty>) {
   return (
     <CommandPrimitive.Empty
       data-slot="command-empty"
-      className="py-6 text-center text-sm"
+      className={cn("py-6 text-center text-sm", className)}
       {...props}
     />
   )


### PR DESCRIPTION
## Summary

  Fixes layout shift and UX flicker in the MCP servers picker  (used by both ChatInput and ScheduledJobForm).
  ### Before
  - Popover resized between loading → empty → populated states
  (small while loading/empty, ~300px when populated).
  - On first open, the popover briefly showed only the GitHub
  entry while the Smithery registry was still fetching.
  - Typing in the search box flashed "No servers found" during
  the 300ms debounce + fetch before new results arrived.

  ### After
  - Popover has a fixed total height of **300px** (48px input +
  252px list) across all states.
  - Loader and "No servers found" are vertically centered in the   list area.
  - First open shows a full-area loader until the Smithery
  registry resolves — no GitHub-only flash.
  - Subsequent searches keep current results visible and show a
  small inline spinner in the search input; "No servers found"
  only renders after the fetch actually returns empty.
