### PR TITLE
Feat/repo less jobs

### DIFF
--- a/packages/agent-configuration/src/git/opencode.ts
+++ b/packages/agent-configuration/src/git/opencode.ts
@@ -11,9 +11,9 @@
  */
 
 /**
- * OpenCode permission rules that block dangerous git operations.
+ * OpenCode permission rules.
  *
- * The rules block:
+ * `bash` rules block dangerous git operations:
  * - git commit --amend (history rewriting)
  * - git rebase (history rewriting)
  * - git reset --hard (history rewriting)
@@ -21,6 +21,13 @@
  * - git branch -d/-D/-m/-M (branch manipulation)
  * - git checkout (use "git restore" for file operations)
  * - git switch (branch switching)
+ *
+ * `edit` and `webfetch` are explicitly allowed. Without these, opencode falls
+ * back to its built-in default ("ask"), which in headless/scheduled mode
+ * becomes an auto-rejection — see the `external_directory` denial that crashes
+ * scheduled runs the first time the agent (or opencode itself) touches
+ * `/tmp/logs/*`. `webfetch` is opened up so MCP servers and the agent's own
+ * web tooling work in scheduled jobs.
  */
 export const OPENCODE_PERMISSIONS = {
   bash: {
@@ -41,6 +48,12 @@ export const OPENCODE_PERMISSIONS = {
     "git branch * -M*": "deny",
     "git checkout*": "deny",
     "git switch*": "deny",
+  },
+  edit: {
+    "*": "allow",
+  },
+  webfetch: {
+    "*": "allow",
   },
 } as const
 

--- a/packages/web/app/api/cron/agent-lifecycle/route.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/route.ts
@@ -10,6 +10,7 @@ import { getUserCredentials } from "@/lib/db/api-helpers"
 import { getClaudeCredentials } from "@/lib/claude-credentials"
 import { PATHS } from "@/lib/constants"
 import type { Settings } from "@/lib/types"
+import { NEW_REPOSITORY } from "@/lib/types"
 import { DEFAULT_SETTINGS } from "@/lib/storage"
 import { createSandboxForChat, deleteSandboxQuietly } from "@/lib/sandbox"
 import {
@@ -316,13 +317,17 @@ async function startJobExecution(
   run: Prisma.ScheduledJobRunGetPayload<object>,
   daytona: Daytona
 ) {
-  // 1. Get GitHub token for the user
+  const isRepoLess = job.repo === NEW_REPOSITORY
+
+  // 1. Get GitHub token for the user — required for cloned repos, optional
+  //    for repo-less jobs (the sandbox never reaches out to GitHub, though
+  //    MCP servers may still want a token of their own).
   const account = await prisma.account.findFirst({
     where: { userId: job.userId, provider: "github" },
     select: { access_token: true },
   })
 
-  if (!account?.access_token) {
+  if (!isRepoLess && !account?.access_token) {
     throw new Error("GitHub account not linked")
   }
 
@@ -344,10 +349,13 @@ async function startJobExecution(
     data: { chatId: chat.id, status: "running" },
   })
 
-  // 4. Determine base branch (may be from last run if continueFromLastRun is enabled)
+  // 4. Determine base branch (may be from last run if continueFromLastRun is
+  //    enabled). Only applies to repo-backed jobs — repo-less sandboxes have
+  //    no remote, so we carry context forward via the prompt instead (see
+  //    step 8 below).
   let effectiveBaseBranch = job.baseBranch
 
-  if (job.continueFromLastRun) {
+  if (job.continueFromLastRun && !isRepoLess) {
     // Find the last successful run with commits
     const lastSuccessfulRun = await prisma.scheduledJobRun.findFirst({
       where: {
@@ -372,7 +380,7 @@ async function startJobExecution(
             `https://api.github.com/repos/${owner}/${repoName}/pulls/${lastSuccessfulRun.prNumber}`,
             {
               headers: {
-                Authorization: `Bearer ${account.access_token}`,
+                Authorization: `Bearer ${account!.access_token}`,
                 Accept: "application/vnd.github.v3+json",
               },
             }
@@ -395,14 +403,15 @@ async function startJobExecution(
     }
   }
 
-  // 5. Create fresh sandbox
+  // 5. Create fresh sandbox. createSandboxForChat detects NEW_REPOSITORY and
+  //    skips the clone path, so we don't need the GitHub token in that case.
   const branch = `scheduled/${job.id}/${format(new Date(), "yyyyMMdd-HHmmss")}`
   const { sandbox, sandboxId, previewUrlPattern } = await createSandboxForChat({
     daytona,
     repo: job.repo,
     baseBranch: effectiveBaseBranch,
     newBranch: branch,
-    githubToken: account.access_token,
+    githubToken: account?.access_token ?? undefined,
     userId: job.userId,
   })
 
@@ -457,6 +466,41 @@ async function startJobExecution(
 
   // 8. Build the prompt (augment with trigger context for webhook-triggered runs)
   let finalPrompt = job.prompt
+
+  // Repo-less continueFromLastRun: there's no remote branch to carry forward,
+  // so include the previous run's final assistant message as prompt context.
+  if (job.continueFromLastRun && isRepoLess) {
+    const lastRun = await prisma.scheduledJobRun.findFirst({
+      where: {
+        jobId: job.id,
+        status: "completed",
+        chatId: { not: null },
+        id: { not: run.id },
+      },
+      orderBy: { completedAt: "desc" },
+      select: { chatId: true },
+    })
+
+    if (lastRun?.chatId) {
+      const lastAssistantMessage = await prisma.message.findFirst({
+        where: { chatId: lastRun.chatId, role: "assistant" },
+        orderBy: { timestamp: "desc" },
+        select: { content: true },
+      })
+
+      if (lastAssistantMessage?.content?.trim()) {
+        finalPrompt = [
+          `## Context from previous run`,
+          ``,
+          lastAssistantMessage.content.trim(),
+          ``,
+          `---`,
+          ``,
+          job.prompt,
+        ].join("\n")
+      }
+    }
+  }
 
   if (run.triggerContext && job.triggerType === "webhook") {
     const ctx = run.triggerContext as {
@@ -586,6 +630,7 @@ async function finalizeScheduledRun(
   let commitCount = 0
   let prUrl: string | null = null
   let prNumber: number | null = null
+  const isRepoLess = job.repo === NEW_REPOSITORY
 
   if (run.sandboxId && run.branch) {
     try {
@@ -596,6 +641,12 @@ async function finalizeScheduledRun(
       if (run.backgroundSessionId) {
         await finalizeTurn(sandbox, run.backgroundSessionId, { repoPath })
       }
+
+      // Repo-less sandboxes have no remote to compare against and nothing to
+      // push/PR — just finalize the turn and bail out of the git workflow.
+      if (isRepoLess) {
+        // fall through to run-record update below
+      } else {
 
       // Count commits on branch vs the base branch this run was created from
       const baseForComparison = run.baseBranch || job.baseBranch
@@ -663,6 +714,7 @@ async function finalizeScheduledRun(
           await git.push(repoPath, account.access_token, pushOptions)
         }
       }
+      } // end !isRepoLess
     } catch (err) {
       console.error(`[agent-lifecycle] Error finalizing run ${run.id}:`, err)
     }

--- a/packages/web/app/api/scheduled-jobs/route.ts
+++ b/packages/web/app/api/scheduled-jobs/route.ts
@@ -12,6 +12,7 @@ import {
 import { addMinutes, addYears } from "date-fns"
 import { toScheduledJobResponse } from "@/lib/scheduled-jobs/types"
 import { createWebhook } from "@upstream/common"
+import { NEW_REPOSITORY } from "@/lib/types"
 
 // =============================================================================
 // Constants
@@ -91,6 +92,13 @@ export async function POST(req: NextRequest): Promise<Response> {
     }
     if (!body.agent?.trim()) {
       return badRequest("agent is required")
+    }
+
+    const isRepoLess = body.repo.trim() === NEW_REPOSITORY
+
+    // Webhook triggers need a real GitHub repo to attach to.
+    if (triggerType === "webhook" && isRepoLess) {
+      return badRequest("Webhook triggers require a repository")
     }
 
     // Validate trigger-specific fields

--- a/packages/web/components/scheduled-jobs/ScheduledJobForm.tsx
+++ b/packages/web/components/scheduled-jobs/ScheduledJobForm.tsx
@@ -2,14 +2,14 @@
 
 import { useState, useEffect, useMemo } from "react"
 import * as Dialog from "@radix-ui/react-dialog"
-import { Clock, ChevronDown } from "lucide-react"
+import { Clock, ChevronDown, X } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { ModalHeader, focusChatPrompt } from "@/components/ui/modal-header"
 import { RepoCombobox } from "@/components/chat/RepoCombobox"
 import { BranchCombobox } from "@/components/chat/BranchCombobox"
 import { McpServersCombobox } from "@/components/chat/McpServersCombobox"
 import { type ScheduledJob } from "@/lib/scheduled-jobs/types"
-import { agentModels, agentLabels, getModelLabel, type Agent } from "@/lib/types"
+import { agentModels, agentLabels, getModelLabel, type Agent, NEW_REPOSITORY } from "@/lib/types"
 import { AgentIcon } from "@/components/icons/agent-icons"
 
 // =============================================================================
@@ -130,8 +130,12 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
   // Form state
   const [name, setName] = useState(job?.name ?? "")
   const [prompt, setPrompt] = useState(job?.prompt ?? "")
-  const [repo, setRepo] = useState(job?.repo ?? "")
+  // Empty string means "no repo" in form state; on submit we send NEW_REPOSITORY.
+  const [repo, setRepo] = useState(
+    job?.repo && job.repo !== NEW_REPOSITORY ? job.repo : ""
+  )
   const [baseBranch, setBaseBranch] = useState(job?.baseBranch ?? "main")
+  const isRepoLess = !repo
   const [agent, setAgent] = useState<Agent>((job?.agent as Agent) ?? "opencode")
   const [model, setModel] = useState(job?.model ?? "")
   const [triggerType, setTriggerType] = useState<"interval" | "webhook">(job?.triggerType ?? "interval")
@@ -175,7 +179,7 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
       const initialModels = agentModels[initialAgent] ?? []
       setName(job?.name ?? "")
       setPrompt(job?.prompt ?? "")
-      setRepo(job?.repo ?? "")
+      setRepo(job?.repo && job.repo !== NEW_REPOSITORY ? job.repo : "")
       setBaseBranch(job?.baseBranch ?? "main")
       setAgent(initialAgent)
       setModel(job?.model ?? initialModels[0]?.value ?? "")
@@ -197,6 +201,14 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
       setModel(models[0].value)
     }
   }, [agent, model])
+
+  // Webhook triggers require a real GitHub repo — snap back to interval if the
+  // user clears the repo while webhook was selected.
+  useEffect(() => {
+    if (isRepoLess && triggerType === "webhook") {
+      setTriggerType("interval")
+    }
+  }, [isRepoLess, triggerType])
 
   // Close dropdowns when clicking outside
   useEffect(() => {
@@ -224,15 +236,17 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
       setError("Prompt is required")
       return null
     }
-    if (!repo) {
-      setError("Repository is required")
+    if (isRepoLess && triggerType === "webhook") {
+      setError("Webhook triggers require a repository")
       return null
     }
     const runAtHourUtc = localHourToUtc(runAtHourLocal)
     return {
       name: name.trim(),
       prompt: prompt.trim(),
-      repo,
+      // Empty form value means repo-less; send the NEW_REPOSITORY sentinel so
+      // the backend can route through its existing no-clone sandbox path.
+      repo: repo || NEW_REPOSITORY,
       baseBranch,
       agent,
       model: model || null,
@@ -240,7 +254,8 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
       intervalMinutes: triggerType === "interval" ? intervalMinutes : undefined,
       runAtHour: triggerType === "interval" && intervalMinutes >= 1440 ? runAtHourUtc : undefined,
       runAtDay: triggerType === "interval" && intervalMinutes === 10080 ? runAtDay : undefined,
-      autoPR,
+      // Auto-PR has nothing to push to in repo-less mode.
+      autoPR: isRepoLess ? false : autoPR,
       continueFromLastRun,
     }
   }
@@ -275,7 +290,9 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
           // values before flipping isDraft to false.
           name: name.trim() || "(draft)",
           prompt: prompt.trim() || "(draft)",
-          repo: repo || "__draft__",
+          // Drafts default to the repo-less sentinel so the row passes the
+          // backend's repo check before the user fills the form in fully.
+          repo: repo || NEW_REPOSITORY,
           baseBranch: baseBranch || "main",
           agent,
           model: model || null,
@@ -431,22 +448,30 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
                 "inline-flex rounded-md bg-muted p-0.5",
                 isLocked && "opacity-50"
               )}>
-                {TRIGGER_TYPES.map((t) => (
-                  <button
-                    key={t.value}
-                    type="button"
-                    onClick={() => !isLocked && setTriggerType(t.value)}
-                    disabled={isLocked}
-                    className={cn(
-                      "px-3 py-1 text-sm rounded-md transition-colors cursor-pointer",
-                      triggerType === t.value
-                        ? "bg-background shadow-sm"
-                        : "text-muted-foreground hover:text-foreground"
-                    )}
-                  >
-                    {t.label}
-                  </button>
-                ))}
+                {TRIGGER_TYPES.map((t) => {
+                  // Webhook triggers attach to a GitHub repo, so they're not
+                  // available in repo-less mode.
+                  const isWebhookDisabled = t.value === "webhook" && isRepoLess
+                  const disabled = isLocked || isWebhookDisabled
+                  return (
+                    <button
+                      key={t.value}
+                      type="button"
+                      onClick={() => !disabled && setTriggerType(t.value)}
+                      disabled={disabled}
+                      title={isWebhookDisabled ? "Select a repository to use webhook triggers" : undefined}
+                      className={cn(
+                        "px-3 py-1 text-sm rounded-md transition-colors cursor-pointer",
+                        triggerType === t.value
+                          ? "bg-background shadow-sm"
+                          : "text-muted-foreground hover:text-foreground",
+                        isWebhookDisabled && "opacity-50 cursor-not-allowed"
+                      )}
+                    >
+                      {t.label}
+                    </button>
+                  )
+                })}
               </div>
             </div>
 
@@ -548,7 +573,24 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
                       showLabel
                     />
 
-                    {/* Branch selector */}
+                    {/* Clear-repo X — only in create mode; edits keep the
+                        repo immutable since the sandbox/branch pipeline is
+                        already wired to it. */}
+                    {repo && !isEditing && (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setRepo("")
+                          setBaseBranch("main")
+                        }}
+                        className="text-muted-foreground hover:text-foreground transition-colors cursor-pointer p-0.5"
+                        title="Remove repository"
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    )}
+
+                    {/* Branch selector — only meaningful when a repo is set. */}
                     {repo && (
                       <BranchCombobox
                         repo={repo}
@@ -654,7 +696,10 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
             <div>
               <label className="block text-sm font-medium mb-2">Options</label>
               <div className="space-y-2">
-                {/* Continue from last run - only for scheduled triggers */}
+                {/* Continue from last run — same checkbox in both modes, but
+                    the backend interprets it differently: with a repo it
+                    reuses the prior branch; repo-less it prepends the prior
+                    run's final output as prompt context. */}
                 {triggerType === "interval" && (
                   <div className="flex items-center gap-2">
                     <input
@@ -665,23 +710,28 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
                       className="h-4 w-4 rounded border-border"
                     />
                     <label htmlFor="continueFromLastRun" className="text-sm">
-                      Include commits from the previous run
+                      {isRepoLess
+                        ? "Include the previous run's output as context"
+                        : "Include commits from the previous run"}
                     </label>
                   </div>
                 )}
 
-                <div className="flex items-center gap-2">
-                  <input
-                    type="checkbox"
-                    id="autoPR"
-                    checked={autoPR}
-                    onChange={(e) => setAutoPR(e.target.checked)}
-                    className="h-4 w-4 rounded border-border"
-                  />
-                  <label htmlFor="autoPR" className="text-sm">
-                    Automatically create PR when there are new commits
-                  </label>
-                </div>
+                {/* Auto-PR has no target in repo-less mode (no remote to push to). */}
+                {!isRepoLess && (
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      id="autoPR"
+                      checked={autoPR}
+                      onChange={(e) => setAutoPR(e.target.checked)}
+                      className="h-4 w-4 rounded border-border"
+                    />
+                    <label htmlFor="autoPR" className="text-sm">
+                      Automatically create PR when there are new commits
+                    </label>
+                  </div>
+                )}
               </div>
             </div>
 

--- a/packages/web/components/scheduled-jobs/ScheduledJobsView.tsx
+++ b/packages/web/components/scheduled-jobs/ScheduledJobsView.tsx
@@ -10,6 +10,11 @@ import { ConfirmDialog } from "@/components/modals/ConfirmDialog"
 import { MessageBubble } from "@/components/MessageBubble"
 import { type ScheduledJob, type ScheduledJobRun, formatInterval } from "@/lib/scheduled-jobs/types"
 import type { Message } from "@/lib/types"
+import { NEW_REPOSITORY } from "@/lib/types"
+
+function getRepoLabel(repo: string): string {
+  return repo === NEW_REPOSITORY ? "No repository" : repo
+}
 
 // =============================================================================
 // Helpers
@@ -568,7 +573,7 @@ export function ScheduledJobsView({ onOpenForm, refreshKey, urlJobId, onNavigate
                     </div>
                   </div>
                   <div className="mt-3 space-y-1.5 text-sm text-muted-foreground">
-                    <div className="truncate">{job.repo}</div>
+                    <div className={cn("truncate", job.repo === NEW_REPOSITORY && "italic")}>{getRepoLabel(job.repo)}</div>
                     <div className="flex items-center justify-between gap-2">
                       <span>{getTriggerDescription(job)}</span>
                       <span className={cn(
@@ -617,8 +622,11 @@ export function ScheduledJobsView({ onOpenForm, refreshKey, urlJobId, onNavigate
                           )}
                         </div>
                       </td>
-                      <td className="px-4 py-3 text-sm text-muted-foreground">
-                        {job.repo}
+                      <td className={cn(
+                        "px-4 py-3 text-sm text-muted-foreground",
+                        job.repo === NEW_REPOSITORY && "italic"
+                      )}>
+                        {getRepoLabel(job.repo)}
                       </td>
                       <td className="px-4 py-3 text-sm text-muted-foreground">
                         {getTriggerDescription(job)}


### PR DESCRIPTION
## Summary

  Adds **repo-less scheduled jobs** — users can create scheduled   agent runs that aren't tied to a GitHub repository, intended
  for personal automations (Gmail digests, Notion sync, Calendar   checks, etc. via MCP servers).

  Also fixes an OpenCode permission crash that affected any
  scheduled job using OpenCode — surfaced quickly in repo-less
  jobs because the agent's only filesystem touch is OpenCode's
  own `/tmp/logs/*` writes.

  ## What's new

  ### Repo-less scheduled jobs

  - `ScheduledJobForm` no longer requires a repository. Empty
  form value submits as the existing `NEW_REPOSITORY`
  (`"__new__"`) sentinel.
  - ✕ button next to the repo selector clears it back to
  repo-less (mirrors the `ChatInput` pattern).
  - When repo-less:
    - Branch picker hidden
    - Auto-PR option hidden (no remote to push to)
    - Webhook trigger disabled with a tooltip (webhooks need a
  GitHub repo)
    - Trigger auto-snaps back to **interval** if the user clears   the repo while webhook was selected
    - `continueFromLastRun` checkbox stays — relabeled to
  *"Include the previous run's output as context"* and prepends
  the prior run's final assistant message to the prompt
  - `POST /api/scheduled-jobs` accepts `repo === NEW_REPOSITORY`   without GitHub auth and rejects webhook + repo-less combos.
  - `agent-lifecycle` cron:
    - Skips the GitHub-account check for repo-less jobs
    - Passes `undefined` token to `createSandboxForChat`
  (existing `isNewRepo` path handles the rest — fresh `git
  init`, README, `scheduled/<jobId>/<ts>` branch)
    - Skips the entire commit-count / push / PR finalize block
  when repo-less
  - `ScheduledJobsView` shows *"No repository"* in italic
  instead of the raw `__new__` sentinel.

  ### OpenCode permission fix

  - `OPENCODE_PERMISSIONS` now declares `edit: { "*": "allow" }`   and `webfetch: { "*": "allow" }` alongside the existing
  `bash` rules.
  - Without these, OpenCode's built-in `external_directory`
  guard auto-rejected `/tmp/logs/*` in headless mode and killed
  the agent process at startup (`sqlite-migration:done` →
  `auto-rejecting` → exit).
  - All existing git-safety denies on `bash` are preserved.
  - No change needed for **Codex** (already passes `--yolo` in
  non-plan mode = `--ask-for-approval=never
  --sandbox=danger-full-access`) or **Claude Code** (different
  permission model, unaffected).

  