### PR TITLE
Fix Open Code shared pool models 

### DIFF
--- a/packages/common/src/agents.ts
+++ b/packages/common/src/agents.ts
@@ -98,21 +98,28 @@ export interface ModelOption {
   requiresKey?: ProviderId | "none"
 }
 
-/** Models allowed to run on the server-shared OpenCode API key */
+/**
+ * Models allowed to run on the server-shared OpenCode API key.
+ *
+ * The shared key is an OpenCode **Go** subscription key, so these must use the
+ * `opencode-go/` prefix to route through Go (the $10/mo pool the key pays for).
+ * The `opencode/` prefix would route through OpenCode **Zen** (pay-as-you-go),
+ * where the Go key has no balance — that yields an "insufficient balance" error.
+ */
 const SHARED_OPENCODE_ALLOWED = new Set<string>([
-  "opencode/glm-5",
-  "opencode/glm-5.1",
-  "opencode/kimi-k2.5",
-  "opencode/kimi-k2.6",
-  "opencode/mimo-v2.5",
-  "opencode/mimo-v2.5-pro",
-  "opencode/minimax-m2.5",
-  "opencode/minimax-m2.7",
-  "opencode/minimax-m3",
-  "opencode/qwen3-6-plus",
-  "opencode/qwen3-7-max",
-  "opencode/deepseek-v4-pro",
-  "opencode/deepseek-v4-flash",
+  "opencode-go/glm-5",
+  "opencode-go/glm-5.1",
+  "opencode-go/kimi-k2.5",
+  "opencode-go/kimi-k2.6",
+  "opencode-go/mimo-v2.5",
+  "opencode-go/mimo-v2.5-pro",
+  "opencode-go/minimax-m2.5",
+  "opencode-go/minimax-m2.7",
+  "opencode-go/minimax-m3",
+  "opencode-go/qwen3.6-plus",
+  "opencode-go/qwen3.7-max",
+  "opencode-go/deepseek-v4-pro",
+  "opencode-go/deepseek-v4-flash",
 ])
 
 export const agentModels: Record<Agent, ModelOption[]> = {
@@ -131,40 +138,42 @@ export const agentModels: Record<Agent, ModelOption[]> = {
     { value: "opencode/nemotron-3-super-free", label: "Nemotron 3 Super (Free)", requiresKey: "none" },
     { value: "opencode/deepseek-v4-flash-free", label: "DeepSeek V4 Flash (Free)", requiresKey: "none" },
     { value: "opencode/mimo-v2.5-free", label: "MiMo v2.5 (Free)", requiresKey: "none" },
-    // Paid opencode/ models (requires OpenCode API key)
-    // Curated models shown first when OPENCODE_API_KEY (server-shared) is available
-    { value: "opencode/glm-5", label: "GLM-5", requiresKey: "opencode" },
-    { value: "opencode/glm-5.1", label: "GLM-5.1", requiresKey: "opencode" },
-    { value: "opencode/kimi-k2.5", label: "Kimi K2.5", requiresKey: "opencode" },
-    { value: "opencode/kimi-k2.6", label: "Kimi K2.6", requiresKey: "opencode" },
-    { value: "opencode/mimo-v2.5-pro", label: "MiMo v2.5 Pro", requiresKey: "opencode" },
-    { value: "opencode/minimax-m2.5", label: "MiniMax M2.5", requiresKey: "opencode" },
-    { value: "opencode/minimax-m2.7", label: "MiniMax M2.7", requiresKey: "opencode" },
-    { value: "opencode/minimax-m3", label: "MiniMax M3", requiresKey: "opencode" },
-    { value: "opencode/qwen3-6-plus", label: "Qwen3.6 Plus", requiresKey: "opencode" },
-    { value: "opencode/qwen3-7-max", label: "Qwen3.7 Max", requiresKey: "opencode" },
-    { value: "opencode/deepseek-v4-pro", label: "DeepSeek V4 Pro", requiresKey: "opencode" },
-    { value: "opencode/deepseek-v4-flash", label: "DeepSeek V4 Flash", requiresKey: "opencode" },
+    // Curated OpenCode Go models (opencode-go/ prefix), runnable on the
+    // server-shared Go subscription key. Shown first when OPENCODE_API_KEY is
+    // available. These route through Go, not Zen — see SHARED_OPENCODE_ALLOWED.
+    { value: "opencode-go/glm-5", label: "GLM-5 (Go)", requiresKey: "opencode" },
+    { value: "opencode-go/glm-5.1", label: "GLM-5.1 (Go)", requiresKey: "opencode" },
+    { value: "opencode-go/kimi-k2.5", label: "Kimi K2.5 (Go)", requiresKey: "opencode" },
+    { value: "opencode-go/kimi-k2.6", label: "Kimi K2.6 (Go)", requiresKey: "opencode" },
+    { value: "opencode-go/mimo-v2.5-pro", label: "MiMo v2.5 Pro (Go)", requiresKey: "opencode" },
+    { value: "opencode-go/minimax-m2.5", label: "MiniMax M2.5 (Go)", requiresKey: "opencode" },
+    { value: "opencode-go/minimax-m2.7", label: "MiniMax M2.7 (Go)", requiresKey: "opencode" },
+    { value: "opencode-go/minimax-m3", label: "MiniMax M3 (Go)", requiresKey: "opencode" },
+    { value: "opencode-go/qwen3.6-plus", label: "Qwen3.6 Plus (Go)", requiresKey: "opencode" },
+    { value: "opencode-go/qwen3.7-max", label: "Qwen3.7 Max (Go)", requiresKey: "opencode" },
+    { value: "opencode-go/deepseek-v4-pro", label: "DeepSeek V4 Pro (Go)", requiresKey: "opencode" },
+    { value: "opencode-go/deepseek-v4-flash", label: "DeepSeek V4 Flash (Go)", requiresKey: "opencode" },
 
-    // Remaining paid models (preserve original order, excluding duplicates)
-    { value: "opencode/claude-sonnet-4", label: "Claude Sonnet 4", requiresKey: "opencode" },
-    { value: "opencode/claude-sonnet-4-5", label: "Claude Sonnet 4.5", requiresKey: "opencode" },
-    { value: "opencode/claude-sonnet-4-6", label: "Claude Sonnet 4.6", requiresKey: "opencode" },
-    { value: "opencode/claude-haiku-4-5", label: "Claude Haiku 4.5", requiresKey: "opencode" },
-    { value: "opencode/claude-opus-4-5", label: "Claude Opus 4.5", requiresKey: "opencode" },
-    { value: "opencode/claude-opus-4-6", label: "Claude Opus 4.6", requiresKey: "opencode" },
-    { value: "opencode/claude-opus-4-7", label: "Claude Opus 4.7", requiresKey: "opencode" },
-    { value: "opencode/claude-opus-4-8", label: "Claude Opus 4.8", requiresKey: "opencode" },
-    { value: "opencode/gpt-5", label: "GPT-5", requiresKey: "opencode" },
-    { value: "opencode/gpt-5-codex", label: "GPT-5 Codex", requiresKey: "opencode" },
-    { value: "opencode/gpt-5.1-codex", label: "GPT-5.1 Codex", requiresKey: "opencode" },
-    { value: "opencode/gpt-5-nano", label: "GPT-5 Nano", requiresKey: "opencode" },
-    { value: "opencode/gpt-5.4", label: "GPT-5.4", requiresKey: "opencode" },
-    { value: "opencode/gpt-5.5", label: "GPT-5.5", requiresKey: "opencode" },
-    { value: "opencode/gemini-3-flash", label: "Gemini 3 Flash", requiresKey: "opencode" },
-    { value: "opencode/gemini-3.5-flash", label: "Gemini 3.5 Flash", requiresKey: "opencode" },
-    { value: "opencode/gemini-3.1-pro", label: "Gemini 3.1 Pro", requiresKey: "opencode" },
-    // Anthropic direct models (requires Anthropic API key)
+    // Remaining paid models — route through OpenCode Zen (pay-as-you-go credits).
+    // Preserve original order, excluding duplicates.
+    { value: "opencode/claude-sonnet-4", label: "Claude Sonnet 4 (Zen)", requiresKey: "opencode" },
+    { value: "opencode/claude-sonnet-4-5", label: "Claude Sonnet 4.5 (Zen)", requiresKey: "opencode" },
+    { value: "opencode/claude-sonnet-4-6", label: "Claude Sonnet 4.6 (Zen)", requiresKey: "opencode" },
+    { value: "opencode/claude-haiku-4-5", label: "Claude Haiku 4.5 (Zen)", requiresKey: "opencode" },
+    { value: "opencode/claude-opus-4-5", label: "Claude Opus 4.5 (Zen)", requiresKey: "opencode" },
+    { value: "opencode/claude-opus-4-6", label: "Claude Opus 4.6 (Zen)", requiresKey: "opencode" },
+    { value: "opencode/claude-opus-4-7", label: "Claude Opus 4.7 (Zen)", requiresKey: "opencode" },
+    { value: "opencode/claude-opus-4-8", label: "Claude Opus 4.8 (Zen)", requiresKey: "opencode" },
+    { value: "opencode/gpt-5", label: "GPT-5 (Zen)", requiresKey: "opencode" },
+    { value: "opencode/gpt-5-codex", label: "GPT-5 Codex (Zen)", requiresKey: "opencode" },
+    { value: "opencode/gpt-5.1-codex", label: "GPT-5.1 Codex (Zen)", requiresKey: "opencode" },
+    { value: "opencode/gpt-5-nano", label: "GPT-5 Nano (Zen)", requiresKey: "opencode" },
+    { value: "opencode/gpt-5.4", label: "GPT-5.4 (Zen)", requiresKey: "opencode" },
+    { value: "opencode/gpt-5.5", label: "GPT-5.5 (Zen)", requiresKey: "opencode" },
+    { value: "opencode/gemini-3-flash", label: "Gemini 3 Flash (Zen)", requiresKey: "opencode" },
+    { value: "opencode/gemini-3.5-flash", label: "Gemini 3.5 Flash (Zen)", requiresKey: "opencode" },
+    { value: "opencode/gemini-3.1-pro", label: "Gemini 3.1 Pro (Zen)", requiresKey: "opencode" },
+    // Anthropic direct models — route to Anthropic on the user's own Anthropic key
     { value: "anthropic/claude-sonnet-4-5", label: "Claude Sonnet 4.5", requiresKey: "anthropic" },
     { value: "anthropic/claude-sonnet-4-6", label: "Claude Sonnet 4.6", requiresKey: "anthropic" },
     { value: "anthropic/claude-haiku-4-5", label: "Claude Haiku 4.5", requiresKey: "anthropic" },
@@ -172,7 +181,7 @@ export const agentModels: Record<Agent, ModelOption[]> = {
     { value: "anthropic/claude-opus-4-6", label: "Claude Opus 4.6", requiresKey: "anthropic" },
     { value: "anthropic/claude-opus-4-7", label: "Claude Opus 4.7", requiresKey: "anthropic" },
     { value: "anthropic/claude-opus-4-8", label: "Claude Opus 4.8", requiresKey: "anthropic" },
-    // OpenAI direct models (requires OpenAI API key)
+    // OpenAI direct models — route to OpenAI on the user's own OpenAI key
     { value: "openai/gpt-3.5-turbo", label: "GPT-3.5 Turbo", requiresKey: "openai" },
     { value: "openai/gpt-4", label: "GPT-4", requiresKey: "openai" },
     { value: "openai/gpt-4-turbo", label: "GPT-4 Turbo", requiresKey: "openai" },


### PR DESCRIPTION
### Summary

The server-shared `OPENCODE_API_KEY` is an OpenCode **Go** subscription key ($10/mo pool).

The curated models in `agents.ts` were still using the `opencode/` prefix, which routes through OpenCode **Zen** pay-as-you-go. Since the Go key has no Zen balance, users saw an **"insufficient balance"** error whenever they tried to run a curated model using the shared key.

This PR switches curated/allowlisted models to the `opencode-go/` prefix so they route through Go, where the shared key has balance, while leaving all other paid models on `opencode/` for Zen.

---

### Changes

- **`SHARED_OPENCODE_ALLOWED`**
  - Moved all 13 entries from `opencode/*` to `opencode-go/*`.
  - Normalized two model slugs to match the Go catalog:
    - `qwen3-6-plus` → `qwen3.6-plus`
    - `qwen3-7-max` → `qwen3.7-max`

- **Curated model list**
  - Switched curated models to the `opencode-go/` prefix.
  - Added `(Go)` suffixes to labels so the routing path is visible in the model picker.

- **Remaining paid models**
  - Kept on the `opencode/` prefix.
  - Added `(Zen)` suffixes to clarify that these consume pay-as-you-go credits.

- **Comments**
  - Documented the Go-vs-Zen distinction for:
    - `SHARED_OPENCODE_ALLOWED`
    - model groupings
  - Clarified that `anthropic/` and `openai/` models route to those providers using the user's own key.

---

### Why

- Curated models are meant to be covered by the shared OpenCode Go key.
- To use the Go subscription pool, those models must use the `opencode-go/` prefix.
- The `(Go)` and `(Zen)` label suffixes make the billing path clear to users.

---

### Impact

- Single file changed:
  - `packages/common/src/agents.ts`
- Diff size:
  - `+57 / -48`
- No API or schema changes.
- Only model option values, labels, comments, and the shared-key allowlist were updated.

---

### Testing

- [ ] Verify a curated `opencode-go/*` model runs on the shared key without an **"insufficient balance"** error.
- [ ] Verify `opencode/*` Zen models still require and consume the user's OpenCode credits as before.