### PR TITLE
Implement file upload size limit handling and improve error messaging for oversized attachments

### DIFF
--- a/packages/web/lib/chat-messages.ts
+++ b/packages/web/lib/chat-messages.ts
@@ -61,10 +61,24 @@ export async function sendMessageToApi(
   }
 
   if (!response.ok) {
+    // Vercel serverless functions reject request bodies over 4.5 MB with a 413
+    // *before* the route runs, so the body is a non-JSON edge error page. Map it
+    // to a clear message (the client-side guard in useFileUpload should catch
+    // this first, but this covers any edge case that slips through).
+    if (response.status === 413) {
+      return {
+        ok: false,
+        error: "Attachments are too large to upload (max ~4 MB total). Remove or shrink files and try again.",
+        isDailyLimit: false,
+      }
+    }
     const err = await response.json().catch(() => ({}))
     return {
       ok: false,
-      error: err.error || "Failed to send message",
+      // Surface the HTTP status when the server didn't return a JSON error
+      // message, so failures like 500/502/504 are identifiable instead of
+      // collapsing into a bare "Failed to send message".
+      error: err.error || `Failed to send message (HTTP ${response.status})`,
       isDailyLimit: err.error === "DAILY_LIMIT_EXCEEDED",
       resetAt: err.resetAt,
     }

--- a/packages/web/lib/hooks/useFileUpload.ts
+++ b/packages/web/lib/hooks/useFileUpload.ts
@@ -11,7 +11,15 @@ import { getFileType } from "@/lib/file-preview"
 import type { PendingFile } from "@/lib/types"
 
 // File upload constraints
-const MAX_FILE_SIZE = 30 * 1024 * 1024 // 30 MB
+//
+// Vercel serverless functions (the production deployment) reject any request
+// body larger than 4.5 MB with a 413 "Content Too Large" — a hard platform
+// limit that can't be raised. Attachments are sent as multipart/form-data
+// alongside a JSON payload, so we cap the *combined* size of all attachments
+// below that, leaving margin for the payload and multipart boundaries. This
+// makes oversized uploads fail fast with a clear message instead of an opaque
+// 413 in production.
+const MAX_TOTAL_UPLOAD_SIZE = 4 * 1024 * 1024 // 4 MB across all attachments
 const MAX_FILE_COUNT = 20
 const MAX_IMAGE_DIMENSION = 8000 // 8000 x 8000 pixels
 
@@ -151,11 +159,18 @@ export function useFileUpload(options: UseFileUploadOptions = {}): UseFileUpload
       fileArray.splice(availableSlots) // Only process files that fit
     }
 
+    // Attachments are sent together in a single request, so enforce the budget
+    // against the running total (files already pending + everything added now).
+    let runningTotal = pendingFiles.reduce((sum, pf) => sum + pf.size, 0)
+    const limitMb = (MAX_TOTAL_UPLOAD_SIZE / (1024 * 1024)).toFixed(1)
+
     // Validate each file
     for (const file of fileArray) {
-      // Check file size
-      if (file.size > MAX_FILE_SIZE) {
-        errors.push(`"${file.name}" exceeds 30 MB limit`)
+      // Enforce the combined request-body budget (server upload limit).
+      if (runningTotal + file.size > MAX_TOTAL_UPLOAD_SIZE) {
+        errors.push(
+          `"${file.name}" can't be added — attachments must total under ${limitMb} MB (server upload limit)`
+        )
         continue
       }
 
@@ -175,6 +190,7 @@ export function useFileUpload(options: UseFileUploadOptions = {}): UseFileUpload
       }
 
       validFiles.push(file)
+      runningTotal += file.size
     }
 
     // Show errors if any


### PR DESCRIPTION
## Handle oversized file uploads gracefully

  ### Problem
  Uploading large files failed in production with an opaque error. The UI allowed up  to 30 MB per file, but the app is deployed on **Vercel serverless functions**, which
  reject any request body over **4.5 MB** with a `413 Content Too Large` — a hard  platform limit that can't be raised. Users hit a generic "Failed to send message"
  with no indication of why.

  ### Changes
  - **`useFileUpload.ts`** — Replace the 30 MB per-file limit with a **4 MB combined
    budget** across all attachments (checked against the running total of pending +
    newly added files), leaving margin for the JSON payload and multipart boundaries.
    Oversized attachments now fail fast client-side with a clear message before any
    upload is attempted.
  - **`chat-messages.ts`** — Add a server-response safety net:
    - `413` → friendly "attachments too large (max ~4 MB total)" message.
    - Other non-OK responses without a JSON body → surface the HTTP status
      (`Failed to send message (HTTP <status>)`) instead of a bare generic error.

 