### PR TITLE
fix: allow external_directory permission in opencode config

### DIFF
--- a/packages/agent-configuration/src/git/opencode.ts
+++ b/packages/agent-configuration/src/git/opencode.ts
@@ -22,12 +22,13 @@
  * - git checkout (use "git restore" for file operations)
  * - git switch (branch switching)
  *
- * `edit` and `webfetch` are explicitly allowed. Without these, opencode falls
- * back to its built-in default ("ask"), which in headless/scheduled mode
- * becomes an auto-rejection — see the `external_directory` denial that crashes
- * scheduled runs the first time the agent (or opencode itself) touches
- * `/tmp/logs/*`. `webfetch` is opened up so MCP servers and the agent's own
- * web tooling work in scheduled jobs.
+ * `edit`, `webfetch`, and `external_directory` are explicitly allowed. Without
+ * these, opencode falls back to its built-in default ("ask"), which in
+ * headless/scheduled mode becomes an auto-rejection. `external_directory` is
+ * needed whenever the agent or opencode itself touches paths outside the
+ * project root — e.g. `/tmp/logs/*` for log output or `/home/daytona/uploads/*`
+ * for user-uploaded files. `webfetch` is opened up so MCP servers and the
+ * agent's own web tooling work in scheduled jobs.
  */
 export const OPENCODE_PERMISSIONS = {
   bash: {
@@ -53,6 +54,9 @@ export const OPENCODE_PERMISSIONS = {
     "*": "allow",
   },
   webfetch: {
+    "*": "allow",
+  },
+  external_directory: {
     "*": "allow",
   },
 } as const

--- a/packages/agent-configuration/src/git/opencode.ts
+++ b/packages/agent-configuration/src/git/opencode.ts
@@ -25,10 +25,9 @@
  * `edit`, `webfetch`, and `external_directory` are explicitly allowed. Without
  * these, opencode falls back to its built-in default ("ask"), which in
  * headless/scheduled mode becomes an auto-rejection. `external_directory` is
- * needed whenever the agent or opencode itself touches paths outside the
- * project root — e.g. `/tmp/logs/*` for log output or `/home/daytona/uploads/*`
- * for user-uploaded files. `webfetch` is opened up so MCP servers and the
- * agent's own web tooling work in scheduled jobs.
+ * scoped to `/home/daytona/uploads/*` so the agent can read user-uploaded
+ * files without granting access to all external paths. `webfetch` is opened
+ * up so MCP servers and the agent's own web tooling work in scheduled jobs.
  */
 export const OPENCODE_PERMISSIONS = {
   bash: {
@@ -57,7 +56,7 @@ export const OPENCODE_PERMISSIONS = {
     "*": "allow",
   },
   external_directory: {
-    "*": "allow",
+    "/home/daytona/uploads/*": "allow",
   },
 } as const
 


### PR DESCRIPTION
Opencode's `external_directory` permission is triggered whenever a bash command accesses a path outside the project root (e.g. /home/daytona/uploads/* for user-uploaded files, /tmp/logs/* for log output). Without it explicitly allowed, opencode auto-rejects the permission in headless/scheduled mode, crashing the agent with "permission requested: external_directory; auto-rejecting".