### PR TITLE
Add voice-to-text dictation to the chat composer

### DIFF
--- a/packages/web/components/chat/ChatInput.tsx
+++ b/packages/web/components/chat/ChatInput.tsx
@@ -355,8 +355,9 @@ export function ChatInput({
             ) : null}
           </div>
 
-          {/* Voice dictation (speech-to-text) — pinned to the top-right corner,
-              in line with the message text input. Only shown when supported. */}
+          {/* Voice dictation (speech-to-text) — anchored to the bottom-right,
+              vertically aligned with the send button even as the textarea
+              grows. Only shown when supported. */}
           {speech.isSupported && (
             <button
               type="button"
@@ -364,7 +365,7 @@ export function ChatInput({
               disabled={speech.permissionDenied}
               aria-pressed={speech.isListening}
               className={cn(
-                "shrink-0 self-start flex items-center justify-center rounded-md transition-colors",
+                "shrink-0 flex items-center justify-center rounded-md transition-colors",
                 isMobile ? "h-9 w-9" : "h-7 w-7",
                 speech.permissionDenied
                   ? "text-muted-foreground/40 cursor-not-allowed"

--- a/packages/web/components/chat/ChatInput.tsx
+++ b/packages/web/components/chat/ChatInput.tsx
@@ -354,6 +354,42 @@ export function ChatInput({
               </button>
             ) : null}
           </div>
+
+          {/* Voice dictation (speech-to-text) — pinned to the top-right corner,
+              in line with the message text input. Only shown when supported. */}
+          {speech.isSupported && (
+            <button
+              type="button"
+              onClick={toggleListening}
+              disabled={speech.permissionDenied}
+              aria-pressed={speech.isListening}
+              className={cn(
+                "shrink-0 self-start flex items-center justify-center rounded-md transition-colors",
+                isMobile ? "h-9 w-9" : "h-7 w-7",
+                speech.permissionDenied
+                  ? "text-muted-foreground/40 cursor-not-allowed"
+                  : speech.isListening
+                  ? "text-red-500 bg-red-500/10 animate-pulse cursor-pointer"
+                  : "text-muted-foreground hover:text-foreground cursor-pointer"
+              )}
+              title={
+                speech.permissionDenied
+                  ? "Microphone access denied"
+                  : speech.isListening
+                  ? "Stop dictation"
+                  : "Dictate prompt"
+              }
+              aria-label={
+                speech.permissionDenied
+                  ? "Microphone access denied"
+                  : speech.isListening
+                  ? "Stop voice dictation"
+                  : "Start voice dictation"
+              }
+            >
+              <Mic className={cn(isMobile ? "h-4 w-4" : "h-3.5 w-3.5")} />
+            </button>
+          )}
         </div>
 
         {/* File upload error message */}
@@ -394,41 +430,6 @@ export function ChatInput({
             >
               <Paperclip className={cn(isMobile ? "h-4 w-4" : "h-3.5 w-3.5")} />
             </button>
-
-            {/* Voice dictation (speech-to-text) button — only when supported */}
-            {speech.isSupported && (
-              <button
-                type="button"
-                onClick={toggleListening}
-                disabled={speech.permissionDenied}
-                aria-pressed={speech.isListening}
-                className={cn(
-                  "shrink-0 flex items-center justify-center rounded-md transition-colors",
-                  isMobile ? "h-7 w-7" : "h-6 w-6",
-                  speech.permissionDenied
-                    ? "text-muted-foreground/40 cursor-not-allowed"
-                    : speech.isListening
-                    ? "text-red-500 bg-red-500/10 animate-pulse cursor-pointer"
-                    : "text-muted-foreground hover:text-foreground cursor-pointer"
-                )}
-                title={
-                  speech.permissionDenied
-                    ? "Microphone access denied"
-                    : speech.isListening
-                    ? "Stop dictation"
-                    : "Dictate prompt"
-                }
-                aria-label={
-                  speech.permissionDenied
-                    ? "Microphone access denied"
-                    : speech.isListening
-                    ? "Stop voice dictation"
-                    : "Start voice dictation"
-                }
-              >
-                <Mic className={cn(isMobile ? "h-4 w-4" : "h-3.5 w-3.5")} />
-              </button>
-            )}
 
             {/* Repo display/selector */}
             {showRepoButton ? (

--- a/packages/web/components/chat/ChatInput.tsx
+++ b/packages/web/components/chat/ChatInput.tsx
@@ -1,9 +1,10 @@
 "use client"
 
 import { useRef, useEffect, useCallback, useState } from "react"
-import { AlertTriangle, ArrowUp, Square, ChevronDown, Github, X, Paperclip, Pencil, ListChecks } from "lucide-react"
+import { AlertTriangle, ArrowUp, Square, ChevronDown, Github, X, Paperclip, Pencil, ListChecks, Mic } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useModals } from "@/lib/contexts"
+import { useSpeechRecognition } from "@/lib/hooks/useSpeechRecognition"
 import type { Chat, Agent, CredentialFlags, PendingFile } from "@/lib/types"
 import { NEW_REPOSITORY } from "@/lib/types"
 import { PendingFilesDisplay } from "./PendingFilesDisplay"
@@ -146,6 +147,60 @@ export function ChatInput({
   const [showModeDropdown, setShowModeDropdown] = useState(false)
   const [showModeSheet, setShowModeSheet] = useState(false)
 
+  // -- Speech-to-text (voice dictation) -------------------------------------
+  // Keep the latest input in a ref so the recognition callback (created once
+  // per render but invoked asynchronously) always reads the current value.
+  const inputRef = useRef(input)
+  inputRef.current = input
+  // Cursor position to restore after a controlled-state update inserts text.
+  const pendingSelectionRef = useRef<number | null>(null)
+
+  const insertTranscript = useCallback((text: string) => {
+    const textarea = textareaRef.current
+    const current = inputRef.current
+    // Determine where to insert: at the caret if focused, else append.
+    const hasSelection = textarea && document.activeElement === textarea
+    const start = hasSelection ? textarea.selectionStart ?? current.length : current.length
+    const end = hasSelection ? textarea.selectionEnd ?? current.length : current.length
+
+    const before = current.slice(0, start)
+    const after = current.slice(end)
+    // Add a space between existing text and the new chunk when needed.
+    const needsLeadingSpace = before.length > 0 && !/\s$/.test(before)
+    const insertion = (needsLeadingSpace ? " " : "") + text
+    const next = before + insertion + after
+
+    pendingSelectionRef.current = start + insertion.length
+    onInputChange(next)
+  }, [onInputChange, textareaRef])
+
+  const speech = useSpeechRecognition({ onResult: insertTranscript })
+
+  // Restore the caret after a transcript insertion re-renders the textarea.
+  useEffect(() => {
+    if (pendingSelectionRef.current === null) return
+    const textarea = textareaRef.current
+    const pos = pendingSelectionRef.current
+    pendingSelectionRef.current = null
+    if (!textarea) return
+    textarea.focus()
+    textarea.setSelectionRange(pos, pos)
+  }, [input, textareaRef])
+
+  const toggleListening = useCallback(() => {
+    if (speech.isListening) {
+      speech.stop()
+    } else {
+      speech.start()
+    }
+  }, [speech])
+
+  // Stop dictation when a message is sent.
+  const handleSendWithSpeechStop = useCallback(() => {
+    if (speech.isListening) speech.stop()
+    onSend()
+  }, [speech, onSend])
+
   // Close mode dropdown when clicking outside (desktop only)
   useEffect(() => {
     if (isMobile) return
@@ -268,7 +323,7 @@ export function ChatInput({
           )}>
             {isRunning && canQueue ? (
               <button
-                onClick={onSend}
+                onClick={handleSendWithSpeechStop}
                 title="Queue message (sent after current response)"
                 className={cn(
                   "flex items-center justify-center rounded-md bg-primary text-primary-foreground hover:bg-primary/90 active:bg-primary/80 transition-colors",
@@ -289,7 +344,7 @@ export function ChatInput({
               </button>
             ) : canSend ? (
               <button
-                onClick={onSend}
+                onClick={handleSendWithSpeechStop}
                 className={cn(
                   "flex items-center justify-center rounded-md bg-primary text-primary-foreground hover:bg-primary/90 active:bg-primary/80 transition-colors",
                   isMobile ? "h-9 w-9" : "h-7 w-7"
@@ -339,6 +394,41 @@ export function ChatInput({
             >
               <Paperclip className={cn(isMobile ? "h-4 w-4" : "h-3.5 w-3.5")} />
             </button>
+
+            {/* Voice dictation (speech-to-text) button — only when supported */}
+            {speech.isSupported && (
+              <button
+                type="button"
+                onClick={toggleListening}
+                disabled={speech.permissionDenied}
+                aria-pressed={speech.isListening}
+                className={cn(
+                  "shrink-0 flex items-center justify-center rounded-md transition-colors",
+                  isMobile ? "h-7 w-7" : "h-6 w-6",
+                  speech.permissionDenied
+                    ? "text-muted-foreground/40 cursor-not-allowed"
+                    : speech.isListening
+                    ? "text-red-500 bg-red-500/10 animate-pulse cursor-pointer"
+                    : "text-muted-foreground hover:text-foreground cursor-pointer"
+                )}
+                title={
+                  speech.permissionDenied
+                    ? "Microphone access denied"
+                    : speech.isListening
+                    ? "Stop dictation"
+                    : "Dictate prompt"
+                }
+                aria-label={
+                  speech.permissionDenied
+                    ? "Microphone access denied"
+                    : speech.isListening
+                    ? "Stop voice dictation"
+                    : "Start voice dictation"
+                }
+              >
+                <Mic className={cn(isMobile ? "h-4 w-4" : "h-3.5 w-3.5")} />
+              </button>
+            )}
 
             {/* Repo display/selector */}
             {showRepoButton ? (

--- a/packages/web/lib/hooks/useSpeechRecognition.ts
+++ b/packages/web/lib/hooks/useSpeechRecognition.ts
@@ -1,0 +1,251 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+
+// =============================================================================
+// Web Speech API type declarations
+//
+// The SpeechRecognition interfaces are not part of the standard TypeScript DOM
+// lib, so we declare the minimal surface we use here. They are vendor-prefixed
+// (webkitSpeechRecognition) in Chrome/Safari.
+// =============================================================================
+
+interface SpeechRecognitionAlternative {
+  readonly transcript: string
+  readonly confidence: number
+}
+
+interface SpeechRecognitionResult {
+  readonly isFinal: boolean
+  readonly length: number
+  item(index: number): SpeechRecognitionAlternative
+  [index: number]: SpeechRecognitionAlternative
+}
+
+interface SpeechRecognitionResultList {
+  readonly length: number
+  item(index: number): SpeechRecognitionResult
+  [index: number]: SpeechRecognitionResult
+}
+
+interface SpeechRecognitionEvent extends Event {
+  readonly resultIndex: number
+  readonly results: SpeechRecognitionResultList
+}
+
+interface SpeechRecognitionErrorEvent extends Event {
+  readonly error: string
+  readonly message: string
+}
+
+interface SpeechRecognitionInstance extends EventTarget {
+  lang: string
+  continuous: boolean
+  interimResults: boolean
+  maxAlternatives: number
+  start(): void
+  stop(): void
+  abort(): void
+  onresult: ((event: SpeechRecognitionEvent) => void) | null
+  onerror: ((event: SpeechRecognitionErrorEvent) => void) | null
+  onend: (() => void) | null
+  onstart: (() => void) | null
+}
+
+type SpeechRecognitionConstructor = new () => SpeechRecognitionInstance
+
+declare global {
+  interface Window {
+    SpeechRecognition?: SpeechRecognitionConstructor
+    webkitSpeechRecognition?: SpeechRecognitionConstructor
+  }
+}
+
+function getSpeechRecognition(): SpeechRecognitionConstructor | null {
+  if (typeof window === "undefined") return null
+  return window.SpeechRecognition ?? window.webkitSpeechRecognition ?? null
+}
+
+// Stop listening after this many ms with no new speech results.
+const SILENCE_TIMEOUT_MS = 4000
+
+export interface UseSpeechRecognitionOptions {
+  /**
+   * Called whenever a final (committed) chunk of speech is recognized. Receives
+   * the recognized text. Use this to insert the text into an input.
+   */
+  onResult?: (transcript: string) => void
+  /** BCP-47 language tag. Defaults to the browser/document language. */
+  lang?: string
+  /**
+   * Auto-stop after a period of silence. Defaults to true so the mic doesn't
+   * stay open indefinitely.
+   */
+  stopOnSilence?: boolean
+}
+
+export interface UseSpeechRecognitionResult {
+  /** Whether recognition is currently active. */
+  isListening: boolean
+  /** Whether the browser supports the Web Speech API. */
+  isSupported: boolean
+  /** Whether microphone permission has been denied. */
+  permissionDenied: boolean
+  /** The latest interim (not-yet-final) transcript, for live UI feedback. */
+  transcript: string
+  /** A human-readable error, if recognition failed. */
+  error: string | null
+  /** Start listening. No-op if unsupported or already listening. */
+  start: () => void
+  /** Stop listening. */
+  stop: () => void
+}
+
+/**
+ * Speech-to-text hook built on the browser Web Speech API.
+ *
+ * Dependency-free — uses `window.SpeechRecognition` /
+ * `window.webkitSpeechRecognition`. Feature-detect via the returned
+ * `isSupported` and only render UI when it is true.
+ *
+ * @example
+ * ```tsx
+ * const { isListening, isSupported, start, stop } = useSpeechRecognition({
+ *   onResult: (text) => insertIntoInput(text),
+ * })
+ * ```
+ */
+export function useSpeechRecognition(
+  options: UseSpeechRecognitionOptions = {}
+): UseSpeechRecognitionResult {
+  const { lang, stopOnSilence = true } = options
+
+  const [isSupported, setIsSupported] = useState(false)
+  const [isListening, setIsListening] = useState(false)
+  const [permissionDenied, setPermissionDenied] = useState(false)
+  const [transcript, setTranscript] = useState("")
+  const [error, setError] = useState<string | null>(null)
+
+  const recognitionRef = useRef<SpeechRecognitionInstance | null>(null)
+  const silenceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Keep the latest onResult callback in a ref so the recognition event
+  // handlers (bound once) always call the current closure.
+  const onResultRef = useRef(options.onResult)
+  onResultRef.current = options.onResult
+  // Tracks user intent so we don't fight the engine's own auto-stop.
+  const listeningRef = useRef(false)
+
+  // Feature-detect support on mount (client-only).
+  useEffect(() => {
+    setIsSupported(getSpeechRecognition() !== null)
+  }, [])
+
+  const clearSilenceTimer = useCallback(() => {
+    if (silenceTimerRef.current) {
+      clearTimeout(silenceTimerRef.current)
+      silenceTimerRef.current = null
+    }
+  }, [])
+
+  const stop = useCallback(() => {
+    listeningRef.current = false
+    clearSilenceTimer()
+    recognitionRef.current?.stop()
+  }, [clearSilenceTimer])
+
+  const armSilenceTimer = useCallback(() => {
+    if (!stopOnSilence) return
+    clearSilenceTimer()
+    silenceTimerRef.current = setTimeout(() => {
+      stop()
+    }, SILENCE_TIMEOUT_MS)
+  }, [stopOnSilence, clearSilenceTimer, stop])
+
+  const start = useCallback(() => {
+    const Ctor = getSpeechRecognition()
+    if (!Ctor || listeningRef.current) return
+
+    setError(null)
+    setTranscript("")
+
+    const recognition = new Ctor()
+    const docLang = typeof document !== "undefined" ? document.documentElement.lang : ""
+    recognition.lang = lang || docLang || "en-US"
+    recognition.continuous = true
+    recognition.interimResults = true
+    recognition.maxAlternatives = 1
+
+    recognition.onstart = () => {
+      setIsListening(true)
+      armSilenceTimer()
+    }
+
+    recognition.onresult = (event: SpeechRecognitionEvent) => {
+      armSilenceTimer()
+      let interim = ""
+      for (let i = event.resultIndex; i < event.results.length; i++) {
+        const result = event.results[i]
+        const text = result[0]?.transcript ?? ""
+        if (result.isFinal) {
+          const finalText = text.trim()
+          if (finalText) {
+            onResultRef.current?.(finalText)
+          }
+        } else {
+          interim += text
+        }
+      }
+      setTranscript(interim)
+    }
+
+    recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
+      if (event.error === "not-allowed" || event.error === "service-not-allowed") {
+        setPermissionDenied(true)
+        setError("Microphone access was denied.")
+      } else if (event.error === "no-speech") {
+        // Benign — user didn't say anything before silence/stop.
+        setError(null)
+      } else if (event.error !== "aborted") {
+        setError(`Speech recognition error: ${event.error}`)
+      }
+    }
+
+    recognition.onend = () => {
+      listeningRef.current = false
+      clearSilenceTimer()
+      setIsListening(false)
+      setTranscript("")
+      recognitionRef.current = null
+    }
+
+    recognitionRef.current = recognition
+    listeningRef.current = true
+    try {
+      recognition.start()
+    } catch {
+      // start() throws if called while already started; reset state.
+      listeningRef.current = false
+      setIsListening(false)
+    }
+  }, [lang, armSilenceTimer, clearSilenceTimer])
+
+  // Clean up on unmount.
+  useEffect(() => {
+    return () => {
+      clearSilenceTimer()
+      listeningRef.current = false
+      recognitionRef.current?.abort()
+      recognitionRef.current = null
+    }
+  }, [clearSilenceTimer])
+
+  return {
+    isListening,
+    isSupported,
+    permissionDenied,
+    transcript,
+    error,
+    start,
+    stop,
+  }
+}


### PR DESCRIPTION
## Summary

Adds browser-based speech-to-text support to the chat composer using the Web Speech API. Users can now dictate prompts with a microphone button, review/edit the transcript, and send normally no backend, API keys, or extra dependencies required.

Also improves composer UX by keeping the mic button aligned with the send button as the textarea expands, with proper accessibility and mobile support.

@jamesmurdza or @abdulrehmann231 have a look!

Closes #161 
