### PR TITLE
feat(usage): add plan tiers

### DIFF
--- a/packages/web/app/admin/page.tsx
+++ b/packages/web/app/admin/page.tsx
@@ -403,8 +403,8 @@ export default function AdminDashboard() {
                 onToggleAdmin={(userId, isAdmin) => {
                   updateUserMutation.mutate({ userId, isAdmin })
                 }}
-                onTogglePro={(userId, isPro) => {
-                  updateUserMutation.mutate({ userId, isPro })
+                onPlanChange={(userId, plan) => {
+                  updateUserMutation.mutate({ userId, plan })
                 }}
                 isUpdating={updateUserMutation.isPending ? updateUserMutation.variables?.userId : null}
                 currentUserId={session?.user?.id}

--- a/packages/web/app/api/admin/users/[userId]/route.ts
+++ b/packages/web/app/api/admin/users/[userId]/route.ts
@@ -2,10 +2,13 @@ import { NextRequest, NextResponse } from "next/server"
 import { prisma } from "@/lib/db/prisma"
 import { requireAdmin, isAuthError } from "@/lib/db/api-helpers"
 import { logActivity } from "@/lib/db/activity-log"
+import type { Plan } from "@/lib/server/usage-budgets"
+
+const PLANS: readonly Plan[] = ["free", "pro", "unlimited"]
 
 /**
  * PATCH /api/admin/users/[userId]
- * Update user properties (e.g., toggle admin status, toggle pro status)
+ * Update user properties (e.g., toggle admin status, change subscription plan)
  */
 export async function PATCH(
   request: NextRequest,
@@ -17,7 +20,7 @@ export async function PATCH(
   const { userId: targetUserId } = await params
 
   // Parse request body
-  let body: { isAdmin?: boolean; isPro?: boolean }
+  let body: { isAdmin?: boolean; plan?: string }
   try {
     body = await request.json()
   } catch {
@@ -27,7 +30,7 @@ export async function PATCH(
   // Validate the target user exists
   const targetUser = await prisma.user.findUnique({
     where: { id: targetUserId },
-    select: { id: true, isAdmin: true, isPro: true, name: true },
+    select: { id: true, isAdmin: true, plan: true, name: true },
   })
 
   if (!targetUser) {
@@ -43,12 +46,18 @@ export async function PATCH(
   }
 
   // Build update data
-  const updateData: { isAdmin?: boolean; isPro?: boolean } = {}
+  const updateData: { isAdmin?: boolean; plan?: Plan } = {}
   if (typeof body.isAdmin === "boolean") {
     updateData.isAdmin = body.isAdmin
   }
-  if (typeof body.isPro === "boolean") {
-    updateData.isPro = body.isPro
+  if (body.plan !== undefined) {
+    if (!PLANS.includes(body.plan as Plan)) {
+      return NextResponse.json(
+        { error: `Invalid plan. Expected one of: ${PLANS.join(", ")}` },
+        { status: 400 }
+      )
+    }
+    updateData.plan = body.plan as Plan
   }
 
   // If no valid updates, return error
@@ -65,7 +74,7 @@ export async function PATCH(
       name: true,
       email: true,
       isAdmin: true,
-      isPro: true,
+      plan: true,
     },
   })
 

--- a/packages/web/app/api/admin/users/route.ts
+++ b/packages/web/app/api/admin/users/route.ts
@@ -153,7 +153,7 @@ export async function GET(request: NextRequest) {
       image: true,
       githubId: true,
       isAdmin: true,
-      isPro: true,
+      plan: true,
       createdAt: true,
     },
   })
@@ -195,7 +195,7 @@ export async function GET(request: NextRequest) {
         image: user.image,
         githubId: user.githubId,
         isAdmin: user.isAdmin,
-        isPro: user.isPro,
+        plan: user.plan,
         totalMessages: messageCountMap.get(user.id) ?? 0,
         lastActivityAt: lastActivity?.createdAt.toISOString() ?? null,
         lastActivityAction: lastActivity?.action ?? null,

--- a/packages/web/app/api/user/usage/route.ts
+++ b/packages/web/app/api/user/usage/route.ts
@@ -11,6 +11,7 @@ import {
   getStartOfUtcDay,
   getNextUtcDayReset,
   type BudgetUnit,
+  type Plan,
 } from "@/lib/server/usage-budgets"
 import { agentLabels, type Agent } from "@background-agents/common"
 
@@ -25,14 +26,15 @@ export interface PoolUsage {
   used: number
   /** Estimated cost (USD) of today's shared-pool usage for this provider. */
   costUsd: number
-  /** Daily budget in `unit`, or null when unlimited (Pro, own key, or no budget). */
+  /** Daily budget in `unit`, or null when unlimited (unlimited plan, own key, or no budget). */
   limit: number | null
   /** True when the user has their own key for this provider (shared pool unused). */
   ownKey: boolean
 }
 
 export interface UsageResponse {
-  isPro: boolean
+  /** The user's subscription tier. */
+  plan: Plan
   /** ISO timestamp of the next daily reset (UTC midnight). */
   resetAt: string
   pools: PoolUsage[]
@@ -50,9 +52,9 @@ export async function GET(): Promise<Response> {
   try {
     const user = await prisma.user.findUnique({
       where: { id: userId },
-      select: { isPro: true, credentials: true },
+      select: { plan: true, credentials: true },
     })
-    const isPro = user?.isPro ?? false
+    const plan: Plan = user?.plan ?? "free"
     const storedCreds = decryptUserCredentials(
       user?.credentials as Record<string, unknown> | null
     )
@@ -62,7 +64,7 @@ export async function GET(): Promise<Response> {
       SHARED_POOL_AGENTS.map(async (agent) => {
         const provider = providerForAgent(agent)
         const ownKey = resolvePool(agent, storedCreds) === "user"
-        const budget = getProviderBudget(provider)
+        const budget = getProviderBudget(provider, plan)
         const unit = budget?.unit ?? "tokens"
         const { limitedTokens, costUsd } = await sumSharedUsage({
           userId,
@@ -76,8 +78,9 @@ export async function GET(): Promise<Response> {
             : unit === "cost"
               ? costUsd
               : limitedTokens
-        // Unlimited when Pro, on own key, or no configured budget.
-        const limit = isPro || ownKey ? null : (budget?.limit ?? null)
+        // Unlimited on own key, or when the plan has no budget (unlimited plan
+        // or a provider with none configured). `budget` already reflects plan.
+        const limit = ownKey ? null : (budget?.limit ?? null)
         return {
           agent,
           provider,
@@ -92,7 +95,7 @@ export async function GET(): Promise<Response> {
     )
 
     const response: UsageResponse = {
-      isPro,
+      plan,
       resetAt: getNextUtcDayReset().toISOString(),
       pools,
     }

--- a/packages/web/components/admin/UserTable.tsx
+++ b/packages/web/components/admin/UserTable.tsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 import { formatDistanceToNow } from "date-fns"
 import { Search, ChevronLeft, ChevronRight, Shield, ShieldOff, ArrowUp, ArrowDown, ArrowUpDown, Crown, Mail, Github } from "lucide-react"
 import { cn } from "@/lib/utils"
+import type { Plan } from "@/lib/server/usage-budgets"
 
 interface User {
   id: string
@@ -12,11 +13,32 @@ interface User {
   image: string | null
   githubId: string | null
   isAdmin: boolean
-  isPro: boolean
+  plan: Plan
   totalMessages: number
   lastActivityAt: string | null
   lastActivityAction: string | null
   createdAt: string
+}
+
+/** Admin-cycle order for the plan control: free → pro → unlimited → free. */
+const PLAN_CYCLE: Record<Plan, Plan> = {
+  free: "pro",
+  pro: "unlimited",
+  unlimited: "free",
+}
+
+const PLAN_LABEL: Record<Plan, string> = {
+  free: "Free",
+  pro: "Pro",
+  unlimited: "Unlimited",
+}
+
+/** Pill styling per plan for the admin table. */
+const PLAN_STYLE: Record<Plan, string> = {
+  free: "bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-400",
+  pro: "bg-amber-100 text-amber-700 hover:bg-amber-200 dark:bg-amber-900/30 dark:text-amber-400",
+  unlimited:
+    "bg-violet-100 text-violet-700 hover:bg-violet-200 dark:bg-violet-900/30 dark:text-violet-400",
 }
 
 interface Pagination {
@@ -40,7 +62,7 @@ interface UserTableProps {
   onPageChange: (page: number) => void
   onSortChange: (field: SortField) => void
   onToggleAdmin: (userId: string, isAdmin: boolean) => void
-  onTogglePro: (userId: string, isPro: boolean) => void
+  onPlanChange: (userId: string, plan: Plan) => void
   isUpdating?: string | null
   currentUserId?: string
 }
@@ -86,13 +108,13 @@ function SortHeader({
 function MobileUserCard({
   user,
   onToggleAdmin,
-  onTogglePro,
+  onPlanChange,
   isUpdating,
   currentUserId,
 }: {
   user: User
   onToggleAdmin: (userId: string, isAdmin: boolean) => void
-  onTogglePro: (userId: string, isPro: boolean) => void
+  onPlanChange: (userId: string, plan: Plan) => void
   isUpdating?: string | null
   currentUserId?: string
 }) {
@@ -147,18 +169,17 @@ function MobileUserCard({
       {/* Actions row */}
       <div className="flex items-center gap-2 pt-1">
         <button
-          onClick={() => onTogglePro(user.id, !user.isPro)}
+          onClick={() => onPlanChange(user.id, PLAN_CYCLE[user.plan])}
           disabled={isUpdating === user.id}
           className={cn(
             "inline-flex items-center gap-1 rounded-full px-3 py-1.5 text-xs font-medium transition-colors",
-            user.isPro
-              ? "bg-amber-100 text-amber-700 hover:bg-amber-200 dark:bg-amber-900/30 dark:text-amber-400"
-              : "bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-400",
+            PLAN_STYLE[user.plan],
             "disabled:cursor-not-allowed disabled:opacity-50"
           )}
+          title={`Click to change plan (→ ${PLAN_LABEL[PLAN_CYCLE[user.plan]]})`}
         >
           <Crown className="h-3 w-3" />
-          {user.isPro ? "Pro" : "Free"}
+          {PLAN_LABEL[user.plan]}
         </button>
         <button
           onClick={() => onToggleAdmin(user.id, !user.isAdmin)}
@@ -199,7 +220,7 @@ export function UserTable({
   onPageChange,
   onSortChange,
   onToggleAdmin,
-  onTogglePro,
+  onPlanChange,
   isUpdating,
   currentUserId,
 }: UserTableProps) {
@@ -261,7 +282,7 @@ export function UserTable({
               key={user.id}
               user={user}
               onToggleAdmin={onToggleAdmin}
-              onTogglePro={onTogglePro}
+              onPlanChange={onPlanChange}
               isUpdating={isUpdating}
               currentUserId={currentUserId}
             />
@@ -280,7 +301,7 @@ export function UserTable({
                 <SortHeader label="Messages" field="totalMessages" currentField={sortField} currentOrder={sortOrder} onSort={onSortChange} align="center" />
                 <SortHeader label="Last Active" field="lastActivityAt" currentField={sortField} currentOrder={sortOrder} onSort={onSortChange} />
                 <SortHeader label="Joined" field="createdAt" currentField={sortField} currentOrder={sortOrder} onSort={onSortChange} />
-                <th className="px-4 py-3 text-center font-medium">Pro</th>
+                <th className="px-4 py-3 text-center font-medium">Plan</th>
                 <th className="px-4 py-3 text-center font-medium">Admin</th>
               </tr>
             </thead>
@@ -379,17 +400,17 @@ export function UserTable({
                     </td>
                     <td className="px-4 py-3 text-center">
                       <button
-                        onClick={() => onTogglePro(user.id, !user.isPro)}
+                        onClick={() => onPlanChange(user.id, PLAN_CYCLE[user.plan])}
                         disabled={isUpdating === user.id}
-                        className={`inline-flex items-center gap-1 rounded-full px-2 py-1 text-xs font-medium transition-colors ${
-                          user.isPro
-                            ? "bg-amber-100 text-amber-700 hover:bg-amber-200 dark:bg-amber-900/30 dark:text-amber-400"
-                            : "bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-400"
-                        } disabled:cursor-not-allowed disabled:opacity-50`}
-                        title={user.isPro ? "Click to remove Pro status" : "Click to grant Pro status"}
+                        className={cn(
+                          "inline-flex items-center gap-1 rounded-full px-2 py-1 text-xs font-medium transition-colors",
+                          PLAN_STYLE[user.plan],
+                          "disabled:cursor-not-allowed disabled:opacity-50"
+                        )}
+                        title={`Click to change plan (→ ${PLAN_LABEL[PLAN_CYCLE[user.plan]]})`}
                       >
                         <Crown className="h-3 w-3" />
-                        {user.isPro ? "Pro" : "Free"}
+                        {PLAN_LABEL[user.plan]}
                       </button>
                     </td>
                     <td className="px-4 py-3 text-center">

--- a/packages/web/components/modals/LimitReachedDialog.tsx
+++ b/packages/web/components/modals/LimitReachedDialog.tsx
@@ -191,7 +191,7 @@ export function LimitReachedDialog({
                     Upgrade to Pro
                   </div>
                   <div className="text-xs text-muted-foreground">
-                    Unlimited usage on all shared pools and priority support
+                    Higher daily limits on all shared pools and priority support
                   </div>
                 </div>
                 <div className="shrink-0 text-xs font-medium text-amber-600 dark:text-amber-400 px-2 py-0.5 rounded bg-amber-500/10">

--- a/packages/web/components/modals/settings/UsageSection.tsx
+++ b/packages/web/components/modals/settings/UsageSection.tsx
@@ -79,10 +79,10 @@ interface UsageSectionProps {
 }
 
 /**
- * Daily token usage for each shared credential pool. Free users see their usage
- * against the per-provider daily budget; Pro users and own-key providers show as
- * unlimited. The "tokens" shown are the cache-excluded limited measure that the
- * rate limiter actually counts.
+ * Daily token usage for each shared credential pool. Free and Pro users see
+ * their usage against the per-provider daily budget (Pro's is 2× the free one);
+ * unlimited-plan users and own-key providers show as unlimited. The "tokens"
+ * shown are the cache-excluded limited measure that the rate limiter counts.
  */
 export function UsageSection({ isMobile }: UsageSectionProps) {
   const [data, setData] = useState<UsageResponse | null>(null)
@@ -133,11 +133,15 @@ export function UsageSection({ isMobile }: UsageSectionProps) {
           {data.pools.map((pool) => (
             <PoolBar key={pool.provider} pool={pool} />
           ))}
-          {data.isPro && (
+          {data.plan === "unlimited" ? (
             <p className="text-[11px] text-primary mt-2">
-              Pro plan — shared pools are unlimited. Usage shown for reference.
+              Unlimited plan — shared pools are uncapped. Usage shown for reference.
             </p>
-          )}
+          ) : data.plan === "pro" ? (
+            <p className="text-[11px] text-primary mt-2">
+              Pro plan — 2× the free daily budget on each shared pool.
+            </p>
+          ) : null}
         </div>
       )}
     </div>

--- a/packages/web/lib/db/usage-limit.ts
+++ b/packages/web/lib/db/usage-limit.ts
@@ -2,9 +2,10 @@
  * Token-based usage limits for the shared credential pools.
  *
  * Free users get a daily, per-provider, cache-excluded token budget when using
- * a shared pool (Claude OAuth / Gemini / OpenCode server keys). Users running on
- * their own key, and Pro users, are unlimited. Usage is summed from the
- * TokenUsage ledger (populated post-turn by tokscale metering).
+ * a shared pool (Claude OAuth / Gemini / OpenCode server keys). Pro users get
+ * the same daily budget scaled by PRO_BUDGET_MULTIPLIER; only `unlimited`-plan
+ * users (and anyone running on their own key) are uncapped. Usage is summed from
+ * the TokenUsage ledger (populated post-turn by tokscale metering).
  *
  * Because a turn's token cost is only known after it runs, enforcement is
  * post-hoc: we block the NEXT turn once the period's usage has met the budget.
@@ -21,11 +22,12 @@ import {
   getNextUtcDayReset,
   getStartOfUtcDay,
   type BudgetUnit,
+  type Plan,
 } from "@/lib/server/usage-budgets"
 
 export interface UsageLimitResult {
   allowed: boolean
-  isPro: boolean
+  plan: Plan
   provider: ProviderName
   /** "shared" pools are limited; "user" pools are always allowed. */
   pool: "shared" | "user"
@@ -43,7 +45,8 @@ export interface UsageLimitResult {
 /**
  * Check whether a user may start a turn on `agent` given the shared-pool token
  * budget. Unlimited (allowed, no limit) when: the agent has no shared pool, the
- * user supplied their own key for it, or the user is Pro.
+ * user supplied their own key for it, or the user is on the `unlimited` plan.
+ * Free and Pro users are capped (Pro at PRO_BUDGET_MULTIPLIER× the free budget).
  */
 export async function checkSharedPoolUsage(
   userId: string,
@@ -54,18 +57,19 @@ export async function checkSharedPoolUsage(
 
   const user = await prisma.user.findUnique({
     where: { id: userId },
-    select: { isPro: true, credentials: true },
+    select: { plan: true, credentials: true },
   })
 
+  const plan: Plan = user?.plan ?? "free"
   const storedCreds = decryptUserCredentials(
     user?.credentials as Record<string, unknown> | null
   )
   const pool = resolvePool(agent, storedCreds)
 
-  const budget = getProviderBudget(provider)
+  const budget = getProviderBudget(provider, plan)
 
   const base = {
-    isPro: user?.isPro ?? false,
+    plan,
     provider,
     pool,
     unit: budget?.unit ?? ("tokens" as BudgetUnit),
@@ -78,13 +82,8 @@ export async function checkSharedPoolUsage(
     return { ...base, allowed: true, limit: null, remaining: null }
   }
 
-  // Pro users: unlimited on shared pools.
-  if (base.isPro) {
-    return { ...base, allowed: true, limit: null, remaining: null }
-  }
-
   if (budget == null) {
-    // No configured budget ⇒ effectively unlimited.
+    // Unlimited plan, or a provider with no configured budget ⇒ unlimited.
     return { ...base, allowed: true, limit: null, remaining: null }
   }
 

--- a/packages/web/lib/query/hooks/useAdminUsersQuery.ts
+++ b/packages/web/lib/query/hooks/useAdminUsersQuery.ts
@@ -3,6 +3,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { useSession } from "next-auth/react"
 import { queryKeys } from "../keys"
+import type { Plan } from "@/lib/server/usage-budgets"
 
 interface User {
   id: string
@@ -11,7 +12,7 @@ interface User {
   image: string | null
   githubId: string | null
   isAdmin: boolean
-  isPro: boolean
+  plan: Plan
   totalMessages: number
   lastActivityAt: string | null
   lastActivityAction: string | null
@@ -80,17 +81,17 @@ export function useAdminUsersQuery(options: UseAdminUsersQueryOptions = {}) {
   })
 }
 
-// Mutation for updating user properties (admin status, pro status)
+// Mutation for updating user properties (admin status, subscription plan)
 interface UpdateUserParams {
   userId: string
   isAdmin?: boolean
-  isPro?: boolean
+  plan?: Plan
 }
 
-async function updateUser({ userId, isAdmin, isPro }: UpdateUserParams): Promise<User> {
-  const body: { isAdmin?: boolean; isPro?: boolean } = {}
+async function updateUser({ userId, isAdmin, plan }: UpdateUserParams): Promise<User> {
+  const body: { isAdmin?: boolean; plan?: Plan } = {}
   if (typeof isAdmin === "boolean") body.isAdmin = isAdmin
-  if (typeof isPro === "boolean") body.isPro = isPro
+  if (plan !== undefined) body.plan = plan
 
   const response = await fetch(`/api/admin/users/${userId}`, {
     method: "PATCH",

--- a/packages/web/lib/server/credential-flags.ts
+++ b/packages/web/lib/server/credential-flags.ts
@@ -13,6 +13,7 @@ import {
   getNextUtcDayReset,
   getStartOfUtcWeek,
   getNextUtcWeekReset,
+  type Plan,
 } from "@/lib/server/usage-budgets"
 import { flagsFromCredentials, CREDENTIAL_KEYS, type CredentialFlags } from "@/lib/credentials"
 
@@ -21,14 +22,16 @@ export interface EffectiveFlags {
   limitResetAt: Date | null
   /** Remaining limited tokens (cache-excluded) for free users; null = unlimited. */
   limitRemaining: number | null
-  /** Limited tokens used by the shared Claude pool this period (daily free / weekly pro). */
+  /** Limited tokens used by the shared Claude pool this period (daily capped / weekly unlimited). */
   limitUsed: number | null
-  /** Daily token budget for free users; null for pro/unlimited. */
+  /** Daily token budget for capped plans (free/pro); null when unlimited. */
   limitTotal: number | null
-  /** Whether usage is tracked weekly (pro) vs daily (free) */
+  /** Whether usage is tracked weekly (unlimited plan) vs daily (free/pro) */
   isWeekly: boolean
-  /** Whether user is a pro subscriber */
+  /** Whether the user has a paid plan (pro or unlimited) */
   isPro: boolean
+  /** The user's subscription tier. */
+  plan: Plan
 }
 
 /**
@@ -44,7 +47,7 @@ export interface EffectiveFlags {
 export async function getEffectiveCredentialFlags(userId: string): Promise<EffectiveFlags> {
   const user = await prisma.user.findUnique({
     where: { id: userId },
-    select: { credentials: true, isPro: true },
+    select: { credentials: true, plan: true },
   })
 
   // Decrypt stored credentials (only those the user has saved)
@@ -88,7 +91,8 @@ export async function getEffectiveCredentialFlags(userId: string): Promise<Effec
   // (no personal API key or subscription token)
   const hasOwnAnthropicKey = !!flags.ANTHROPIC_API_KEY || !!flags.CLAUDE_CODE_CREDENTIALS
   const usesSharedPool = flags.CLAUDE_SHARED_POOL_AVAILABLE && !hasOwnAnthropicKey
-  const isPro = user?.isPro ?? false
+  const plan: Plan = user?.plan ?? "free"
+  const isPro = plan !== "free"
 
   let limitResetAt: Date | null = null
   let limitRemaining: number | null = null
@@ -98,8 +102,8 @@ export async function getEffectiveCredentialFlags(userId: string): Promise<Effec
 
   if (usesSharedPool) {
     // Limited tokens (cache-excluded) consumed from the shared Claude pool.
-    if (isPro) {
-      // Pro users: weekly usage for display only — no cap.
+    if (plan === "unlimited") {
+      // Unlimited plan: weekly usage for display only — no cap.
       isWeekly = true
       const { limitedTokens } = await sumSharedUsage({
         userId,
@@ -110,7 +114,7 @@ export async function getEffectiveCredentialFlags(userId: string): Promise<Effec
       limitResetAt = getNextUtcWeekReset()
       // limitTotal / limitRemaining stay null (unlimited)
     } else {
-      // Free users: daily token budget.
+      // Free and Pro users: daily token budget (Pro = 2× free).
       const { limitedTokens } = await sumSharedUsage({
         userId,
         provider: "claude",
@@ -119,7 +123,7 @@ export async function getEffectiveCredentialFlags(userId: string): Promise<Effec
       limitUsed = limitedTokens
       limitResetAt = getNextUtcDayReset()
 
-      const budget = getDailyTokenBudget("claude")
+      const budget = getDailyTokenBudget("claude", plan)
       if (budget != null) {
         limitTotal = budget
         limitRemaining = Math.max(0, budget - limitedTokens)
@@ -128,5 +132,5 @@ export async function getEffectiveCredentialFlags(userId: string): Promise<Effec
     }
   }
 
-  return { flags, limitResetAt, limitRemaining, limitUsed, limitTotal, isPro, isWeekly }
+  return { flags, limitResetAt, limitRemaining, limitUsed, limitTotal, isPro, isWeekly, plan }
 }

--- a/packages/web/lib/server/usage-budgets.ts
+++ b/packages/web/lib/server/usage-budgets.ts
@@ -1,9 +1,9 @@
 /**
  * Per-provider daily budgets for the shared credential pools.
  *
- * Free users get a daily budget per shared pool; Pro users are unlimited. The
- * budget *unit* differs by provider — each pool is metered in whatever measure
- * best reflects its cost:
+ * Budgets scale by plan: `free` gets the base daily budget, `pro` gets 2× that
+ * budget (still daily), and `unlimited` is uncapped. The budget *unit* differs
+ * by provider — each pool is metered in whatever measure best reflects its cost:
  *   - claude   → "tokens": cache-excluded limited tokens (input + output +
  *                reasoning; see UsageTotals.limitedTokens).
  *   - opencode → "cost": USD spend (tokscale's per-turn cost), since OpenCode
@@ -16,6 +16,9 @@
 
 import type { ProviderName } from "@background-agents/common"
 
+/** Subscription tier (mirrors Prisma's `Plan` enum). */
+export type Plan = "free" | "pro" | "unlimited"
+
 /** Unit a provider's shared-pool budget is measured in. */
 export type BudgetUnit = "tokens" | "cost" | "messages"
 
@@ -25,6 +28,9 @@ export interface ProviderBudget {
   limit: number
 }
 
+/** Multiplier applied to the free daily budget for `pro` users. */
+export const PRO_BUDGET_MULTIPLIER = 2
+
 /** Free-tier daily budget per shared-pool provider, with its unit. */
 export const FREE_DAILY_BUDGETS: Partial<Record<ProviderName, ProviderBudget>> = {
   // TODO(token-budgets): replace placeholders with tuned values.
@@ -33,18 +39,34 @@ export const FREE_DAILY_BUDGETS: Partial<Record<ProviderName, ProviderBudget>> =
   gemini: { unit: "messages", limit: 100 },
 }
 
-/** Daily budget descriptor for a provider, or null when unlimited. */
-export function getProviderBudget(provider: ProviderName): ProviderBudget | null {
-  return FREE_DAILY_BUDGETS[provider] ?? null
+/**
+ * Daily budget descriptor for a provider on a given plan, or null when
+ * unlimited (the `unlimited` plan, or a provider with no configured budget).
+ * `pro` gets `PRO_BUDGET_MULTIPLIER`× the free budget; `free` gets the base.
+ */
+export function getProviderBudget(
+  provider: ProviderName,
+  plan: Plan = "free"
+): ProviderBudget | null {
+  if (plan === "unlimited") return null
+  const base = FREE_DAILY_BUDGETS[provider]
+  if (!base) return null
+  if (plan === "pro") {
+    return { unit: base.unit, limit: base.limit * PRO_BUDGET_MULTIPLIER }
+  }
+  return base
 }
 
 /**
- * Daily token budget for a provider, or null when the provider isn't metered
- * in tokens (cost/message-based) or is unlimited. Used by the Claude-specific
- * limit display in credential-flags.
+ * Daily token budget for a provider on a given plan, or null when the provider
+ * isn't metered in tokens (cost/message-based) or is unlimited. Used by the
+ * Claude-specific limit display in credential-flags.
  */
-export function getDailyTokenBudget(provider: ProviderName): number | null {
-  const b = FREE_DAILY_BUDGETS[provider]
+export function getDailyTokenBudget(
+  provider: ProviderName,
+  plan: Plan = "free"
+): number | null {
+  const b = getProviderBudget(provider, plan)
   return b && b.unit === "tokens" ? b.limit : null
 }
 

--- a/packages/web/prisma/migrations/20260617000000_add_user_plan/migration.sql
+++ b/packages/web/prisma/migrations/20260617000000_add_user_plan/migration.sql
@@ -1,0 +1,13 @@
+-- Subscription tier enum + column, replacing the boolean `isPro`.
+--   free      → per-provider daily budget
+--   pro       → 2× the free daily budget
+--   unlimited → no shared-pool cap
+CREATE TYPE "Plan" AS ENUM ('free', 'pro', 'unlimited');
+
+ALTER TABLE "User" ADD COLUMN "plan" "Plan" NOT NULL DEFAULT 'free';
+
+-- Existing Pro subscribers map to the new (capped) `pro` tier. Bump any that
+-- should stay uncapped to `unlimited` manually after this migration.
+UPDATE "User" SET "plan" = 'pro' WHERE "isPro" = true;
+
+ALTER TABLE "User" DROP COLUMN "isPro";

--- a/packages/web/prisma/schema.prisma
+++ b/packages/web/prisma/schema.prisma
@@ -6,6 +6,13 @@ datasource db {
   provider = "postgresql"
 }
 
+// Subscription tier. See User.plan.
+enum Plan {
+  free
+  pro
+  unlimited
+}
+
 // =============================================================================
 // User - linked to GitHub OAuth
 // =============================================================================
@@ -23,8 +30,11 @@ model User {
   // Admin flag for analytics dashboard access
   isAdmin Boolean @default(false)
 
-  // Pro subscription flag for unlimited shared Claude usage
-  isPro Boolean @default(false)
+  // Subscription tier governing shared-pool budgets:
+  //   free      → per-provider daily budget
+  //   pro        → 2× the free daily budget
+  //   unlimited  → no shared-pool cap
+  plan Plan @default(free)
 
   // JSONB for flexible settings storage (no migrations needed for new fields)
   // { defaultAgent, defaultModel, theme }


### PR DESCRIPTION
Pro gets 2x free budget, only Unlimited…

Replace the boolean User.isPro with a Plan enum (free | pro | unlimited). Shared-pool budgets now scale by plan: free = base daily budget, pro = 2x, unlimited = uncapped. Pro is now capped (daily window) where it was previously unlimited; only the new unlimited plan is uncapped.

- schema + migration: Plan enum, plan column (default free), backfill isPro=true -> pro, drop isPro
- usage-budgets: Plan type, PRO_BUDGET_MULTIPLIER, plan-aware getProviderBudget / getDailyTokenBudget
- usage-limit / credential-flags: cap free & pro daily, unlimited uncapped (weekly display)
- usage API + UsageSection: return/render plan; per-plan footer note
- admin: plan-cycling control (free -> pro -> unlimited), enum-validated PATCH
- LimitReachedDialog: correct Pro upsell copy (no longer "unlimited")