### PR TITLE
refactor: split ScheduledJobForm and ScheduledJobsView into focused modules

### DIFF
--- a/packages/web/components/scheduled-jobs/JobRunDetail.tsx
+++ b/packages/web/components/scheduled-jobs/JobRunDetail.tsx
@@ -1,0 +1,155 @@
+"use client"
+
+import { useState } from "react"
+import { Clock, ChevronDown, Check, GitPullRequest } from "lucide-react"
+import { formatDistanceToNow } from "date-fns"
+import { cn } from "@/lib/utils"
+import { MessageBubble } from "@/components/MessageBubble"
+import { type ScheduledJob, type ScheduledJobRun } from "@/lib/scheduled-jobs/types"
+import type { Message } from "@/lib/types"
+import { getRunStatusIcon, formatRunLabel, formatDuration } from "./helpers"
+
+interface JobRunDetailProps {
+  job: ScheduledJob
+  runs: ScheduledJobRun[]
+  selectedRun: ScheduledJobRun | null
+  onSelectRun: (run: ScheduledJobRun) => void
+  messages: Message[]
+}
+
+export function JobRunDetail({ job, runs, selectedRun, onSelectRun, messages }: JobRunDetailProps) {
+  const [dropdownOpen, setDropdownOpen] = useState(false)
+
+  return (
+    <div className="flex-1 flex flex-col min-h-0">
+      {/* Detail Header - styled like chat header */}
+      <div className="flex items-center justify-between pt-3 shrink-0" style={{ paddingLeft: "1.625rem", paddingRight: "1rem" }}>
+        <div className="flex items-center gap-2">
+          {/* Title - styled like chat title */}
+          <span className="flex h-7 items-center text-sm font-medium text-foreground px-2 rounded-md hover:bg-accent transition-colors cursor-default">
+            {job.name}
+          </span>
+        </div>
+
+        {/* Run selector dropdown */}
+        <div className="relative">
+          <button
+            onClick={() => setDropdownOpen(!dropdownOpen)}
+            className="flex items-center gap-2 px-3 py-1.5 rounded-md hover:bg-accent transition-colors cursor-pointer"
+          >
+            {selectedRun ? (
+              <>
+                {getRunStatusIcon(selectedRun.status)}
+                <span className="text-sm">{formatRunLabel(selectedRun)}</span>
+              </>
+            ) : (
+              <span className="text-sm text-muted-foreground">No runs yet</span>
+            )}
+            <ChevronDown className={cn("h-4 w-4 transition-transform", dropdownOpen && "rotate-180")} />
+          </button>
+
+          {dropdownOpen && runs.length > 0 && (
+            <>
+              <div
+                className="fixed inset-0 z-40"
+                onClick={() => setDropdownOpen(false)}
+              />
+              <div className="absolute right-0 top-full mt-1 z-50 w-72 max-h-80 overflow-y-auto rounded-md border border-border bg-popover shadow-lg py-1">
+                {runs.map((run) => (
+                  <button
+                    key={run.id}
+                    onClick={() => {
+                      onSelectRun(run)
+                      setDropdownOpen(false)
+                    }}
+                    className={cn(
+                      "flex items-center gap-2 w-full px-3 py-2 text-sm hover:bg-accent text-left",
+                      run.id === selectedRun?.id && "bg-accent"
+                    )}
+                  >
+                    {getRunStatusIcon(run.status)}
+                    <span className="flex-1">{formatRunLabel(run)}</span>
+                  </button>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Detail Content */}
+      <main className="flex-1 overflow-auto">
+        {selectedRun ? (
+          <div className="max-w-4xl mx-auto p-6">
+            {/* Error display */}
+            {selectedRun.error && (
+              <div className="mb-6 rounded-md bg-destructive/10 px-4 py-3 text-sm text-destructive">
+                <div className="font-medium mb-1">Run failed</div>
+                <div className="whitespace-pre-wrap">{selectedRun.error}</div>
+              </div>
+            )}
+
+            {/* Messages */}
+            <div className="space-y-4">
+              {messages.length === 0 ? (
+                <div className="text-center py-12 text-muted-foreground">
+                  {selectedRun.status === "running" ? (
+                    <div className="flex items-center justify-center gap-2">
+                      <Clock className="h-4 w-4 animate-pulse" />
+                      Agent is running...
+                    </div>
+                  ) : (
+                    "No messages for this run"
+                  )}
+                </div>
+              ) : (
+                <>
+                  {messages.map((message, index) => (
+                    <MessageBubble
+                      key={message.id || index}
+                      message={message}
+                      isStreaming={selectedRun.status === "running" && index === messages.length - 1}
+                    />
+                  ))}
+
+                  {/* Completion summary - styled like system messages */}
+                  {selectedRun.status === "completed" && selectedRun.completedAt && (
+                    <div className="flex items-start gap-2 text-sm">
+                      <Check className="h-3.5 w-3.5 mt-0.5 shrink-0 text-green-600 dark:text-green-400" />
+                      <span className="text-muted-foreground">
+                        Agent finished after {formatDuration(selectedRun.startedAt, selectedRun.completedAt)}.
+                      </span>
+                    </div>
+                  )}
+
+                  {/* PR created message */}
+                  {selectedRun.status === "completed" && selectedRun.prUrl && (
+                    <div className="flex items-start gap-2 text-sm">
+                      <GitPullRequest className="h-3.5 w-3.5 mt-0.5 shrink-0 text-green-600 dark:text-green-400" />
+                      <a
+                        href={selectedRun.prUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-muted-foreground hover:text-foreground transition-colors"
+                      >
+                        Created PR #{selectedRun.prNumber}.
+                      </a>
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-col items-center justify-center py-16 text-center">
+            <Clock className="h-12 w-12 text-muted-foreground/50 mb-4" />
+            <h2 className="text-lg font-medium mb-2">No runs yet</h2>
+            <p className="text-muted-foreground">
+              This job will run {formatDistanceToNow(job.nextRunAt, { addSuffix: true })}
+            </p>
+          </div>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/packages/web/components/scheduled-jobs/JobsList.tsx
+++ b/packages/web/components/scheduled-jobs/JobsList.tsx
@@ -1,0 +1,218 @@
+"use client"
+
+import { useState } from "react"
+import { MoreHorizontal, Play, Pencil, Trash2 } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { type ScheduledJob } from "@/lib/scheduled-jobs/types"
+import { NEW_REPOSITORY } from "@/lib/types"
+import { getJobStatusIcon, getLastRunText, getTriggerDescription, getRepoLabel } from "./helpers"
+
+interface JobsListProps {
+  jobs: ScheduledJob[]
+  onSelect: (jobId: string, jobName: string) => void
+  onEdit: (job: ScheduledJob) => void
+  onRunNow: (job: ScheduledJob) => void
+  onRequestDelete: (job: ScheduledJob) => void
+}
+
+/**
+ * Per-row actions dropdown (Edit / Run Now / Delete). Shared by both the mobile
+ * card and desktop table layouts so the menu markup lives in exactly one place.
+ */
+function JobRowMenu({
+  job,
+  open,
+  onToggle,
+  onEdit,
+  onRunNow,
+  onRequestDelete,
+}: {
+  job: ScheduledJob
+  open: boolean
+  onToggle: () => void
+  onEdit: (job: ScheduledJob) => void
+  onRunNow: (job: ScheduledJob) => void
+  onRequestDelete: (job: ScheduledJob) => void
+}) {
+  return (
+    <div className="relative inline-block">
+      <button
+        onClick={(e) => {
+          e.stopPropagation()
+          onToggle()
+        }}
+        className="p-1.5 rounded-md hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <MoreHorizontal className="h-4 w-4" />
+      </button>
+
+      {open && (
+        <>
+          <div
+            className="fixed inset-0 z-40"
+            onClick={(e) => {
+              e.stopPropagation()
+              onToggle()
+            }}
+          />
+          <div className="absolute right-0 top-full mt-1 z-50 w-36 rounded-md border border-border bg-popover py-1 shadow-lg">
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onEdit(job)
+              }}
+              className="flex w-full items-center gap-2 px-3 py-1.5 text-sm hover:bg-accent"
+            >
+              <Pencil className="h-3.5 w-3.5" />
+              Edit
+            </button>
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onRunNow(job)
+              }}
+              className="flex w-full items-center gap-2 px-3 py-1.5 text-sm hover:bg-accent"
+            >
+              <Play className="h-3.5 w-3.5" />
+              Run Now
+            </button>
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onToggle()
+                onRequestDelete(job)
+              }}
+              className="flex w-full items-center gap-2 px-3 py-1.5 text-sm text-destructive hover:bg-accent"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+              Delete
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+export function JobsList({ jobs, onSelect, onEdit, onRunNow, onRequestDelete }: JobsListProps) {
+  const [menuOpenId, setMenuOpenId] = useState<string | null>(null)
+
+  const renderMenu = (job: ScheduledJob) => (
+    <JobRowMenu
+      job={job}
+      open={menuOpenId === job.id}
+      onToggle={() => setMenuOpenId(menuOpenId === job.id ? null : job.id)}
+      onEdit={(j) => {
+        setMenuOpenId(null)
+        onEdit(j)
+      }}
+      onRunNow={(j) => {
+        setMenuOpenId(null)
+        onRunNow(j)
+      }}
+      onRequestDelete={onRequestDelete}
+    />
+  )
+
+  return (
+    <>
+      {/* Mobile Card Layout */}
+      <div className="space-y-3 md:hidden">
+        {jobs.map((job) => (
+          <div
+            key={job.id}
+            className="rounded-lg border border-border bg-white/50 dark:bg-white/5 p-4 cursor-pointer"
+            onClick={() => onSelect(job.id, job.name)}
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex items-center gap-2 min-w-0 flex-1">
+                {getJobStatusIcon(job)}
+                <span className={cn(
+                  "text-sm font-medium truncate",
+                  !job.enabled && "text-muted-foreground"
+                )}>
+                  {job.name}
+                </span>
+                {!job.enabled && (
+                  <span className="text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground shrink-0">
+                    Disabled
+                  </span>
+                )}
+              </div>
+              <div className="shrink-0">{renderMenu(job)}</div>
+            </div>
+            <div className="mt-3 space-y-1.5 text-sm text-muted-foreground">
+              <div className={cn("truncate", job.repo === NEW_REPOSITORY && "italic")}>{getRepoLabel(job.repo)}</div>
+              <div className="flex items-center justify-between gap-2">
+                <span>{getTriggerDescription(job)}</span>
+                <span className={cn(
+                  job.lastRun?.status === "error" && "text-destructive"
+                )}>
+                  {getLastRunText(job)}
+                </span>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Desktop Table Layout */}
+      <div className="hidden md:block rounded-lg border border-border bg-background">
+        <table className="w-full">
+          <thead>
+            <tr className="border-b border-border bg-muted/50">
+              <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">Name</th>
+              <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">Repository</th>
+              <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">Schedule</th>
+              <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">Last run</th>
+              <th className="px-4 py-2.5 w-10"></th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {jobs.map((job) => (
+              <tr
+                key={job.id}
+                className="bg-white/50 dark:bg-white/5 cursor-pointer"
+                onClick={() => onSelect(job.id, job.name)}
+              >
+                <td className="px-4 py-3">
+                  <div className="flex items-center gap-2">
+                    {getJobStatusIcon(job)}
+                    <span className={cn(
+                      "text-sm font-medium",
+                      !job.enabled && "text-muted-foreground"
+                    )}>
+                      {job.name}
+                    </span>
+                    {!job.enabled && (
+                      <span className="text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
+                        Disabled
+                      </span>
+                    )}
+                  </div>
+                </td>
+                <td className={cn(
+                  "px-4 py-3 text-sm text-muted-foreground",
+                  job.repo === NEW_REPOSITORY && "italic"
+                )}>
+                  {getRepoLabel(job.repo)}
+                </td>
+                <td className="px-4 py-3 text-sm text-muted-foreground">
+                  {getTriggerDescription(job)}
+                </td>
+                <td className="px-4 py-3 text-sm text-muted-foreground">
+                  <span className={cn(
+                    job.lastRun?.status === "error" && "text-destructive"
+                  )}>
+                    {getLastRunText(job)}
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-right">{renderMenu(job)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
+  )
+}

--- a/packages/web/components/scheduled-jobs/ScheduleFields.tsx
+++ b/packages/web/components/scheduled-jobs/ScheduleFields.tsx
@@ -1,0 +1,150 @@
+"use client"
+
+import {
+  INTERVAL_PRESETS,
+  INTERVAL_UNITS,
+  CUSTOM_INTERVAL,
+  DAYS_OF_WEEK,
+  TIME_OPTIONS,
+  inferIntervalMode,
+  type IntervalUnit,
+} from "./form-config"
+
+interface ScheduleFieldsProps {
+  isCustomInterval: boolean
+  intervalMinutes: number
+  customIntervalValue: number
+  customIntervalUnit: IntervalUnit
+  runAtDay: number
+  runAtHourLocal: number
+  /** Resolved interval the schedule will actually run at (preset or custom). */
+  effectiveIntervalMinutes: number
+  timezoneName: string
+  setIsCustomInterval: (v: boolean) => void
+  setIntervalMinutes: (v: number) => void
+  setCustomIntervalValue: (v: number) => void
+  setCustomIntervalUnit: (v: IntervalUnit) => void
+  setRunAtDay: (v: number) => void
+  setRunAtHourLocal: (v: number) => void
+}
+
+export function ScheduleFields({
+  isCustomInterval,
+  intervalMinutes,
+  customIntervalValue,
+  customIntervalUnit,
+  runAtDay,
+  runAtHourLocal,
+  effectiveIntervalMinutes,
+  timezoneName,
+  setIsCustomInterval,
+  setIntervalMinutes,
+  setCustomIntervalValue,
+  setCustomIntervalUnit,
+  setRunAtDay,
+  setRunAtHourLocal,
+}: ScheduleFieldsProps) {
+  return (
+    <div className="space-y-1">
+      <div className="flex flex-wrap items-center gap-2 text-sm">
+        <span className="text-muted-foreground">Run every</span>
+        <select
+          value={isCustomInterval ? CUSTOM_INTERVAL : intervalMinutes}
+          onChange={(e) => {
+            const val = parseInt(e.target.value, 10)
+            if (val === CUSTOM_INTERVAL) {
+              // Seed custom inputs from the current preset so the
+              // effective interval doesn't change just by toggling
+              // into Custom mode.
+              const mode = inferIntervalMode(intervalMinutes)
+              setIsCustomInterval(true)
+              setCustomIntervalValue(mode.customValue)
+              setCustomIntervalUnit(mode.customUnit)
+            } else {
+              setIsCustomInterval(false)
+              setIntervalMinutes(val)
+            }
+          }}
+          className="rounded-md border border-border bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        >
+          {INTERVAL_PRESETS.map((p) => (
+            <option key={p.value} value={p.value}>
+              {p.label}
+            </option>
+          ))}
+          <option value={CUSTOM_INTERVAL}>Custom…</option>
+        </select>
+
+        {isCustomInterval && (
+          <>
+            <input
+              type="number"
+              min={customIntervalUnit === "minutes" ? 10 : 1}
+              step={1}
+              value={customIntervalValue}
+              onChange={(e) => {
+                const n = parseInt(e.target.value, 10)
+                setCustomIntervalValue(Number.isFinite(n) ? Math.max(1, n) : 1)
+              }}
+              className="w-16 rounded-md border border-border bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            />
+            <select
+              value={customIntervalUnit}
+              onChange={(e) => setCustomIntervalUnit(e.target.value as IntervalUnit)}
+              className="rounded-md border border-border bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            >
+              {INTERVAL_UNITS.map((u) => (
+                <option key={u.value} value={u.value}>
+                  {u.label}
+                </option>
+              ))}
+            </select>
+          </>
+        )}
+
+        {/* Day of week - only for exactly weekly */}
+        {effectiveIntervalMinutes === 10080 && (
+          <>
+            <span className="text-muted-foreground">on</span>
+            <select
+              value={runAtDay}
+              onChange={(e) => setRunAtDay(parseInt(e.target.value, 10))}
+              className="rounded-md border border-border bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            >
+              {DAYS_OF_WEEK.map((d) => (
+                <option key={d.value} value={d.value}>
+                  {d.label}
+                </option>
+              ))}
+            </select>
+          </>
+        )}
+
+        {/* Time of day - for daily and weekly (preset or custom) */}
+        {effectiveIntervalMinutes >= 1440 && (
+          <>
+            <span className="text-muted-foreground">at</span>
+            <select
+              value={runAtHourLocal}
+              onChange={(e) => setRunAtHourLocal(parseInt(e.target.value, 10))}
+              className="rounded-md border border-border bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            >
+              {TIME_OPTIONS.map((t) => (
+                <option key={t.value} value={t.value}>
+                  {t.label}
+                </option>
+              ))}
+            </select>
+            <span className="text-muted-foreground">{timezoneName}</span>
+          </>
+        )}
+      </div>
+
+      {isCustomInterval && effectiveIntervalMinutes < 10 && (
+        <p className="text-xs text-destructive">
+          Interval must be at least 10 minutes.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/packages/web/components/scheduled-jobs/ScheduledJobForm.tsx
+++ b/packages/web/components/scheduled-jobs/ScheduledJobForm.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { useState, useEffect, useMemo } from "react"
 import * as Dialog from "@radix-ui/react-dialog"
 import { Clock, ChevronDown, X, Copy, RefreshCw, Check } from "lucide-react"
 import { cn } from "@/lib/utils"
@@ -9,42 +8,11 @@ import { RepoCombobox } from "@/components/chat/RepoCombobox"
 import { BranchCombobox } from "@/components/chat/BranchCombobox"
 import { McpServersCombobox } from "@/components/chat/McpServersCombobox"
 import { type ScheduledJob } from "@/lib/scheduled-jobs/types"
-import { agentModels, agentLabels, getModelLabel, type Agent, NEW_REPOSITORY } from "@/lib/types"
+import { agentLabels, getModelLabel } from "@/lib/types"
 import { AgentIcon } from "@/components/icons/agent-icons"
-
-// =============================================================================
-// Timezone Helpers
-// =============================================================================
-
-/** Get the user's timezone offset in hours (e.g., -8 for PST) */
-function getTimezoneOffset(): number {
-  return -new Date().getTimezoneOffset() / 60
-}
-
-/** Get short timezone name (e.g., "PST", "EST") */
-function getTimezoneName(): string {
-  return new Intl.DateTimeFormat('en-US', { timeZoneName: 'short' })
-    .formatToParts(new Date())
-    .find(part => part.type === 'timeZoneName')?.value ?? 'Local'
-}
-
-/** Convert local hour (0-23) to UTC hour */
-function localHourToUtc(localHour: number): number {
-  const offset = getTimezoneOffset()
-  let utcHour = localHour - offset
-  if (utcHour < 0) utcHour += 24
-  if (utcHour >= 24) utcHour -= 24
-  return Math.floor(utcHour)
-}
-
-/** Convert UTC hour (0-23) to local hour */
-function utcHourToLocal(utcHour: number): number {
-  const offset = getTimezoneOffset()
-  let localHour = utcHour + offset
-  if (localHour < 0) localHour += 24
-  if (localHour >= 24) localHour -= 24
-  return Math.floor(localHour)
-}
+import { ScheduleFields } from "@/components/scheduled-jobs/ScheduleFields"
+import { TRIGGER_TYPES, AVAILABLE_AGENTS } from "@/components/scheduled-jobs/form-config"
+import { useScheduledJobForm } from "@/lib/hooks/useScheduledJobForm"
 
 // =============================================================================
 // Types
@@ -59,477 +27,67 @@ interface ScheduledJobFormProps {
 }
 
 // =============================================================================
-// Constants
-// =============================================================================
-
-const TRIGGER_TYPES = [
-  {
-    label: "On a schedule",
-    value: "interval",
-    description: "Run at regular intervals"
-  },
-  {
-    label: "Via webhook",
-    value: "incoming",
-    description: "Triggered by any external app (GitHub, Jira, Slack, Linear, …) — paste the generated URL into the source app"
-  },
-] as const
-
-const INTERVAL_PRESETS = [
-  { label: "10 minutes", value: 10 },
-  { label: "15 minutes", value: 15 },
-  { label: "30 minutes", value: 30 },
-  { label: "Hour", value: 60 },
-  { label: "6 hours", value: 360 },
-  { label: "Day", value: 1440 },
-  { label: "Week", value: 10080 },
-]
-
-const CUSTOM_INTERVAL = -1
-
-type IntervalUnit = "minutes" | "hours" | "days" | "weeks"
-
-const UNIT_MINUTES: Record<IntervalUnit, number> = {
-  minutes: 1,
-  hours: 60,
-  days: 1440,
-  weeks: 10080,
-}
-
-const INTERVAL_UNITS: { label: string; value: IntervalUnit }[] = [
-  { label: "minutes", value: "minutes" },
-  { label: "hours", value: "hours" },
-  { label: "days", value: "days" },
-  { label: "weeks", value: "weeks" },
-]
-
-/** Express a stored intervalMinutes as either a preset or a (value, unit) pair. */
-function inferIntervalMode(minutes: number): {
-  isCustom: boolean
-  intervalMinutes: number
-  customValue: number
-  customUnit: IntervalUnit
-} {
-  if (INTERVAL_PRESETS.some((p) => p.value === minutes)) {
-    return { isCustom: false, intervalMinutes: minutes, customValue: 10, customUnit: "minutes" }
-  }
-  if (minutes % 10080 === 0) {
-    return { isCustom: true, intervalMinutes: minutes, customValue: minutes / 10080, customUnit: "weeks" }
-  }
-  if (minutes % 1440 === 0) {
-    return { isCustom: true, intervalMinutes: minutes, customValue: minutes / 1440, customUnit: "days" }
-  }
-  if (minutes % 60 === 0) {
-    return { isCustom: true, intervalMinutes: minutes, customValue: minutes / 60, customUnit: "hours" }
-  }
-  return { isCustom: true, intervalMinutes: minutes, customValue: minutes, customUnit: "minutes" }
-}
-
-const DAYS_OF_WEEK = [
-  { label: "Monday", value: 1 },
-  { label: "Tuesday", value: 2 },
-  { label: "Wednesday", value: 3 },
-  { label: "Thursday", value: 4 },
-  { label: "Friday", value: 5 },
-  { label: "Saturday", value: 6 },
-  { label: "Sunday", value: 0 },
-]
-
-const TIME_OPTIONS = [
-  { label: "12:00 AM", value: 0 },
-  { label: "1:00 AM", value: 1 },
-  { label: "2:00 AM", value: 2 },
-  { label: "3:00 AM", value: 3 },
-  { label: "4:00 AM", value: 4 },
-  { label: "5:00 AM", value: 5 },
-  { label: "6:00 AM", value: 6 },
-  { label: "7:00 AM", value: 7 },
-  { label: "8:00 AM", value: 8 },
-  { label: "9:00 AM", value: 9 },
-  { label: "10:00 AM", value: 10 },
-  { label: "11:00 AM", value: 11 },
-  { label: "12:00 PM", value: 12 },
-  { label: "1:00 PM", value: 13 },
-  { label: "2:00 PM", value: 14 },
-  { label: "3:00 PM", value: 15 },
-  { label: "4:00 PM", value: 16 },
-  { label: "5:00 PM", value: 17 },
-  { label: "6:00 PM", value: 18 },
-  { label: "7:00 PM", value: 19 },
-  { label: "8:00 PM", value: 20 },
-  { label: "9:00 PM", value: 21 },
-  { label: "10:00 PM", value: 22 },
-  { label: "11:00 PM", value: 23 },
-]
-
-const AVAILABLE_AGENTS: Agent[] = ["opencode", "claude-code", "codex"]
-
-// =============================================================================
 // Component
 // =============================================================================
 
 export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = false }: ScheduledJobFormProps) {
-  const isEditing = !!job
-
-  // Form state
-  const [name, setName] = useState(job?.name ?? "")
-  const [prompt, setPrompt] = useState(job?.prompt ?? "")
-  // Empty string means "no repo" in form state; on submit we send NEW_REPOSITORY.
-  const [repo, setRepo] = useState(
-    job?.repo && job.repo !== NEW_REPOSITORY ? job.repo : ""
-  )
-  const [baseBranch, setBaseBranch] = useState(job?.baseBranch ?? "main")
-  const isRepoLess = !repo
-  const [agent, setAgent] = useState<Agent>((job?.agent as Agent) ?? "opencode")
-  const [model, setModel] = useState(job?.model ?? "")
-  const [triggerType, setTriggerType] = useState<"interval" | "incoming">(job?.triggerType ?? "interval")
-  const initialIntervalMode = inferIntervalMode(job?.intervalMinutes ?? 1440)
-  const [intervalMinutes, setIntervalMinutes] = useState(initialIntervalMode.intervalMinutes)
-  const [isCustomInterval, setIsCustomInterval] = useState(initialIntervalMode.isCustom)
-  const [customIntervalValue, setCustomIntervalValue] = useState(initialIntervalMode.customValue)
-  const [customIntervalUnit, setCustomIntervalUnit] = useState<IntervalUnit>(initialIntervalMode.customUnit)
-  const [runAtHourLocal, setRunAtHourLocal] = useState(9) // Local time, default to 9 AM
-  const [runAtDay, setRunAtDay] = useState(1) // Default to Monday
-  const [autoPR, setAutoPR] = useState(job?.autoPR ?? true)
-  const [continueFromLastRun, setContinueFromLastRun] = useState(job?.continueFromLastRun ?? false)
-
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-
-  // In create mode, the form may "materialize" the job into the DB the first
-  // time the user clicks the MCP picker, so MCP server connections have a real
-  // job id to hang off of. If the user then cancels, we DELETE the row so we
-  // don't leave a half-configured job behind. On final submit this id is what
-  // we PATCH (instead of POSTing again).
-  // Materialized rows are created with enabled: false so the cron doesn't pick
-  // them up before the user finishes; the final submit flips enabled back on.
-  const [materializedJobId, setMaterializedJobId] = useState<string | null>(null)
-
-  // Dropdown state
-  const [showAgentDropdown, setShowAgentDropdown] = useState(false)
-  const [showModelDropdown, setShowModelDropdown] = useState(false)
-
-  // Incoming-webhook URL state. The token comes from the saved job and can be
-  // swapped out via the rotate-token endpoint without closing the modal.
-  const [incomingToken, setIncomingToken] = useState<string | null>(job?.incomingToken ?? null)
-  const [copiedUrl, setCopiedUrl] = useState(false)
-  const [rotating, setRotating] = useState(false)
-
-  // Get available models for selected agent
-  const availableModels = agentModels[agent] ?? []
-
-  // Get timezone name for display
-  const timezoneName = useMemo(() => getTimezoneName(), [])
-
-  // What we actually send to the API (preset value, or custom value × unit).
-  const effectiveIntervalMinutes = isCustomInterval
-    ? Math.max(1, Math.floor(customIntervalValue || 0) * UNIT_MINUTES[customIntervalUnit])
-    : intervalMinutes
-
-  // Which Options-section toggles apply. The "continue" toggle is interval-only;
-  // auto-PR needs a repo to push to. The section header renders only when at
-  // least one applies — these same flags gate both the header and the toggles
-  // so they can't drift apart.
-  const showContinueOption = triggerType === "interval"
-  const showAutoPROption = !isRepoLess
-  const hasOptions = showContinueOption || showAutoPROption
-
-  // Reset form state when job prop changes or modal opens
-  useEffect(() => {
-    if (open) {
-      const initialAgent = (job?.agent as Agent) ?? "opencode"
-      const initialModels = agentModels[initialAgent] ?? []
-      setName(job?.name ?? "")
-      setPrompt(job?.prompt ?? "")
-      setRepo(job?.repo && job.repo !== NEW_REPOSITORY ? job.repo : "")
-      setBaseBranch(job?.baseBranch ?? "main")
-      setAgent(initialAgent)
-      setModel(job?.model ?? initialModels[0]?.value ?? "")
-      setTriggerType(job?.triggerType ?? "interval")
-      const mode = inferIntervalMode(job?.intervalMinutes ?? 1440)
-      setIntervalMinutes(mode.intervalMinutes)
-      setIsCustomInterval(mode.isCustom)
-      setCustomIntervalValue(mode.customValue)
-      setCustomIntervalUnit(mode.customUnit)
-      setRunAtHourLocal(9)
-      setRunAtDay(1)
-      setAutoPR(job?.autoPR ?? true)
-      setContinueFromLastRun(job?.continueFromLastRun ?? false)
-      setError(null)
-      setMaterializedJobId(null)
-      setIncomingToken(job?.incomingToken ?? null)
-      setCopiedUrl(false)
-      setRotating(false)
-    }
-  }, [open, job])
-
-  // Update model when agent changes
-  useEffect(() => {
-    const models = agentModels[agent] ?? []
-    if (models.length > 0 && !models.find(m => m.value === model)) {
-      setModel(models[0].value)
-    }
-  }, [agent, model])
-
-  useEffect(() => {
-    if (triggerType === "incoming" && !incomingToken) {
-      setIncomingToken(crypto.randomUUID())
-    }
-  }, [triggerType, incomingToken])
-
-  // Close dropdowns when clicking outside
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      const target = e.target as HTMLElement
-      if (!target.closest('[data-dropdown]')) {
-        setShowAgentDropdown(false)
-        setShowModelDropdown(false)
-      }
-    }
-    document.addEventListener('click', handleClickOutside)
-    return () => document.removeEventListener('click', handleClickOutside)
-  }, [])
-
-  /**
-   * Build the request body for create/update from current form state.
-   * Returns `null` and sets the visible error if required fields are missing.
-   */
-  function buildPayload(): Record<string, unknown> | null {
-    if (!name.trim()) {
-      setError("Name is required")
-      return null
-    }
-    if (!prompt.trim()) {
-      setError("Prompt is required")
-      return null
-    }
-    if (triggerType === "interval" && effectiveIntervalMinutes < 10) {
-      setError("Interval must be at least 10 minutes")
-      return null
-    }
-    const runAtHourUtc = localHourToUtc(runAtHourLocal)
-    return {
-      name: name.trim(),
-      prompt: prompt.trim(),
-      // Empty form value means repo-less; send the NEW_REPOSITORY sentinel so
-      // the backend can route through its existing no-clone sandbox path.
-      repo: repo || NEW_REPOSITORY,
-      baseBranch,
-      agent,
-      model: model || null,
-      triggerType,
-      intervalMinutes: triggerType === "interval" ? effectiveIntervalMinutes : undefined,
-      runAtHour: triggerType === "interval" && effectiveIntervalMinutes >= 1440 ? runAtHourUtc : undefined,
-      runAtDay: triggerType === "interval" && effectiveIntervalMinutes === 10080 ? runAtDay : undefined,
-      // Auto-PR has nothing to push to in repo-less mode.
-      autoPR: isRepoLess ? false : autoPR,
-      continueFromLastRun,
-    }
-  }
-
-  /**
-   * Materialize callback for the MCP picker — fired on the first MCP click
-   * during create mode. POSTs the job (with enabled: false so the cron won't
-   * pick it up mid-config) and returns the new id to the picker. Uses
-   * placeholders for name/prompt if the user hasn't typed them yet; the
-   * final-submit validation in handleSubmit enforces real values before the
-   * row goes live. The form stays open and continues acting like create mode
-   * until the user hits "Create" (PATCH to flip enabled on) or "Cancel"
-   * (DELETE the row).
-   *
-   * Works for both interval and incoming triggers — the POST mints an
-   * incomingToken regardless, so the URL panel can render immediately for
-   * incoming-typed drafts. If the user flips the trigger pill after
-   * materialize, the final-submit PATCH carries the new triggerType.
-   */
-  async function materializeJob(_draftId: string): Promise<string | null> {
-    setError(null)
-    try {
-      const res = await fetch("/api/scheduled-jobs", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          // Placeholders only exist on disk while isDraft = true. They're never
-          // shown in the UI list (the GET filters drafts out) and the cron
-          // skips drafts. The final submit PATCH replaces them with real
-          // values before flipping isDraft to false.
-          name: name.trim() || "(draft)",
-          prompt: prompt.trim() || "(draft)",
-          // Drafts default to the repo-less sentinel so the row passes the
-          // backend's repo check before the user fills the form in fully.
-          repo: repo || NEW_REPOSITORY,
-          baseBranch: baseBranch || "main",
-          agent,
-          model: model || null,
-          triggerType,
-          // Carry the client-minted token (if any) so the persisted URL matches
-          // what the panel is already showing. Null on interval drafts — the
-          // server mints a dormant one.
-          incomingToken: incomingToken ?? undefined,
-          // intervalMinutes is required by the POST for "interval" — pass a
-          // safe placeholder for incoming drafts so the validator doesn't
-          // reject. Final submit overrides whichever value matters.
-          intervalMinutes:
-            triggerType === "interval" ? effectiveIntervalMinutes : 10,
-          autoPR,
-          continueFromLastRun,
-          enabled: false,
-          isDraft: true,
-        }),
-      })
-      if (!res.ok) {
-        const data = await res.json()
-        setError(data.error || "Failed to save job")
-        return null
-      }
-      const created = await res.json()
-      setMaterializedJobId(created.id)
-      // Capture the token minted by POST so the URL panel can render the
-      // moment the user flips to "Via webhook".
-      if (created.incomingToken) {
-        setIncomingToken(created.incomingToken)
-      }
-      return created.id
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to save job")
-      return null
-    }
-  }
-
-  // Handle form submit
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-    setError(null)
-
-    const payload = buildPayload()
-    if (!payload) return
-
-    setLoading(true)
-
-    try {
-      const targetId = materializedJobId ?? job?.id
-      const isUpdate = !!targetId
-      const url = isUpdate
-        ? `/api/scheduled-jobs/${targetId}`
-        : "/api/scheduled-jobs"
-      const method = isUpdate ? "PATCH" : "POST"
-
-      // For materialized rows we created with enabled: false + isDraft: true;
-      // promote both on final Create. For real edits, we leave existing state
-      // alone.
-      // Persist the client-minted token on every create path so the saved URL
-      // matches what the panel shows — including after a pre-save rotate. Edits
-      // leave the token alone (rotation there goes through the server endpoint).
-      const body =
-        materializedJobId && !isEditing
-          ? { ...payload, enabled: true, isDraft: false, incomingToken: incomingToken ?? undefined }
-          : isUpdate
-            ? payload
-            : { ...payload, incomingToken: incomingToken ?? undefined }
-
-      const res = await fetch(url, {
-        method,
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-      })
-
-      if (!res.ok) {
-        const data = await res.json()
-        throw new Error(data.error || "Failed to save job")
-      }
-
-      const savedJob = await res.json()
-      // Clear the materialized marker so the close handler doesn't try to
-      // delete what we just successfully saved.
-      setMaterializedJobId(null)
-      onSuccess(savedJob)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to save job")
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  /**
-   * Close handler: if we materialized a job in create mode and the user is
-   * walking away without saving, drop the row so we don't leak draft jobs.
-   * Best-effort — even if cleanup fails we still close the modal.
-   */
-  const handleClose = async () => {
-    if (materializedJobId && !isEditing) {
-      const idToDelete = materializedJobId
-      setMaterializedJobId(null)
-      try {
-        await fetch(`/api/scheduled-jobs/${idToDelete}`, { method: "DELETE" })
-      } catch (err) {
-        console.error("[ScheduledJobForm] cleanup delete failed:", err)
-      }
-    }
-    onClose()
-  }
-
-  /**
-   * Build the URL the user pastes into their external app. Browser-only —
-   * SSR returns an empty string and the panel hides the value until hydration.
-   */
-  const incomingWebhookUrl = useMemo(() => {
-    if (!incomingToken) return ""
-    if (typeof window === "undefined") return ""
-    return `${window.location.origin}/wh/${incomingToken}`
-  }, [incomingToken])
-
-  const handleCopyUrl = async () => {
-    if (!incomingWebhookUrl) return
-    try {
-      await navigator.clipboard.writeText(incomingWebhookUrl)
-      setCopiedUrl(true)
-      setTimeout(() => setCopiedUrl(false), 1500)
-    } catch (err) {
-      console.error("[ScheduledJobForm] copy failed:", err)
-    }
-  }
-
-  const handleRotateToken = async () => {
-    // Create mode: the URL hasn't been handed out anywhere yet, so "rotate" is
-    // just minting a fresh client-side UUID. No server round-trip, no confirm —
-    // the new token is persisted on save (create POST / final PATCH carry it).
-    if (!isEditing) {
-      setIncomingToken(crypto.randomUUID())
-      return
-    }
-    // Edit mode: the URL is live (the user may have wired it into an external
-    // app), so rotate server-side to invalidate the old one immediately.
-    const targetId = job?.id
-    if (!targetId) return
-    if (!confirm("Rotating will invalidate the existing webhook URL. Continue?")) return
-    setRotating(true)
-    setError(null)
-    try {
-      const res = await fetch(`/api/scheduled-jobs/${targetId}/rotate-token`, {
-        method: "POST",
-      })
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}))
-        throw new Error(data.error || "Failed to rotate token")
-      }
-      const updated = await res.json()
-      setIncomingToken(updated.incomingToken ?? null)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to rotate token")
-    } finally {
-      setRotating(false)
-    }
-  }
-
-  const handleAgentChange = (newAgent: Agent) => {
-    setAgent(newAgent)
-    setShowAgentDropdown(false)
-  }
-
-  const handleModelChange = (newModel: string) => {
-    setModel(newModel)
-    setShowModelDropdown(false)
-  }
+  const {
+    isEditing,
+    jobId,
+    name,
+    prompt,
+    repo,
+    baseBranch,
+    isRepoLess,
+    agent,
+    model,
+    triggerType,
+    intervalMinutes,
+    isCustomInterval,
+    customIntervalValue,
+    customIntervalUnit,
+    runAtHourLocal,
+    runAtDay,
+    autoPR,
+    continueFromLastRun,
+    loading,
+    error,
+    materializedJobId,
+    showAgentDropdown,
+    showModelDropdown,
+    incomingToken,
+    copiedUrl,
+    rotating,
+    availableModels,
+    timezoneName,
+    effectiveIntervalMinutes,
+    showContinueOption,
+    showAutoPROption,
+    hasOptions,
+    incomingWebhookUrl,
+    setName,
+    setPrompt,
+    setRepo,
+    setBaseBranch,
+    setTriggerType,
+    setIntervalMinutes,
+    setIsCustomInterval,
+    setCustomIntervalValue,
+    setCustomIntervalUnit,
+    setRunAtHourLocal,
+    setRunAtDay,
+    setAutoPR,
+    setContinueFromLastRun,
+    setShowAgentDropdown,
+    setShowModelDropdown,
+    materializeJob,
+    handleSubmit,
+    handleClose,
+    handleCopyUrl,
+    handleRotateToken,
+    handleAgentChange,
+    handleModelChange,
+  } = useScheduledJobForm({ open, job, onClose, onSuccess })
 
   return (
     <Dialog.Root open={open} onOpenChange={(isOpen) => !isOpen && handleClose()}>
@@ -603,107 +161,22 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
 
             {/* Schedule - only for scheduled trigger */}
             {triggerType === "interval" && (
-              <div className="space-y-1">
-                <div className="flex flex-wrap items-center gap-2 text-sm">
-                  <span className="text-muted-foreground">Run every</span>
-                  <select
-                    value={isCustomInterval ? CUSTOM_INTERVAL : intervalMinutes}
-                    onChange={(e) => {
-                      const val = parseInt(e.target.value, 10)
-                      if (val === CUSTOM_INTERVAL) {
-                        // Seed custom inputs from the current preset so the
-                        // effective interval doesn't change just by toggling
-                        // into Custom mode.
-                        const mode = inferIntervalMode(intervalMinutes)
-                        setIsCustomInterval(true)
-                        setCustomIntervalValue(mode.customValue)
-                        setCustomIntervalUnit(mode.customUnit)
-                      } else {
-                        setIsCustomInterval(false)
-                        setIntervalMinutes(val)
-                      }
-                    }}
-                    className="rounded-md border border-border bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-                  >
-                    {INTERVAL_PRESETS.map((p) => (
-                      <option key={p.value} value={p.value}>
-                        {p.label}
-                      </option>
-                    ))}
-                    <option value={CUSTOM_INTERVAL}>Custom…</option>
-                  </select>
-
-                  {isCustomInterval && (
-                    <>
-                      <input
-                        type="number"
-                        min={customIntervalUnit === "minutes" ? 10 : 1}
-                        step={1}
-                        value={customIntervalValue}
-                        onChange={(e) => {
-                          const n = parseInt(e.target.value, 10)
-                          setCustomIntervalValue(Number.isFinite(n) ? Math.max(1, n) : 1)
-                        }}
-                        className="w-16 rounded-md border border-border bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-                      />
-                      <select
-                        value={customIntervalUnit}
-                        onChange={(e) => setCustomIntervalUnit(e.target.value as IntervalUnit)}
-                        className="rounded-md border border-border bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-                      >
-                        {INTERVAL_UNITS.map((u) => (
-                          <option key={u.value} value={u.value}>
-                            {u.label}
-                          </option>
-                        ))}
-                      </select>
-                    </>
-                  )}
-
-                  {/* Day of week - only for exactly weekly */}
-                  {effectiveIntervalMinutes === 10080 && (
-                    <>
-                      <span className="text-muted-foreground">on</span>
-                      <select
-                        value={runAtDay}
-                        onChange={(e) => setRunAtDay(parseInt(e.target.value, 10))}
-                        className="rounded-md border border-border bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-                      >
-                        {DAYS_OF_WEEK.map((d) => (
-                          <option key={d.value} value={d.value}>
-                            {d.label}
-                          </option>
-                        ))}
-                      </select>
-                    </>
-                  )}
-
-                  {/* Time of day - for daily and weekly (preset or custom) */}
-                  {effectiveIntervalMinutes >= 1440 && (
-                    <>
-                      <span className="text-muted-foreground">at</span>
-                      <select
-                        value={runAtHourLocal}
-                        onChange={(e) => setRunAtHourLocal(parseInt(e.target.value, 10))}
-                        className="rounded-md border border-border bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-                      >
-                        {TIME_OPTIONS.map((t) => (
-                          <option key={t.value} value={t.value}>
-                            {t.label}
-                          </option>
-                        ))}
-                      </select>
-                      <span className="text-muted-foreground">{timezoneName}</span>
-                    </>
-                  )}
-                </div>
-
-                {isCustomInterval && effectiveIntervalMinutes < 10 && (
-                  <p className="text-xs text-destructive">
-                    Interval must be at least 10 minutes.
-                  </p>
-                )}
-              </div>
+              <ScheduleFields
+                isCustomInterval={isCustomInterval}
+                intervalMinutes={intervalMinutes}
+                customIntervalValue={customIntervalValue}
+                customIntervalUnit={customIntervalUnit}
+                runAtDay={runAtDay}
+                runAtHourLocal={runAtHourLocal}
+                effectiveIntervalMinutes={effectiveIntervalMinutes}
+                timezoneName={timezoneName}
+                setIsCustomInterval={setIsCustomInterval}
+                setIntervalMinutes={setIntervalMinutes}
+                setCustomIntervalValue={setCustomIntervalValue}
+                setCustomIntervalUnit={setCustomIntervalUnit}
+                setRunAtDay={setRunAtDay}
+                setRunAtHourLocal={setRunAtHourLocal}
+              />
             )}
 
             {/* Incoming webhook URL panel — shown only for incoming triggers.
@@ -832,7 +305,7 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
                         materializes the job so the picker has a real id;
                         cancel cleans up. */}
                     <McpServersCombobox
-                      entityId={materializedJobId ?? job?.id ?? "draft"}
+                      entityId={materializedJobId ?? jobId ?? "draft"}
                       apiBase="/api/scheduled-jobs"
                       isDraft={!isEditing && !materializedJobId}
                       onMaterializeDraft={materializeJob}

--- a/packages/web/components/scheduled-jobs/ScheduledJobsView.tsx
+++ b/packages/web/components/scheduled-jobs/ScheduledJobsView.tsx
@@ -2,110 +2,13 @@
 
 import { useState, useEffect } from "react"
 import { useSession } from "next-auth/react"
-import { Clock, Plus, MoreHorizontal, Play, Pencil, Trash2, AlertCircle, Check, X, ArrowLeft, ChevronDown, ExternalLink, GitPullRequest, CheckCircle2, XCircle, Circle, RefreshCw } from "lucide-react"
-import { format, formatDistanceToNow } from "date-fns"
-import { cn } from "@/lib/utils"
+import { Clock, Plus } from "lucide-react"
 import { ScheduledJobForm } from "@/components/scheduled-jobs/ScheduledJobForm"
 import { ConfirmDialog } from "@/components/modals/ConfirmDialog"
-import { MessageBubble } from "@/components/MessageBubble"
-import { type ScheduledJob, type ScheduledJobRun, formatInterval } from "@/lib/scheduled-jobs/types"
+import { JobsList } from "@/components/scheduled-jobs/JobsList"
+import { JobRunDetail } from "@/components/scheduled-jobs/JobRunDetail"
+import { type ScheduledJob, type ScheduledJobRun } from "@/lib/scheduled-jobs/types"
 import type { Message } from "@/lib/types"
-import { NEW_REPOSITORY } from "@/lib/types"
-
-function getRepoLabel(repo: string): string {
-  return repo === NEW_REPOSITORY ? "No repository" : repo
-}
-
-// =============================================================================
-// Helpers
-// =============================================================================
-
-function getJobStatusIcon(job: ScheduledJob) {
-  if (!job.enabled) {
-    return <X className="h-3.5 w-3.5 text-muted-foreground" />
-  }
-  if (job.lastRun?.status === "error") {
-    return <AlertCircle className="h-3.5 w-3.5 text-destructive" />
-  }
-  if (job.lastRun?.status === "completed") {
-    return <Check className="h-3.5 w-3.5 text-green-500" />
-  }
-  if (job.lastRun?.status === "running") {
-    return <Clock className="h-3.5 w-3.5 text-blue-500 animate-pulse" />
-  }
-  return <Clock className="h-3.5 w-3.5 text-muted-foreground" />
-}
-
-function getRunStatusIcon(status: string) {
-  switch (status) {
-    case "completed":
-      return <CheckCircle2 className="h-3.5 w-3.5 text-green-500" />
-    case "error":
-      return <XCircle className="h-3.5 w-3.5 text-destructive" />
-    case "running":
-      return <RefreshCw className="h-3.5 w-3.5 text-blue-500 animate-spin" />
-    default:
-      return <Circle className="h-3.5 w-3.5 text-muted-foreground" />
-  }
-}
-
-function getLastRunText(job: ScheduledJob): string {
-  if (!job.lastRun) return "Never run"
-
-  const timeAgo = formatDistanceToNow(job.lastRun.startedAt, { addSuffix: true })
-
-  if (job.lastRun.status === "running") {
-    return `Running ${timeAgo}`
-  }
-  if (job.lastRun.status === "error") {
-    return `Failed ${timeAgo}`
-  }
-  if (job.lastRun.prUrl) {
-    return `PR #${job.lastRun.prNumber} ${timeAgo}`
-  }
-  if (job.lastRun.status === "completed") {
-    return `No changes ${timeAgo}`
-  }
-  return timeAgo
-}
-
-function formatRunLabel(run: ScheduledJobRun): string {
-  return format(run.startedAt, "MMM d, h:mm a")
-}
-
-function formatDuration(startedAt: number, completedAt: number): string {
-  const durationMs = completedAt - startedAt
-  const seconds = Math.floor(durationMs / 1000)
-  const minutes = Math.floor(seconds / 60)
-  const hours = Math.floor(minutes / 60)
-
-  if (hours > 0) {
-    const remainingMinutes = minutes % 60
-    return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`
-  }
-  if (minutes > 0) {
-    const remainingSeconds = seconds % 60
-    return remainingSeconds > 0 ? `${minutes}m ${remainingSeconds}s` : `${minutes}m`
-  }
-  return `${seconds}s`
-}
-
-function getTriggerDescription(job: ScheduledJob): string {
-  if (job.triggerType === "incoming") {
-    return "Webhook"
-  }
-  // Interval trigger - show human-readable schedule
-  const minutes = job.intervalMinutes
-  if (minutes < 60) {
-    return `Every ${minutes} minute${minutes === 1 ? "" : "s"}`
-  }
-  const hours = Math.round(minutes / 60)
-  if (minutes < 1440) {
-    return `Every ${hours} hour${hours === 1 ? "" : "s"}`
-  }
-  const days = Math.round(minutes / 1440)
-  return `Every ${days} day${days === 1 ? "" : "s"}`
-}
 
 // =============================================================================
 // Props
@@ -145,14 +48,12 @@ export function ScheduledJobsView({ onOpenForm, refreshKey, urlJobId, onNavigate
   const [formOpen, setFormOpen] = useState(false)
   const [editingJob, setEditingJob] = useState<ScheduledJob | null>(null)
   const [deleteJob, setDeleteJob] = useState<ScheduledJob | null>(null)
-  const [menuOpenId, setMenuOpenId] = useState<string | null>(null)
 
   // Detail view state
   const [selectedJob, setSelectedJob] = useState<ScheduledJob | null>(null)
   const [runs, setRuns] = useState<ScheduledJobRun[]>([])
   const [selectedRun, setSelectedRun] = useState<ScheduledJobRun | null>(null)
   const [messages, setMessages] = useState<Message[]>([])
-  const [dropdownOpen, setDropdownOpen] = useState(false)
 
   // Reset detail state when returning to list view
   // Note: Don't call setSelectedJobId here - URL changes should drive navigation
@@ -263,7 +164,6 @@ export function ScheduledJobsView({ onOpenForm, refreshKey, urlJobId, onNavigate
   const handleEdit = (job: ScheduledJob) => {
     setEditingJob(job)
     setFormOpen(true)
-    setMenuOpenId(null)
   }
 
   const handleDelete = async () => {
@@ -286,7 +186,6 @@ export function ScheduledJobsView({ onOpenForm, refreshKey, urlJobId, onNavigate
   }
 
   const handleRunNow = async (job: ScheduledJob) => {
-    setMenuOpenId(null)
     try {
       const res = await fetch(`/api/scheduled-jobs/${job.id}/run`, {
         method: "POST",
@@ -323,136 +222,13 @@ export function ScheduledJobsView({ onOpenForm, refreshKey, urlJobId, onNavigate
   // Detail view
   if (selectedJobId && selectedJob) {
     return (
-      <div className="flex-1 flex flex-col min-h-0">
-        {/* Detail Header - styled like chat header */}
-        <div className="flex items-center justify-between pt-3 shrink-0" style={{ paddingLeft: "1.625rem", paddingRight: "1rem" }}>
-          <div className="flex items-center gap-2">
-            {/* Title - styled like chat title */}
-            <span className="flex h-7 items-center text-sm font-medium text-foreground px-2 rounded-md hover:bg-accent transition-colors cursor-default">
-              {selectedJob.name}
-            </span>
-          </div>
-
-          {/* Run selector dropdown */}
-          <div className="relative">
-            <button
-              onClick={() => setDropdownOpen(!dropdownOpen)}
-              className="flex items-center gap-2 px-3 py-1.5 rounded-md hover:bg-accent transition-colors cursor-pointer"
-            >
-              {selectedRun ? (
-                <>
-                  {getRunStatusIcon(selectedRun.status)}
-                  <span className="text-sm">{formatRunLabel(selectedRun)}</span>
-                </>
-              ) : (
-                <span className="text-sm text-muted-foreground">No runs yet</span>
-              )}
-              <ChevronDown className={cn("h-4 w-4 transition-transform", dropdownOpen && "rotate-180")} />
-            </button>
-
-            {dropdownOpen && runs.length > 0 && (
-              <>
-                <div
-                  className="fixed inset-0 z-40"
-                  onClick={() => setDropdownOpen(false)}
-                />
-                <div className="absolute right-0 top-full mt-1 z-50 w-72 max-h-80 overflow-y-auto rounded-md border border-border bg-popover shadow-lg py-1">
-                  {runs.map((run) => (
-                    <button
-                      key={run.id}
-                      onClick={() => {
-                        setSelectedRun(run)
-                        setDropdownOpen(false)
-                      }}
-                      className={cn(
-                        "flex items-center gap-2 w-full px-3 py-2 text-sm hover:bg-accent text-left",
-                        run.id === selectedRun?.id && "bg-accent"
-                      )}
-                    >
-                      {getRunStatusIcon(run.status)}
-                      <span className="flex-1">{formatRunLabel(run)}</span>
-                    </button>
-                  ))}
-                </div>
-              </>
-            )}
-          </div>
-        </div>
-
-        {/* Detail Content */}
-        <main className="flex-1 overflow-auto">
-          {selectedRun ? (
-            <div className="max-w-4xl mx-auto p-6">
-              {/* Error display */}
-              {selectedRun.error && (
-                <div className="mb-6 rounded-md bg-destructive/10 px-4 py-3 text-sm text-destructive">
-                  <div className="font-medium mb-1">Run failed</div>
-                  <div className="whitespace-pre-wrap">{selectedRun.error}</div>
-                </div>
-              )}
-
-              {/* Messages */}
-              <div className="space-y-4">
-                {messages.length === 0 ? (
-                  <div className="text-center py-12 text-muted-foreground">
-                    {selectedRun.status === "running" ? (
-                      <div className="flex items-center justify-center gap-2">
-                        <Clock className="h-4 w-4 animate-pulse" />
-                        Agent is running...
-                      </div>
-                    ) : (
-                      "No messages for this run"
-                    )}
-                  </div>
-                ) : (
-                  <>
-                    {messages.map((message, index) => (
-                      <MessageBubble
-                        key={message.id || index}
-                        message={message}
-                        isStreaming={selectedRun.status === "running" && index === messages.length - 1}
-                      />
-                    ))}
-
-                    {/* Completion summary - styled like system messages */}
-                    {selectedRun.status === "completed" && selectedRun.completedAt && (
-                      <div className="flex items-start gap-2 text-sm">
-                        <Check className="h-3.5 w-3.5 mt-0.5 shrink-0 text-green-600 dark:text-green-400" />
-                        <span className="text-muted-foreground">
-                          Agent finished after {formatDuration(selectedRun.startedAt, selectedRun.completedAt)}.
-                        </span>
-                      </div>
-                    )}
-
-                    {/* PR created message */}
-                    {selectedRun.status === "completed" && selectedRun.prUrl && (
-                      <div className="flex items-start gap-2 text-sm">
-                        <GitPullRequest className="h-3.5 w-3.5 mt-0.5 shrink-0 text-green-600 dark:text-green-400" />
-                        <a
-                          href={selectedRun.prUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-muted-foreground hover:text-foreground transition-colors"
-                        >
-                          Created PR #{selectedRun.prNumber}.
-                        </a>
-                      </div>
-                    )}
-                  </>
-                )}
-              </div>
-            </div>
-          ) : (
-            <div className="flex flex-col items-center justify-center py-16 text-center">
-              <Clock className="h-12 w-12 text-muted-foreground/50 mb-4" />
-              <h2 className="text-lg font-medium mb-2">No runs yet</h2>
-              <p className="text-muted-foreground">
-                This job will run {formatDistanceToNow(selectedJob.nextRunAt, { addSuffix: true })}
-              </p>
-            </div>
-          )}
-        </main>
-      </div>
+      <JobRunDetail
+        job={selectedJob}
+        runs={runs}
+        selectedRun={selectedRun}
+        onSelectRun={setSelectedRun}
+        messages={messages}
+      />
     )
   }
 
@@ -491,217 +267,13 @@ export function ScheduledJobsView({ onOpenForm, refreshKey, urlJobId, onNavigate
             </p>
           </div>
         ) : (
-          <>
-            {/* Mobile Card Layout */}
-            <div className="space-y-3 md:hidden">
-              {jobs.map((job) => (
-                <div
-                  key={job.id}
-                  className="rounded-lg border border-border bg-white/50 dark:bg-white/5 p-4 cursor-pointer"
-                  onClick={() => setSelectedJobId(job.id, job.name)}
-                >
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="flex items-center gap-2 min-w-0 flex-1">
-                      {getJobStatusIcon(job)}
-                      <span className={cn(
-                        "text-sm font-medium truncate",
-                        !job.enabled && "text-muted-foreground"
-                      )}>
-                        {job.name}
-                      </span>
-                      {!job.enabled && (
-                        <span className="text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground shrink-0">
-                          Disabled
-                        </span>
-                      )}
-                    </div>
-                    <div className="relative shrink-0">
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          setMenuOpenId(menuOpenId === job.id ? null : job.id)
-                        }}
-                        className="p-1.5 rounded-md hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
-                      >
-                        <MoreHorizontal className="h-4 w-4" />
-                      </button>
-
-                      {menuOpenId === job.id && (
-                        <>
-                          <div
-                            className="fixed inset-0 z-40"
-                            onClick={(e) => {
-                              e.stopPropagation()
-                              setMenuOpenId(null)
-                            }}
-                          />
-                          <div className="absolute right-0 top-full mt-1 z-50 w-36 rounded-md border border-border bg-popover py-1 shadow-lg">
-                            <button
-                              onClick={(e) => {
-                                e.stopPropagation()
-                                handleEdit(job)
-                              }}
-                              className="flex w-full items-center gap-2 px-3 py-1.5 text-sm hover:bg-accent"
-                            >
-                              <Pencil className="h-3.5 w-3.5" />
-                              Edit
-                            </button>
-                            <button
-                              onClick={(e) => {
-                                e.stopPropagation()
-                                handleRunNow(job)
-                              }}
-                              className="flex w-full items-center gap-2 px-3 py-1.5 text-sm hover:bg-accent"
-                            >
-                              <Play className="h-3.5 w-3.5" />
-                              Run Now
-                            </button>
-                            <button
-                              onClick={(e) => {
-                                e.stopPropagation()
-                                setMenuOpenId(null)
-                                setDeleteJob(job)
-                              }}
-                              className="flex w-full items-center gap-2 px-3 py-1.5 text-sm text-destructive hover:bg-accent"
-                            >
-                              <Trash2 className="h-3.5 w-3.5" />
-                              Delete
-                            </button>
-                          </div>
-                        </>
-                      )}
-                    </div>
-                  </div>
-                  <div className="mt-3 space-y-1.5 text-sm text-muted-foreground">
-                    <div className={cn("truncate", job.repo === NEW_REPOSITORY && "italic")}>{getRepoLabel(job.repo)}</div>
-                    <div className="flex items-center justify-between gap-2">
-                      <span>{getTriggerDescription(job)}</span>
-                      <span className={cn(
-                        job.lastRun?.status === "error" && "text-destructive"
-                      )}>
-                        {getLastRunText(job)}
-                      </span>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-
-            {/* Desktop Table Layout */}
-            <div className="hidden md:block rounded-lg border border-border bg-background">
-              <table className="w-full">
-                <thead>
-                  <tr className="border-b border-border bg-muted/50">
-                    <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">Name</th>
-                    <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">Repository</th>
-                    <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">Schedule</th>
-                    <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">Last run</th>
-                    <th className="px-4 py-2.5 w-10"></th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-border">
-                  {jobs.map((job) => (
-                    <tr
-                      key={job.id}
-                      className="bg-white/50 dark:bg-white/5 cursor-pointer"
-                      onClick={() => setSelectedJobId(job.id, job.name)}
-                    >
-                      <td className="px-4 py-3">
-                        <div className="flex items-center gap-2">
-                          {getJobStatusIcon(job)}
-                          <span className={cn(
-                            "text-sm font-medium",
-                            !job.enabled && "text-muted-foreground"
-                          )}>
-                            {job.name}
-                          </span>
-                          {!job.enabled && (
-                            <span className="text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
-                              Disabled
-                            </span>
-                          )}
-                        </div>
-                      </td>
-                      <td className={cn(
-                        "px-4 py-3 text-sm text-muted-foreground",
-                        job.repo === NEW_REPOSITORY && "italic"
-                      )}>
-                        {getRepoLabel(job.repo)}
-                      </td>
-                      <td className="px-4 py-3 text-sm text-muted-foreground">
-                        {getTriggerDescription(job)}
-                      </td>
-                      <td className="px-4 py-3 text-sm text-muted-foreground">
-                        <span className={cn(
-                          job.lastRun?.status === "error" && "text-destructive"
-                        )}>
-                          {getLastRunText(job)}
-                        </span>
-                      </td>
-                      <td className="px-4 py-3 text-right">
-                        <div className="relative inline-block">
-                          <button
-                            onClick={(e) => {
-                              e.stopPropagation()
-                              setMenuOpenId(menuOpenId === job.id ? null : job.id)
-                            }}
-                            className="p-1.5 rounded-md hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
-                          >
-                            <MoreHorizontal className="h-4 w-4" />
-                          </button>
-
-                          {menuOpenId === job.id && (
-                            <>
-                              <div
-                                className="fixed inset-0 z-40"
-                                onClick={(e) => {
-                                  e.stopPropagation()
-                                  setMenuOpenId(null)
-                                }}
-                              />
-                              <div className="absolute right-0 top-full mt-1 z-50 w-36 rounded-md border border-border bg-popover py-1 shadow-lg">
-                                <button
-                                  onClick={(e) => {
-                                    e.stopPropagation()
-                                    handleEdit(job)
-                                  }}
-                                  className="flex w-full items-center gap-2 px-3 py-1.5 text-sm hover:bg-accent"
-                                >
-                                  <Pencil className="h-3.5 w-3.5" />
-                                  Edit
-                                </button>
-                                <button
-                                  onClick={(e) => {
-                                    e.stopPropagation()
-                                    handleRunNow(job)
-                                  }}
-                                  className="flex w-full items-center gap-2 px-3 py-1.5 text-sm hover:bg-accent"
-                                >
-                                  <Play className="h-3.5 w-3.5" />
-                                  Run Now
-                                </button>
-                                <button
-                                  onClick={(e) => {
-                                    e.stopPropagation()
-                                    setMenuOpenId(null)
-                                    setDeleteJob(job)
-                                  }}
-                                  className="flex w-full items-center gap-2 px-3 py-1.5 text-sm text-destructive hover:bg-accent"
-                                >
-                                  <Trash2 className="h-3.5 w-3.5" />
-                                  Delete
-                                </button>
-                              </div>
-                            </>
-                          )}
-                        </div>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </>
+          <JobsList
+            jobs={jobs}
+            onSelect={setSelectedJobId}
+            onEdit={handleEdit}
+            onRunNow={handleRunNow}
+            onRequestDelete={setDeleteJob}
+          />
         )}
       </main>
 

--- a/packages/web/components/scheduled-jobs/form-config.ts
+++ b/packages/web/components/scheduled-jobs/form-config.ts
@@ -1,0 +1,141 @@
+import type { Agent } from "@/lib/types"
+
+// =============================================================================
+// Timezone Helpers
+// =============================================================================
+
+/** Get the user's timezone offset in hours (e.g., -8 for PST) */
+export function getTimezoneOffset(): number {
+  return -new Date().getTimezoneOffset() / 60
+}
+
+/** Get short timezone name (e.g., "PST", "EST") */
+export function getTimezoneName(): string {
+  return new Intl.DateTimeFormat('en-US', { timeZoneName: 'short' })
+    .formatToParts(new Date())
+    .find(part => part.type === 'timeZoneName')?.value ?? 'Local'
+}
+
+/** Convert local hour (0-23) to UTC hour */
+export function localHourToUtc(localHour: number): number {
+  const offset = getTimezoneOffset()
+  let utcHour = localHour - offset
+  if (utcHour < 0) utcHour += 24
+  if (utcHour >= 24) utcHour -= 24
+  return Math.floor(utcHour)
+}
+
+/** Convert UTC hour (0-23) to local hour */
+export function utcHourToLocal(utcHour: number): number {
+  const offset = getTimezoneOffset()
+  let localHour = utcHour + offset
+  if (localHour < 0) localHour += 24
+  if (localHour >= 24) localHour -= 24
+  return Math.floor(localHour)
+}
+
+// =============================================================================
+// Trigger / Schedule Constants
+// =============================================================================
+
+export const TRIGGER_TYPES = [
+  {
+    label: "On a schedule",
+    value: "interval",
+    description: "Run at regular intervals"
+  },
+  {
+    label: "Via webhook",
+    value: "incoming",
+    description: "Triggered by any external app (GitHub, Jira, Slack, Linear, …) — paste the generated URL into the source app"
+  },
+] as const
+
+export const INTERVAL_PRESETS = [
+  { label: "10 minutes", value: 10 },
+  { label: "15 minutes", value: 15 },
+  { label: "30 minutes", value: 30 },
+  { label: "Hour", value: 60 },
+  { label: "6 hours", value: 360 },
+  { label: "Day", value: 1440 },
+  { label: "Week", value: 10080 },
+]
+
+export const CUSTOM_INTERVAL = -1
+
+export type IntervalUnit = "minutes" | "hours" | "days" | "weeks"
+
+export const UNIT_MINUTES: Record<IntervalUnit, number> = {
+  minutes: 1,
+  hours: 60,
+  days: 1440,
+  weeks: 10080,
+}
+
+export const INTERVAL_UNITS: { label: string; value: IntervalUnit }[] = [
+  { label: "minutes", value: "minutes" },
+  { label: "hours", value: "hours" },
+  { label: "days", value: "days" },
+  { label: "weeks", value: "weeks" },
+]
+
+/** Express a stored intervalMinutes as either a preset or a (value, unit) pair. */
+export function inferIntervalMode(minutes: number): {
+  isCustom: boolean
+  intervalMinutes: number
+  customValue: number
+  customUnit: IntervalUnit
+} {
+  if (INTERVAL_PRESETS.some((p) => p.value === minutes)) {
+    return { isCustom: false, intervalMinutes: minutes, customValue: 10, customUnit: "minutes" }
+  }
+  if (minutes % 10080 === 0) {
+    return { isCustom: true, intervalMinutes: minutes, customValue: minutes / 10080, customUnit: "weeks" }
+  }
+  if (minutes % 1440 === 0) {
+    return { isCustom: true, intervalMinutes: minutes, customValue: minutes / 1440, customUnit: "days" }
+  }
+  if (minutes % 60 === 0) {
+    return { isCustom: true, intervalMinutes: minutes, customValue: minutes / 60, customUnit: "hours" }
+  }
+  return { isCustom: true, intervalMinutes: minutes, customValue: minutes, customUnit: "minutes" }
+}
+
+export const DAYS_OF_WEEK = [
+  { label: "Monday", value: 1 },
+  { label: "Tuesday", value: 2 },
+  { label: "Wednesday", value: 3 },
+  { label: "Thursday", value: 4 },
+  { label: "Friday", value: 5 },
+  { label: "Saturday", value: 6 },
+  { label: "Sunday", value: 0 },
+]
+
+export const TIME_OPTIONS = [
+  { label: "12:00 AM", value: 0 },
+  { label: "1:00 AM", value: 1 },
+  { label: "2:00 AM", value: 2 },
+  { label: "3:00 AM", value: 3 },
+  { label: "4:00 AM", value: 4 },
+  { label: "5:00 AM", value: 5 },
+  { label: "6:00 AM", value: 6 },
+  { label: "7:00 AM", value: 7 },
+  { label: "8:00 AM", value: 8 },
+  { label: "9:00 AM", value: 9 },
+  { label: "10:00 AM", value: 10 },
+  { label: "11:00 AM", value: 11 },
+  { label: "12:00 PM", value: 12 },
+  { label: "1:00 PM", value: 13 },
+  { label: "2:00 PM", value: 14 },
+  { label: "3:00 PM", value: 15 },
+  { label: "4:00 PM", value: 16 },
+  { label: "5:00 PM", value: 17 },
+  { label: "6:00 PM", value: 18 },
+  { label: "7:00 PM", value: 19 },
+  { label: "8:00 PM", value: 20 },
+  { label: "9:00 PM", value: 21 },
+  { label: "10:00 PM", value: 22 },
+  { label: "11:00 PM", value: 23 },
+]
+
+export const AVAILABLE_AGENTS: Agent[] = ["opencode", "claude-code", "codex"]

--- a/packages/web/components/scheduled-jobs/helpers.tsx
+++ b/packages/web/components/scheduled-jobs/helpers.tsx
@@ -1,0 +1,95 @@
+import { Clock, AlertCircle, Check, X, CheckCircle2, XCircle, Circle, RefreshCw } from "lucide-react"
+import { format, formatDistanceToNow } from "date-fns"
+import { type ScheduledJob, type ScheduledJobRun } from "@/lib/scheduled-jobs/types"
+import { NEW_REPOSITORY } from "@/lib/types"
+
+export function getRepoLabel(repo: string): string {
+  return repo === NEW_REPOSITORY ? "No repository" : repo
+}
+
+export function getJobStatusIcon(job: ScheduledJob) {
+  if (!job.enabled) {
+    return <X className="h-3.5 w-3.5 text-muted-foreground" />
+  }
+  if (job.lastRun?.status === "error") {
+    return <AlertCircle className="h-3.5 w-3.5 text-destructive" />
+  }
+  if (job.lastRun?.status === "completed") {
+    return <Check className="h-3.5 w-3.5 text-green-500" />
+  }
+  if (job.lastRun?.status === "running") {
+    return <Clock className="h-3.5 w-3.5 text-blue-500 animate-pulse" />
+  }
+  return <Clock className="h-3.5 w-3.5 text-muted-foreground" />
+}
+
+export function getRunStatusIcon(status: string) {
+  switch (status) {
+    case "completed":
+      return <CheckCircle2 className="h-3.5 w-3.5 text-green-500" />
+    case "error":
+      return <XCircle className="h-3.5 w-3.5 text-destructive" />
+    case "running":
+      return <RefreshCw className="h-3.5 w-3.5 text-blue-500 animate-spin" />
+    default:
+      return <Circle className="h-3.5 w-3.5 text-muted-foreground" />
+  }
+}
+
+export function getLastRunText(job: ScheduledJob): string {
+  if (!job.lastRun) return "Never run"
+
+  const timeAgo = formatDistanceToNow(job.lastRun.startedAt, { addSuffix: true })
+
+  if (job.lastRun.status === "running") {
+    return `Running ${timeAgo}`
+  }
+  if (job.lastRun.status === "error") {
+    return `Failed ${timeAgo}`
+  }
+  if (job.lastRun.prUrl) {
+    return `PR #${job.lastRun.prNumber} ${timeAgo}`
+  }
+  if (job.lastRun.status === "completed") {
+    return `No changes ${timeAgo}`
+  }
+  return timeAgo
+}
+
+export function formatRunLabel(run: ScheduledJobRun): string {
+  return format(run.startedAt, "MMM d, h:mm a")
+}
+
+export function formatDuration(startedAt: number, completedAt: number): string {
+  const durationMs = completedAt - startedAt
+  const seconds = Math.floor(durationMs / 1000)
+  const minutes = Math.floor(seconds / 60)
+  const hours = Math.floor(minutes / 60)
+
+  if (hours > 0) {
+    const remainingMinutes = minutes % 60
+    return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`
+  }
+  if (minutes > 0) {
+    const remainingSeconds = seconds % 60
+    return remainingSeconds > 0 ? `${minutes}m ${remainingSeconds}s` : `${minutes}m`
+  }
+  return `${seconds}s`
+}
+
+export function getTriggerDescription(job: ScheduledJob): string {
+  if (job.triggerType === "incoming") {
+    return "Webhook"
+  }
+  // Interval trigger - show human-readable schedule
+  const minutes = job.intervalMinutes
+  if (minutes < 60) {
+    return `Every ${minutes} minute${minutes === 1 ? "" : "s"}`
+  }
+  const hours = Math.round(minutes / 60)
+  if (minutes < 1440) {
+    return `Every ${hours} hour${hours === 1 ? "" : "s"}`
+  }
+  const days = Math.round(minutes / 1440)
+  return `Every ${days} day${days === 1 ? "" : "s"}`
+}

--- a/packages/web/lib/hooks/useScheduledJobForm.ts
+++ b/packages/web/lib/hooks/useScheduledJobForm.ts
@@ -1,0 +1,452 @@
+"use client"
+
+import { useState, useEffect, useMemo } from "react"
+import { type ScheduledJob } from "@/lib/scheduled-jobs/types"
+import { agentModels, type Agent, NEW_REPOSITORY } from "@/lib/types"
+import {
+  UNIT_MINUTES,
+  inferIntervalMode,
+  getTimezoneName,
+  localHourToUtc,
+  type IntervalUnit,
+} from "@/components/scheduled-jobs/form-config"
+
+interface UseScheduledJobFormArgs {
+  open: boolean
+  job?: ScheduledJob | null
+  onClose: () => void
+  onSuccess: (job: ScheduledJob) => void
+}
+
+/**
+ * All state, effects and side-effecting handlers for the Scheduled Job form.
+ * Kept in one place so the component file is pure layout — change the wiring
+ * here, change the markup there.
+ */
+export function useScheduledJobForm({ open, job, onClose, onSuccess }: UseScheduledJobFormArgs) {
+  const isEditing = !!job
+
+  // Form state
+  const [name, setName] = useState(job?.name ?? "")
+  const [prompt, setPrompt] = useState(job?.prompt ?? "")
+  // Empty string means "no repo" in form state; on submit we send NEW_REPOSITORY.
+  const [repo, setRepo] = useState(
+    job?.repo && job.repo !== NEW_REPOSITORY ? job.repo : ""
+  )
+  const [baseBranch, setBaseBranch] = useState(job?.baseBranch ?? "main")
+  const isRepoLess = !repo
+  const [agent, setAgent] = useState<Agent>((job?.agent as Agent) ?? "opencode")
+  const [model, setModel] = useState(job?.model ?? "")
+  const [triggerType, setTriggerType] = useState<"interval" | "incoming">(job?.triggerType ?? "interval")
+  const initialIntervalMode = inferIntervalMode(job?.intervalMinutes ?? 1440)
+  const [intervalMinutes, setIntervalMinutes] = useState(initialIntervalMode.intervalMinutes)
+  const [isCustomInterval, setIsCustomInterval] = useState(initialIntervalMode.isCustom)
+  const [customIntervalValue, setCustomIntervalValue] = useState(initialIntervalMode.customValue)
+  const [customIntervalUnit, setCustomIntervalUnit] = useState<IntervalUnit>(initialIntervalMode.customUnit)
+  const [runAtHourLocal, setRunAtHourLocal] = useState(9) // Local time, default to 9 AM
+  const [runAtDay, setRunAtDay] = useState(1) // Default to Monday
+  const [autoPR, setAutoPR] = useState(job?.autoPR ?? true)
+  const [continueFromLastRun, setContinueFromLastRun] = useState(job?.continueFromLastRun ?? false)
+
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // In create mode, the form may "materialize" the job into the DB the first
+  // time the user clicks the MCP picker, so MCP server connections have a real
+  // job id to hang off of. If the user then cancels, we DELETE the row so we
+  // don't leave a half-configured job behind. On final submit this id is what
+  // we PATCH (instead of POSTing again).
+  // Materialized rows are created with enabled: false so the cron doesn't pick
+  // them up before the user finishes; the final submit flips enabled back on.
+  const [materializedJobId, setMaterializedJobId] = useState<string | null>(null)
+
+  // Dropdown state
+  const [showAgentDropdown, setShowAgentDropdown] = useState(false)
+  const [showModelDropdown, setShowModelDropdown] = useState(false)
+
+  // Incoming-webhook URL state. The token comes from the saved job and can be
+  // swapped out via the rotate-token endpoint without closing the modal.
+  const [incomingToken, setIncomingToken] = useState<string | null>(job?.incomingToken ?? null)
+  const [copiedUrl, setCopiedUrl] = useState(false)
+  const [rotating, setRotating] = useState(false)
+
+  // Get available models for selected agent
+  const availableModels = agentModels[agent] ?? []
+
+  // Get timezone name for display
+  const timezoneName = useMemo(() => getTimezoneName(), [])
+
+  // What we actually send to the API (preset value, or custom value × unit).
+  const effectiveIntervalMinutes = isCustomInterval
+    ? Math.max(1, Math.floor(customIntervalValue || 0) * UNIT_MINUTES[customIntervalUnit])
+    : intervalMinutes
+
+  // Which Options-section toggles apply. The "continue" toggle is interval-only;
+  // auto-PR needs a repo to push to. The section header renders only when at
+  // least one applies — these same flags gate both the header and the toggles
+  // so they can't drift apart.
+  const showContinueOption = triggerType === "interval"
+  const showAutoPROption = !isRepoLess
+  const hasOptions = showContinueOption || showAutoPROption
+
+  // Reset form state when job prop changes or modal opens
+  useEffect(() => {
+    if (open) {
+      const initialAgent = (job?.agent as Agent) ?? "opencode"
+      const initialModels = agentModels[initialAgent] ?? []
+      setName(job?.name ?? "")
+      setPrompt(job?.prompt ?? "")
+      setRepo(job?.repo && job.repo !== NEW_REPOSITORY ? job.repo : "")
+      setBaseBranch(job?.baseBranch ?? "main")
+      setAgent(initialAgent)
+      setModel(job?.model ?? initialModels[0]?.value ?? "")
+      setTriggerType(job?.triggerType ?? "interval")
+      const mode = inferIntervalMode(job?.intervalMinutes ?? 1440)
+      setIntervalMinutes(mode.intervalMinutes)
+      setIsCustomInterval(mode.isCustom)
+      setCustomIntervalValue(mode.customValue)
+      setCustomIntervalUnit(mode.customUnit)
+      setRunAtHourLocal(9)
+      setRunAtDay(1)
+      setAutoPR(job?.autoPR ?? true)
+      setContinueFromLastRun(job?.continueFromLastRun ?? false)
+      setError(null)
+      setMaterializedJobId(null)
+      setIncomingToken(job?.incomingToken ?? null)
+      setCopiedUrl(false)
+      setRotating(false)
+    }
+  }, [open, job])
+
+  // Update model when agent changes
+  useEffect(() => {
+    const models = agentModels[agent] ?? []
+    if (models.length > 0 && !models.find(m => m.value === model)) {
+      setModel(models[0].value)
+    }
+  }, [agent, model])
+
+  useEffect(() => {
+    if (triggerType === "incoming" && !incomingToken) {
+      setIncomingToken(crypto.randomUUID())
+    }
+  }, [triggerType, incomingToken])
+
+  // Close dropdowns when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      const target = e.target as HTMLElement
+      if (!target.closest('[data-dropdown]')) {
+        setShowAgentDropdown(false)
+        setShowModelDropdown(false)
+      }
+    }
+    document.addEventListener('click', handleClickOutside)
+    return () => document.removeEventListener('click', handleClickOutside)
+  }, [])
+
+  /**
+   * Build the request body for create/update from current form state.
+   * Returns `null` and sets the visible error if required fields are missing.
+   */
+  function buildPayload(): Record<string, unknown> | null {
+    if (!name.trim()) {
+      setError("Name is required")
+      return null
+    }
+    if (!prompt.trim()) {
+      setError("Prompt is required")
+      return null
+    }
+    if (triggerType === "interval" && effectiveIntervalMinutes < 10) {
+      setError("Interval must be at least 10 minutes")
+      return null
+    }
+    const runAtHourUtc = localHourToUtc(runAtHourLocal)
+    return {
+      name: name.trim(),
+      prompt: prompt.trim(),
+      // Empty form value means repo-less; send the NEW_REPOSITORY sentinel so
+      // the backend can route through its existing no-clone sandbox path.
+      repo: repo || NEW_REPOSITORY,
+      baseBranch,
+      agent,
+      model: model || null,
+      triggerType,
+      intervalMinutes: triggerType === "interval" ? effectiveIntervalMinutes : undefined,
+      runAtHour: triggerType === "interval" && effectiveIntervalMinutes >= 1440 ? runAtHourUtc : undefined,
+      runAtDay: triggerType === "interval" && effectiveIntervalMinutes === 10080 ? runAtDay : undefined,
+      // Auto-PR has nothing to push to in repo-less mode.
+      autoPR: isRepoLess ? false : autoPR,
+      continueFromLastRun,
+    }
+  }
+
+  /**
+   * Materialize callback for the MCP picker — fired on the first MCP click
+   * during create mode. POSTs the job (with enabled: false so the cron won't
+   * pick it up mid-config) and returns the new id to the picker. Uses
+   * placeholders for name/prompt if the user hasn't typed them yet; the
+   * final-submit validation in handleSubmit enforces real values before the
+   * row goes live. The form stays open and continues acting like create mode
+   * until the user hits "Create" (PATCH to flip enabled on) or "Cancel"
+   * (DELETE the row).
+   *
+   * Works for both interval and incoming triggers — the POST mints an
+   * incomingToken regardless, so the URL panel can render immediately for
+   * incoming-typed drafts. If the user flips the trigger pill after
+   * materialize, the final-submit PATCH carries the new triggerType.
+   */
+  async function materializeJob(_draftId: string): Promise<string | null> {
+    setError(null)
+    try {
+      const res = await fetch("/api/scheduled-jobs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          // Placeholders only exist on disk while isDraft = true. They're never
+          // shown in the UI list (the GET filters drafts out) and the cron
+          // skips drafts. The final submit PATCH replaces them with real
+          // values before flipping isDraft to false.
+          name: name.trim() || "(draft)",
+          prompt: prompt.trim() || "(draft)",
+          // Drafts default to the repo-less sentinel so the row passes the
+          // backend's repo check before the user fills the form in fully.
+          repo: repo || NEW_REPOSITORY,
+          baseBranch: baseBranch || "main",
+          agent,
+          model: model || null,
+          triggerType,
+          // Carry the client-minted token (if any) so the persisted URL matches
+          // what the panel is already showing. Null on interval drafts — the
+          // server mints a dormant one.
+          incomingToken: incomingToken ?? undefined,
+          // intervalMinutes is required by the POST for "interval" — pass a
+          // safe placeholder for incoming drafts so the validator doesn't
+          // reject. Final submit overrides whichever value matters.
+          intervalMinutes:
+            triggerType === "interval" ? effectiveIntervalMinutes : 10,
+          autoPR,
+          continueFromLastRun,
+          enabled: false,
+          isDraft: true,
+        }),
+      })
+      if (!res.ok) {
+        const data = await res.json()
+        setError(data.error || "Failed to save job")
+        return null
+      }
+      const created = await res.json()
+      setMaterializedJobId(created.id)
+      // Capture the token minted by POST so the URL panel can render the
+      // moment the user flips to "Via webhook".
+      if (created.incomingToken) {
+        setIncomingToken(created.incomingToken)
+      }
+      return created.id
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save job")
+      return null
+    }
+  }
+
+  // Handle form submit
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+
+    const payload = buildPayload()
+    if (!payload) return
+
+    setLoading(true)
+
+    try {
+      const targetId = materializedJobId ?? job?.id
+      const isUpdate = !!targetId
+      const url = isUpdate
+        ? `/api/scheduled-jobs/${targetId}`
+        : "/api/scheduled-jobs"
+      const method = isUpdate ? "PATCH" : "POST"
+
+      // For materialized rows we created with enabled: false + isDraft: true;
+      // promote both on final Create. For real edits, we leave existing state
+      // alone.
+      // Persist the client-minted token on every create path so the saved URL
+      // matches what the panel shows — including after a pre-save rotate. Edits
+      // leave the token alone (rotation there goes through the server endpoint).
+      const body =
+        materializedJobId && !isEditing
+          ? { ...payload, enabled: true, isDraft: false, incomingToken: incomingToken ?? undefined }
+          : isUpdate
+            ? payload
+            : { ...payload, incomingToken: incomingToken ?? undefined }
+
+      const res = await fetch(url, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      })
+
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error || "Failed to save job")
+      }
+
+      const savedJob = await res.json()
+      // Clear the materialized marker so the close handler doesn't try to
+      // delete what we just successfully saved.
+      setMaterializedJobId(null)
+      onSuccess(savedJob)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save job")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  /**
+   * Close handler: if we materialized a job in create mode and the user is
+   * walking away without saving, drop the row so we don't leak draft jobs.
+   * Best-effort — even if cleanup fails we still close the modal.
+   */
+  const handleClose = async () => {
+    if (materializedJobId && !isEditing) {
+      const idToDelete = materializedJobId
+      setMaterializedJobId(null)
+      try {
+        await fetch(`/api/scheduled-jobs/${idToDelete}`, { method: "DELETE" })
+      } catch (err) {
+        console.error("[ScheduledJobForm] cleanup delete failed:", err)
+      }
+    }
+    onClose()
+  }
+
+  /**
+   * Build the URL the user pastes into their external app. Browser-only —
+   * SSR returns an empty string and the panel hides the value until hydration.
+   */
+  const incomingWebhookUrl = useMemo(() => {
+    if (!incomingToken) return ""
+    if (typeof window === "undefined") return ""
+    return `${window.location.origin}/wh/${incomingToken}`
+  }, [incomingToken])
+
+  const handleCopyUrl = async () => {
+    if (!incomingWebhookUrl) return
+    try {
+      await navigator.clipboard.writeText(incomingWebhookUrl)
+      setCopiedUrl(true)
+      setTimeout(() => setCopiedUrl(false), 1500)
+    } catch (err) {
+      console.error("[ScheduledJobForm] copy failed:", err)
+    }
+  }
+
+  const handleRotateToken = async () => {
+    // Create mode: the URL hasn't been handed out anywhere yet, so "rotate" is
+    // just minting a fresh client-side UUID. No server round-trip, no confirm —
+    // the new token is persisted on save (create POST / final PATCH carry it).
+    if (!isEditing) {
+      setIncomingToken(crypto.randomUUID())
+      return
+    }
+    // Edit mode: the URL is live (the user may have wired it into an external
+    // app), so rotate server-side to invalidate the old one immediately.
+    const targetId = job?.id
+    if (!targetId) return
+    if (!confirm("Rotating will invalidate the existing webhook URL. Continue?")) return
+    setRotating(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/scheduled-jobs/${targetId}/rotate-token`, {
+        method: "POST",
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error(data.error || "Failed to rotate token")
+      }
+      const updated = await res.json()
+      setIncomingToken(updated.incomingToken ?? null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to rotate token")
+    } finally {
+      setRotating(false)
+    }
+  }
+
+  const handleAgentChange = (newAgent: Agent) => {
+    setAgent(newAgent)
+    setShowAgentDropdown(false)
+  }
+
+  const handleModelChange = (newModel: string) => {
+    setModel(newModel)
+    setShowModelDropdown(false)
+  }
+
+  return {
+    // identity / mode
+    isEditing,
+    jobId: job?.id,
+    // values
+    name,
+    prompt,
+    repo,
+    baseBranch,
+    isRepoLess,
+    agent,
+    model,
+    triggerType,
+    intervalMinutes,
+    isCustomInterval,
+    customIntervalValue,
+    customIntervalUnit,
+    runAtHourLocal,
+    runAtDay,
+    autoPR,
+    continueFromLastRun,
+    loading,
+    error,
+    materializedJobId,
+    showAgentDropdown,
+    showModelDropdown,
+    incomingToken,
+    copiedUrl,
+    rotating,
+    // derived
+    availableModels,
+    timezoneName,
+    effectiveIntervalMinutes,
+    showContinueOption,
+    showAutoPROption,
+    hasOptions,
+    incomingWebhookUrl,
+    // setters
+    setName,
+    setPrompt,
+    setRepo,
+    setBaseBranch,
+    setModel,
+    setTriggerType,
+    setIntervalMinutes,
+    setIsCustomInterval,
+    setCustomIntervalValue,
+    setCustomIntervalUnit,
+    setRunAtHourLocal,
+    setRunAtDay,
+    setAutoPR,
+    setContinueFromLastRun,
+    setShowAgentDropdown,
+    setShowModelDropdown,
+    // handlers
+    materializeJob,
+    handleSubmit,
+    handleClose,
+    handleCopyUrl,
+    handleRotateToken,
+    handleAgentChange,
+    handleModelChange,
+  }
+}


### PR DESCRIPTION

Extract the two oversized scheduled-jobs components into cohesive pieces so a typical change touches one file:

- Schedule## Refactor: split `ScheduledJobForm` and `ScheduledJobsView` into focused modules

  ### Why
  Both scheduled-jobs components had grown oversized (≈1,700 lines combined), mixing data fetching,  business logic, and large JSX trees in single files. This made changes hard to locate and review. This PR
  extracts them into cohesive modules so a typical change touches **one** file.
  ### What changed
  This is a **pure, behavior-preserving** refactor — code was relocated, not rewritten. No logic, API
  calls, props, or UI behavior changed.

  **`ScheduledJobsView.tsx` — 731 → 303 lines** (now data/orchestration only)
  - `JobsList.tsx` — the list view (mobile cards + desktop table). The per-row actions menu (Edit / Run Now  / Delete), previously copy-pasted in both layouts, is now a single shared `JobRowMenu`.
  - `JobRunDetail.tsx` — the run-detail view + run-selector dropdown.
  - `helpers.tsx` — shared display helpers (status icons, last-run text, duration, trigger description).

  **`ScheduledJobForm.tsx` — 991 → 464 lines** (now pure layout)
  - `lib/hooks/useScheduledJobForm.ts` — all form state, effects, and side-effecting handlers
  (`materializeJob`, `handleSubmit`, `handleClose`, token rotate/copy, etc.), following the existing
  `lib/hooks/` convention.
  - `form-config.ts` — constants + timezone/interval pure helpers.
  - `ScheduleFields.tsx` — the self-contained "run every X on Y at Z" schedule picker.

  ### File overview

  | File | Before | After | Role |
  |------|--------|-------|------|
  | `ScheduledJobForm.tsx` | 991 | 464 | layout only |
  | `ScheduledJobsView.tsx` | 731 | 303 | data/orchestration |
  | `lib/hooks/useScheduledJobForm.ts` | — | 452 | form logic |
  | `form-config.ts` | — | 141 | constants + helpers |
  | `ScheduleFields.tsx` | — | 150 | schedule picker |
  | `JobsList.tsx` | — | 218 | list view (deduped row menu) |
  | `JobRunDetail.tsx` | — | 155 | run-detail view |
  | `helpers.tsx` | — | 95 | shared display helpers |

  ### Design notes
  - Clear seam for future edits: **behavior/wiring** → the hook; **markup** → the component; **schedule
  UI** → `ScheduleFields`; **constants** → `form-config`.
  - Deliberately kept the prompt/repo/branch/MCP/agent/model picker cluster inline — it's bound to ~8
  pieces of form state, so splitting it would reintroduce heavy prop-drilling for no real gain.

  ### Testing
  - `tsc --noEmit` passes for all changed files (the only remaining errors are pre-existing, in the
  untouched `Sidebar.tsx`).
  - No behavior change, so existing flows (create / edit / webhook / MCP materialize-and-cancel / run-now)
  are unaffected.dJobsView (731 -> 303): now data/orchestration only; rendering moved to JobsList (list view, with the row actions menu deduped) and JobRunDetail (run-detail view), with shared display helpers in helpers.tsx.
- ScheduledJobForm (991 -> 464): now pure layout; all state/effects/handlers moved to lib/hooks/useScheduledJobForm.ts. Constants and timezone/interval helpers moved to form-config.ts, and the schedule picker to ScheduleFields.

No behavior change.