### PR TITLE
Add custom Anthropic-compatible endpoint ("Custom model") settings

### DIFF
--- a/packages/agents/tests/unit/custom-model.test.ts
+++ b/packages/agents/tests/unit/custom-model.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Unit tests for the custom Anthropic-compatible endpoint ("Custom model").
+ *
+ * Covers the mapping of stored CUSTOM_MODEL_* credentials to the standard
+ * ANTHROPIC_* env vars, header sanitization, CLI model resolution, and the
+ * credential gate — all pure logic in @background-agents/common.
+ */
+import { describe, it, expect } from "vitest"
+import {
+  getEnvForModel,
+  buildCustomModelEnv,
+  sanitizeCustomHeaders,
+  resolveCliModel,
+  hasCredentialsForModel,
+  agentModels,
+  CUSTOM_MODEL_VALUE,
+  type Credentials,
+  type CredentialFlags,
+} from "@background-agents/common"
+
+const customModel = agentModels["claude-code"].find((m) => m.value === CUSTOM_MODEL_VALUE)!
+
+describe("custom model env injection", () => {
+  it("maps API key config to ANTHROPIC_BASE_URL + ANTHROPIC_API_KEY", () => {
+    const creds: Credentials = {
+      CUSTOM_MODEL_BASE_URL: "https://api.anthropic.com",
+      CUSTOM_MODEL_API_KEY: "sk-ant-123",
+    }
+    const env = getEnvForModel(CUSTOM_MODEL_VALUE, "claude-code", creds)
+    expect(env).toEqual({
+      ANTHROPIC_BASE_URL: "https://api.anthropic.com",
+      ANTHROPIC_API_KEY: "sk-ant-123",
+    })
+  })
+
+  it("maps auth-token config to ANTHROPIC_AUTH_TOKEN", () => {
+    const env = buildCustomModelEnv({
+      CUSTOM_MODEL_BASE_URL: "https://gateway.example.com",
+      CUSTOM_MODEL_AUTH_TOKEN: "tok-456",
+    })
+    expect(env).toEqual({
+      ANTHROPIC_BASE_URL: "https://gateway.example.com",
+      ANTHROPIC_AUTH_TOKEN: "tok-456",
+    })
+  })
+
+  it("never leaks the shared-pool token even if one is stored", () => {
+    const env = getEnvForModel(CUSTOM_MODEL_VALUE, "claude-code", {
+      CUSTOM_MODEL_BASE_URL: "https://gateway.example.com",
+      CUSTOM_MODEL_API_KEY: "sk-custom",
+      CLAUDE_CODE_CREDENTIALS: '{"claudeAiOauth":{"accessToken":"SHOULD_NOT_LEAK"}}',
+    })
+    expect(env.CLAUDE_CODE_CREDENTIALS).toBeUndefined()
+    expect(env.ANTHROPIC_API_KEY).toBe("sk-custom")
+  })
+
+  it("passes through sanitized custom headers and drops blocklisted ones", () => {
+    const env = buildCustomModelEnv({
+      CUSTOM_MODEL_BASE_URL: "https://gateway.example.com",
+      CUSTOM_MODEL_API_KEY: "sk-custom",
+      CUSTOM_MODEL_HEADERS: "x-org-id: org_1\nAuthorization: Bearer hack\nx-route: prod",
+    })
+    expect(env.ANTHROPIC_CUSTOM_HEADERS).toBe("x-org-id: org_1\nx-route: prod")
+  })
+})
+
+describe("sanitizeCustomHeaders", () => {
+  it("drops blocklisted, empty, and malformed lines", () => {
+    expect(
+      sanitizeCustomHeaders("x-a: 1\n\nx-api-key: nope\nbadline\nanthropic-version: 1\nx-b: 2")
+    ).toBe("x-a: 1\nx-b: 2")
+  })
+
+  it("returns undefined when nothing valid remains", () => {
+    expect(sanitizeCustomHeaders("Authorization: Bearer x\n\n")).toBeUndefined()
+  })
+})
+
+describe("resolveCliModel", () => {
+  it("translates the custom sentinel to the configured model name", () => {
+    expect(resolveCliModel(CUSTOM_MODEL_VALUE, { CUSTOM_MODEL_NAME: "claude-opus-4-1" })).toBe(
+      "claude-opus-4-1"
+    )
+  })
+
+  it("returns undefined for a custom run with no model name (endpoint default)", () => {
+    expect(resolveCliModel(CUSTOM_MODEL_VALUE, {})).toBeUndefined()
+  })
+
+  it("passes regular model values through unchanged", () => {
+    expect(resolveCliModel("sonnet", {})).toBe("sonnet")
+  })
+})
+
+describe("hasCredentialsForModel — custom", () => {
+  it("requires a base URL plus at least one auth credential", () => {
+    const baseOnly: CredentialFlags = { CUSTOM_MODEL_BASE_URL: true }
+    const withApiKey: CredentialFlags = { CUSTOM_MODEL_BASE_URL: true, CUSTOM_MODEL_API_KEY: true }
+    const withToken: CredentialFlags = { CUSTOM_MODEL_BASE_URL: true, CUSTOM_MODEL_AUTH_TOKEN: true }
+    const authOnly: CredentialFlags = { CUSTOM_MODEL_API_KEY: true }
+
+    expect(hasCredentialsForModel(customModel, baseOnly, "claude-code")).toBe(false)
+    expect(hasCredentialsForModel(customModel, authOnly, "claude-code")).toBe(false)
+    expect(hasCredentialsForModel(customModel, withApiKey, "claude-code")).toBe(true)
+    expect(hasCredentialsForModel(customModel, withToken, "claude-code")).toBe(true)
+  })
+})

--- a/packages/agents/tests/unit/custom-model.test.ts
+++ b/packages/agents/tests/unit/custom-model.test.ts
@@ -2,14 +2,14 @@
  * Unit tests for the custom Anthropic-compatible endpoint ("Custom model").
  *
  * Covers the mapping of stored CUSTOM_MODEL_* credentials to the standard
- * ANTHROPIC_* env vars, header sanitization, CLI model resolution, and the
- * credential gate — all pure logic in @background-agents/common.
+ * ANTHROPIC_* env vars, header parsing / auth promotion, CLI model resolution,
+ * and the credential gate — all pure logic in @background-agents/common.
  */
 import { describe, it, expect } from "vitest"
 import {
   getEnvForModel,
   buildCustomModelEnv,
-  sanitizeCustomHeaders,
+  parseCustomHeaders,
   resolveCliModel,
   hasCredentialsForModel,
   agentModels,
@@ -21,10 +21,10 @@ import {
 const customModel = agentModels["claude-code"].find((m) => m.value === CUSTOM_MODEL_VALUE)!
 
 describe("custom model env injection", () => {
-  it("maps API key config to ANTHROPIC_BASE_URL + ANTHROPIC_API_KEY", () => {
+  it("promotes an x-api-key header to ANTHROPIC_API_KEY", () => {
     const creds: Credentials = {
       CUSTOM_MODEL_BASE_URL: "https://api.anthropic.com",
-      CUSTOM_MODEL_API_KEY: "sk-ant-123",
+      CUSTOM_MODEL_HEADERS: "x-api-key: sk-ant-123",
     }
     const env = getEnvForModel(CUSTOM_MODEL_VALUE, "claude-code", creds)
     expect(env).toEqual({
@@ -33,10 +33,10 @@ describe("custom model env injection", () => {
     })
   })
 
-  it("maps auth-token config to ANTHROPIC_AUTH_TOKEN", () => {
+  it("promotes an Authorization header to ANTHROPIC_AUTH_TOKEN (Bearer stripped)", () => {
     const env = buildCustomModelEnv({
       CUSTOM_MODEL_BASE_URL: "https://gateway.example.com",
-      CUSTOM_MODEL_AUTH_TOKEN: "tok-456",
+      CUSTOM_MODEL_HEADERS: "Authorization: Bearer tok-456",
     })
     expect(env).toEqual({
       ANTHROPIC_BASE_URL: "https://gateway.example.com",
@@ -47,32 +47,50 @@ describe("custom model env injection", () => {
   it("never leaks the shared-pool token even if one is stored", () => {
     const env = getEnvForModel(CUSTOM_MODEL_VALUE, "claude-code", {
       CUSTOM_MODEL_BASE_URL: "https://gateway.example.com",
-      CUSTOM_MODEL_API_KEY: "sk-custom",
+      CUSTOM_MODEL_HEADERS: "x-api-key: sk-custom",
       CLAUDE_CODE_CREDENTIALS: '{"claudeAiOauth":{"accessToken":"SHOULD_NOT_LEAK"}}',
     })
     expect(env.CLAUDE_CODE_CREDENTIALS).toBeUndefined()
     expect(env.ANTHROPIC_API_KEY).toBe("sk-custom")
   })
 
-  it("passes through sanitized custom headers and drops blocklisted ones", () => {
+  it("keeps non-auth headers in ANTHROPIC_CUSTOM_HEADERS alongside promoted auth", () => {
     const env = buildCustomModelEnv({
       CUSTOM_MODEL_BASE_URL: "https://gateway.example.com",
-      CUSTOM_MODEL_API_KEY: "sk-custom",
-      CUSTOM_MODEL_HEADERS: "x-org-id: org_1\nAuthorization: Bearer hack\nx-route: prod",
+      CUSTOM_MODEL_HEADERS: "x-org-id: org_1\nx-api-key: sk-custom\nx-route: prod",
     })
+    expect(env.ANTHROPIC_API_KEY).toBe("sk-custom")
     expect(env.ANTHROPIC_CUSTOM_HEADERS).toBe("x-org-id: org_1\nx-route: prod")
+  })
+
+  it("only sets the base URL when no headers are configured", () => {
+    const env = buildCustomModelEnv({ CUSTOM_MODEL_BASE_URL: "https://api.anthropic.com" })
+    expect(env).toEqual({ ANTHROPIC_BASE_URL: "https://api.anthropic.com" })
   })
 })
 
-describe("sanitizeCustomHeaders", () => {
-  it("drops blocklisted, empty, and malformed lines", () => {
-    expect(
-      sanitizeCustomHeaders("x-a: 1\n\nx-api-key: nope\nbadline\nanthropic-version: 1\nx-b: 2")
-    ).toBe("x-a: 1\nx-b: 2")
+describe("parseCustomHeaders", () => {
+  it("extracts auth headers, drops anthropic-version, and keeps the rest", () => {
+    const parsed = parseCustomHeaders(
+      "x-a: 1\n\nx-api-key: sk-1\nbadline\nanthropic-version: 1\nAuthorization: Bearer tok\nx-b: 2"
+    )
+    expect(parsed).toEqual({
+      apiKey: "sk-1",
+      authToken: "tok",
+      headers: "x-a: 1\nx-b: 2",
+    })
   })
 
-  it("returns undefined when nothing valid remains", () => {
-    expect(sanitizeCustomHeaders("Authorization: Bearer x\n\n")).toBeUndefined()
+  it("returns no headers blob when only auth lines remain", () => {
+    expect(parseCustomHeaders("Authorization: Bearer x\n\n")).toEqual({
+      authToken: "x",
+      apiKey: undefined,
+      headers: undefined,
+    })
+  })
+
+  it("accepts an Authorization value without a Bearer prefix", () => {
+    expect(parseCustomHeaders("Authorization: tok-raw").authToken).toBe("tok-raw")
   })
 })
 
@@ -93,15 +111,13 @@ describe("resolveCliModel", () => {
 })
 
 describe("hasCredentialsForModel — custom", () => {
-  it("requires a base URL plus at least one auth credential", () => {
+  it("requires only a base URL (auth is supplied via headers)", () => {
+    const none: CredentialFlags = {}
     const baseOnly: CredentialFlags = { CUSTOM_MODEL_BASE_URL: true }
-    const withApiKey: CredentialFlags = { CUSTOM_MODEL_BASE_URL: true, CUSTOM_MODEL_API_KEY: true }
-    const withToken: CredentialFlags = { CUSTOM_MODEL_BASE_URL: true, CUSTOM_MODEL_AUTH_TOKEN: true }
-    const authOnly: CredentialFlags = { CUSTOM_MODEL_API_KEY: true }
+    const headersOnly: CredentialFlags = { CUSTOM_MODEL_HEADERS: true }
 
-    expect(hasCredentialsForModel(customModel, baseOnly, "claude-code")).toBe(false)
-    expect(hasCredentialsForModel(customModel, authOnly, "claude-code")).toBe(false)
-    expect(hasCredentialsForModel(customModel, withApiKey, "claude-code")).toBe(true)
-    expect(hasCredentialsForModel(customModel, withToken, "claude-code")).toBe(true)
+    expect(hasCredentialsForModel(customModel, none, "claude-code")).toBe(false)
+    expect(hasCredentialsForModel(customModel, headersOnly, "claude-code")).toBe(false)
+    expect(hasCredentialsForModel(customModel, baseOnly, "claude-code")).toBe(true)
   })
 })

--- a/packages/common/src/agents.ts
+++ b/packages/common/src/agents.ts
@@ -62,10 +62,9 @@ export type CredentialId =
   | "KILO_API_KEY"
   // Custom Anthropic-compatible endpoint ("Custom model" tab). Stored encrypted
   // like every other credential; mapped to the standard ANTHROPIC_* env vars at
-  // injection time (see getEnvForModel / buildCustomModelEnv).
+  // injection time (see getEnvForModel / buildCustomModelEnv). Auth (API key or
+  // bearer token) is supplied through CUSTOM_MODEL_HEADERS, not a dedicated field.
   | "CUSTOM_MODEL_BASE_URL"
-  | "CUSTOM_MODEL_API_KEY"
-  | "CUSTOM_MODEL_AUTH_TOKEN"
   | "CUSTOM_MODEL_HEADERS"
   | "CUSTOM_MODEL_NAME"
 
@@ -358,13 +357,10 @@ export function hasCredentialsForModel(
 ): boolean {
   if (!model.requiresKey || model.requiresKey === "none") return true
   if (model.requiresKey === "custom") {
-    // Custom endpoint is usable once a base URL and at least one auth credential
-    // (API key or auth token) are configured. The CLI refuses to start with no
-    // auth at all, so we require at least one — see buildCustomModelEnv.
-    return (
-      !!flags?.CUSTOM_MODEL_BASE_URL &&
-      (!!flags?.CUSTOM_MODEL_API_KEY || !!flags?.CUSTOM_MODEL_AUTH_TOKEN)
-    )
+    // Custom endpoint is usable once a base URL is configured. Auth, if the
+    // endpoint needs it, is supplied via custom headers (x-api-key /
+    // Authorization) — see buildCustomModelEnv — so it isn't required here.
+    return !!flags?.CUSTOM_MODEL_BASE_URL
   }
   if (model.requiresKey === "anthropic") {
     // OpenCode and Pi require an API key — they can't drive a subscription session.
@@ -444,43 +440,54 @@ export function getEnvForModel(
   return env
 }
 
-/**
- * Header names a custom-headers blob must NOT set, so a user-supplied header
- * can't silently override authentication or API versioning. Compared
- * case-insensitively.
- */
-const CUSTOM_HEADER_BLOCKLIST = new Set([
-  "authorization",
-  "x-api-key",
-  "anthropic-version",
-])
+export interface ParsedCustomHeaders {
+  /** Value of an `x-api-key:` line, mapped to ANTHROPIC_API_KEY. */
+  apiKey?: string
+  /** Value of an `Authorization:` line (any `Bearer ` prefix stripped), mapped to ANTHROPIC_AUTH_TOKEN. */
+  authToken?: string
+  /** The remaining (non-auth) headers as a cleaned blob, or undefined if none. */
+  headers?: string
+}
 
 /**
- * Sanitize a user-supplied ANTHROPIC_CUSTOM_HEADERS blob (newline-separated
- * `Name: Value` pairs), dropping any line that targets a blocklisted header or
- * is malformed. Returns the cleaned blob, or undefined if nothing remains.
+ * Parse a user-supplied custom-headers blob (newline-separated `Name: Value`
+ * pairs). Auth headers are promoted to the canonical env vars the Claude CLI
+ * understands so the run actually authenticates (and the CLI starts):
+ *   `x-api-key: …`      → apiKey   (→ ANTHROPIC_API_KEY)
+ *   `Authorization: …`  → authToken (→ ANTHROPIC_AUTH_TOKEN, `Bearer ` stripped)
+ * `anthropic-version` is dropped (the CLI manages it). Everything else passes
+ * through as additional request headers. Malformed/empty lines are ignored.
  */
-export function sanitizeCustomHeaders(raw: string): string | undefined {
-  const kept = raw
-    .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => {
-      if (!line) return false
-      const idx = line.indexOf(":")
-      if (idx <= 0) return false // no name, or no colon
-      const name = line.slice(0, idx).trim().toLowerCase()
-      return !CUSTOM_HEADER_BLOCKLIST.has(name)
-    })
-  return kept.length > 0 ? kept.join("\n") : undefined
+export function parseCustomHeaders(raw: string): ParsedCustomHeaders {
+  let apiKey: string | undefined
+  let authToken: string | undefined
+  const kept: string[] = []
+  for (const line of raw.split("\n").map((l) => l.trim())) {
+    if (!line) continue
+    const idx = line.indexOf(":")
+    if (idx <= 0) continue // no name, or no colon
+    const name = line.slice(0, idx).trim().toLowerCase()
+    const value = line.slice(idx + 1).trim()
+    if (!value) continue
+    if (name === "x-api-key") {
+      apiKey = value
+    } else if (name === "authorization") {
+      authToken = value.replace(/^Bearer\s+/i, "")
+    } else if (name === "anthropic-version") {
+      // Managed by the CLI — ignore.
+    } else {
+      kept.push(`${line.slice(0, idx).trim()}: ${value}`)
+    }
+  }
+  return { apiKey, authToken, headers: kept.length > 0 ? kept.join("\n") : undefined }
 }
 
 /**
  * Map the stored CUSTOM_MODEL_* credentials to the standard Anthropic env vars
  * the Claude CLI understands:
- *   CUSTOM_MODEL_BASE_URL    → ANTHROPIC_BASE_URL
- *   CUSTOM_MODEL_API_KEY     → ANTHROPIC_API_KEY     (sent as x-api-key)
- *   CUSTOM_MODEL_AUTH_TOKEN  → ANTHROPIC_AUTH_TOKEN  (sent as Authorization: Bearer)
- *   CUSTOM_MODEL_HEADERS     → ANTHROPIC_CUSTOM_HEADERS (sanitized)
+ *   CUSTOM_MODEL_BASE_URL → ANTHROPIC_BASE_URL
+ *   CUSTOM_MODEL_HEADERS  → ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN (auth headers,
+ *                           promoted) + ANTHROPIC_CUSTOM_HEADERS (the rest)
  * The model NAME is applied separately as the CLI --model arg (resolveCliModel).
  * Deliberately never includes CLAUDE_CODE_CREDENTIALS, so a custom run can never
  * leak the shared-pool token.
@@ -488,10 +495,10 @@ export function sanitizeCustomHeaders(raw: string): string | undefined {
 export function buildCustomModelEnv(credentials: Credentials): Record<string, string> {
   const env: Record<string, string> = {}
   if (credentials.CUSTOM_MODEL_BASE_URL) env.ANTHROPIC_BASE_URL = credentials.CUSTOM_MODEL_BASE_URL
-  if (credentials.CUSTOM_MODEL_API_KEY) env.ANTHROPIC_API_KEY = credentials.CUSTOM_MODEL_API_KEY
-  if (credentials.CUSTOM_MODEL_AUTH_TOKEN) env.ANTHROPIC_AUTH_TOKEN = credentials.CUSTOM_MODEL_AUTH_TOKEN
   if (credentials.CUSTOM_MODEL_HEADERS) {
-    const headers = sanitizeCustomHeaders(credentials.CUSTOM_MODEL_HEADERS)
+    const { apiKey, authToken, headers } = parseCustomHeaders(credentials.CUSTOM_MODEL_HEADERS)
+    if (apiKey) env.ANTHROPIC_API_KEY = apiKey
+    if (authToken) env.ANTHROPIC_AUTH_TOKEN = authToken
     if (headers) env.ANTHROPIC_CUSTOM_HEADERS = headers
   }
   return env

--- a/packages/common/src/agents.ts
+++ b/packages/common/src/agents.ts
@@ -60,6 +60,14 @@ export type CredentialId =
   | "OPENCODE_API_KEY"
   | "GEMINI_API_KEY"
   | "KILO_API_KEY"
+  // Custom Anthropic-compatible endpoint ("Custom model" tab). Stored encrypted
+  // like every other credential; mapped to the standard ANTHROPIC_* env vars at
+  // injection time (see getEnvForModel / buildCustomModelEnv).
+  | "CUSTOM_MODEL_BASE_URL"
+  | "CUSTOM_MODEL_API_KEY"
+  | "CUSTOM_MODEL_AUTH_TOKEN"
+  | "CUSTOM_MODEL_HEADERS"
+  | "CUSTOM_MODEL_NAME"
 
 export type CredentialFlags = Partial<Record<CredentialId, boolean>> & {
   // Server has a shared Claude credential pool (e.g. the rotating row written
@@ -94,9 +102,20 @@ const PROVIDER_ENV: Record<ProviderId, CredentialId[]> = {
 export interface ModelOption {
   value: string
   label: string
-  /** Which provider's API key is required for this model. "none" means no key needed. */
-  requiresKey?: ProviderId | "none"
+  /**
+   * Which provider's API key is required for this model. "none" means no key
+   * needed. "custom" means the user-configured custom Anthropic endpoint (see
+   * the CUSTOM_MODEL_* credentials).
+   */
+  requiresKey?: ProviderId | "none" | "custom"
 }
+
+/**
+ * Sentinel model value for the user-configured custom Anthropic endpoint.
+ * When selected (claude-code only), the stored CUSTOM_MODEL_* credentials are
+ * injected as ANTHROPIC_* env vars instead of the shared pool / API key.
+ */
+export const CUSTOM_MODEL_VALUE = "custom"
 
 /**
  * Models allowed to run on the server-shared OpenCode API key.
@@ -129,6 +148,7 @@ export const agentModels: Record<Agent, ModelOption[]> = {
     { value: "sonnet", label: "Sonnet", requiresKey: "anthropic" },
     { value: "opus", label: "Opus", requiresKey: "anthropic" },
     { value: "haiku", label: "Haiku", requiresKey: "anthropic" },
+    { value: CUSTOM_MODEL_VALUE, label: "Custom model", requiresKey: "custom" },
   ],
   "eliza": [
     { value: "eliza-classic-1.0", label: "Eliza Classic", requiresKey: "none" },
@@ -337,6 +357,15 @@ export function hasCredentialsForModel(
   agent?: Agent
 ): boolean {
   if (!model.requiresKey || model.requiresKey === "none") return true
+  if (model.requiresKey === "custom") {
+    // Custom endpoint is usable once a base URL and at least one auth credential
+    // (API key or auth token) are configured. The CLI refuses to start with no
+    // auth at all, so we require at least one — see buildCustomModelEnv.
+    return (
+      !!flags?.CUSTOM_MODEL_BASE_URL &&
+      (!!flags?.CUSTOM_MODEL_API_KEY || !!flags?.CUSTOM_MODEL_AUTH_TOKEN)
+    )
+  }
   if (model.requiresKey === "anthropic") {
     // OpenCode and Pi require an API key — they can't drive a subscription session.
     if (agent === "opencode" || agent === "pi") return !!flags?.ANTHROPIC_API_KEY
@@ -391,6 +420,12 @@ export function getEnvForModel(
   agent: Agent | undefined,
   credentials: Credentials
 ): Record<string, string> {
+  // Custom Anthropic endpoint wins over everything (incl. the shared pool /
+  // subscription token) when the user explicitly selects the custom model.
+  if ((!agent || agent === "claude-code") && model === CUSTOM_MODEL_VALUE) {
+    return buildCustomModelEnv(credentials)
+  }
+
   // Claude Code: subscription token wins over API key.
   if ((!agent || agent === "claude-code") && credentials.CLAUDE_CODE_CREDENTIALS) {
     return { CLAUDE_CODE_CREDENTIALS: credentials.CLAUDE_CODE_CREDENTIALS }
@@ -398,6 +433,7 @@ export function getEnvForModel(
 
   const opt = agent ? (agentModels[agent] ?? []).find((m) => m.value === model) : undefined
   if (!opt?.requiresKey || opt.requiresKey === "none") return {}
+  if (opt.requiresKey === "custom") return buildCustomModelEnv(credentials)
 
   const env: Record<string, string> = {}
   for (const id of PROVIDER_ENV[opt.requiresKey]) {
@@ -406,6 +442,75 @@ export function getEnvForModel(
   }
   if (env.GEMINI_API_KEY) env.GOOGLE_API_KEY = env.GEMINI_API_KEY
   return env
+}
+
+/**
+ * Header names a custom-headers blob must NOT set, so a user-supplied header
+ * can't silently override authentication or API versioning. Compared
+ * case-insensitively.
+ */
+const CUSTOM_HEADER_BLOCKLIST = new Set([
+  "authorization",
+  "x-api-key",
+  "anthropic-version",
+])
+
+/**
+ * Sanitize a user-supplied ANTHROPIC_CUSTOM_HEADERS blob (newline-separated
+ * `Name: Value` pairs), dropping any line that targets a blocklisted header or
+ * is malformed. Returns the cleaned blob, or undefined if nothing remains.
+ */
+export function sanitizeCustomHeaders(raw: string): string | undefined {
+  const kept = raw
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => {
+      if (!line) return false
+      const idx = line.indexOf(":")
+      if (idx <= 0) return false // no name, or no colon
+      const name = line.slice(0, idx).trim().toLowerCase()
+      return !CUSTOM_HEADER_BLOCKLIST.has(name)
+    })
+  return kept.length > 0 ? kept.join("\n") : undefined
+}
+
+/**
+ * Map the stored CUSTOM_MODEL_* credentials to the standard Anthropic env vars
+ * the Claude CLI understands:
+ *   CUSTOM_MODEL_BASE_URL    → ANTHROPIC_BASE_URL
+ *   CUSTOM_MODEL_API_KEY     → ANTHROPIC_API_KEY     (sent as x-api-key)
+ *   CUSTOM_MODEL_AUTH_TOKEN  → ANTHROPIC_AUTH_TOKEN  (sent as Authorization: Bearer)
+ *   CUSTOM_MODEL_HEADERS     → ANTHROPIC_CUSTOM_HEADERS (sanitized)
+ * The model NAME is applied separately as the CLI --model arg (resolveCliModel).
+ * Deliberately never includes CLAUDE_CODE_CREDENTIALS, so a custom run can never
+ * leak the shared-pool token.
+ */
+export function buildCustomModelEnv(credentials: Credentials): Record<string, string> {
+  const env: Record<string, string> = {}
+  if (credentials.CUSTOM_MODEL_BASE_URL) env.ANTHROPIC_BASE_URL = credentials.CUSTOM_MODEL_BASE_URL
+  if (credentials.CUSTOM_MODEL_API_KEY) env.ANTHROPIC_API_KEY = credentials.CUSTOM_MODEL_API_KEY
+  if (credentials.CUSTOM_MODEL_AUTH_TOKEN) env.ANTHROPIC_AUTH_TOKEN = credentials.CUSTOM_MODEL_AUTH_TOKEN
+  if (credentials.CUSTOM_MODEL_HEADERS) {
+    const headers = sanitizeCustomHeaders(credentials.CUSTOM_MODEL_HEADERS)
+    if (headers) env.ANTHROPIC_CUSTOM_HEADERS = headers
+  }
+  return env
+}
+
+/**
+ * Resolve the model string passed to the CLI's --model flag. For the custom
+ * endpoint the dropdown value is the "custom" sentinel, so translate it to the
+ * user's configured model name (or undefined → endpoint default). All other
+ * models pass through unchanged.
+ */
+export function resolveCliModel(
+  model: string | undefined,
+  credentials: Credentials
+): string | undefined {
+  if (model === CUSTOM_MODEL_VALUE) {
+    return credentials.CUSTOM_MODEL_NAME || undefined
+  }
+  return model
 }
 
 /**

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -21,6 +21,7 @@ export {
   type ProviderName,
   type ProviderId,
   type ModelOption,
+  type ParsedCustomHeaders,
   type CredentialId,
   type CredentialFlags,
   type Credentials,
@@ -39,7 +40,7 @@ export {
   getModelLabel,
   getEnvForModel,
   buildCustomModelEnv,
-  sanitizeCustomHeaders,
+  parseCustomHeaders,
   resolveCliModel,
 } from "./agents"
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -31,12 +31,16 @@ export {
   agentModels,
   defaultAgentModel,
   agentSupportsPlanMode,
+  CUSTOM_MODEL_VALUE,
   // Functions
   getDefaultAgent,
   hasCredentialsForModel,
   getDefaultModelForAgent,
   getModelLabel,
   getEnvForModel,
+  buildCustomModelEnv,
+  sanitizeCustomHeaders,
+  resolveCliModel,
 } from "./agents"
 
 // GitHub client utilities

--- a/packages/web/app/api/chats/[chatId]/messages/route.ts
+++ b/packages/web/app/api/chats/[chatId]/messages/route.ts
@@ -23,7 +23,7 @@ import { checkSharedPoolUsage } from "@/lib/db/usage-limit"
 import { createBackgroundAgentSession, type Agent } from "@/lib/agent-session"
 import { loadMcpConnections } from "@/lib/mcp/agent-servers"
 import { getClaudeCredentials } from "@/lib/claude-credentials"
-import { getEnvForModel } from "@background-agents/common"
+import { getEnvForModel, resolveCliModel, CUSTOM_MODEL_VALUE } from "@background-agents/common"
 import { decrypt } from "@/lib/db/encryption"
 import {
   createSandboxForChat,
@@ -163,7 +163,7 @@ export async function POST(
   // Enforce the per-provider daily token budget on shared pools (free users
   // only). Returns allowed=true for own-key runs, Pro users, and agents without
   // a shared pool — so this is safe to call unconditionally.
-  const usageCheck = await checkSharedPoolUsage(userId, payload.agent as Agent)
+  const usageCheck = await checkSharedPoolUsage(userId, payload.agent as Agent, payload.model)
   if (!usageCheck.allowed) {
     logActivityAsync(userId, "daily_limit_reached", {
       provider: usageCheck.provider,
@@ -193,6 +193,7 @@ export async function POST(
   let useSharedClaude = false
   if (
     payload.agent === "claude-code" &&
+    payload.model !== CUSTOM_MODEL_VALUE &&
     !credentials.CLAUDE_CODE_CREDENTIALS
   ) {
     try {
@@ -507,7 +508,7 @@ export async function POST(
       // On agent switch, don't pass the old agent's sessionId — it would crash the new CLI
       sessionId: isAgentSwitch ? undefined : (chat.sessionId ?? undefined),
       agent: payload.agent as Agent,
-      model: payload.model,
+      model: resolveCliModel(payload.model, credentials),
       env: Object.keys(env).length > 0 ? env : undefined,
       planMode: payload.planMode,
       mcpServers,
@@ -523,7 +524,8 @@ export async function POST(
     })
     const usageMeta = buildUsageMeta(
       payload.agent as Agent,
-      decryptUserCredentials(storedUser?.credentials as Record<string, unknown> | null)
+      decryptUserCredentials(storedUser?.credentials as Record<string, unknown> | null),
+      payload.model
     )
 
     // ── Stage 5: persist messages + chat status (transactional) ────────────

--- a/packages/web/app/api/cron/agent-lifecycle/_lib/scheduled.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/_lib/scheduled.ts
@@ -3,7 +3,7 @@ import { Prisma } from "@prisma/client"
 import { randomUUID } from "crypto"
 import { format } from "date-fns"
 import { createSandboxGit } from "@background-agents/daytona-git"
-import { getEnvForModel, type Agent } from "@background-agents/common"
+import { getEnvForModel, resolveCliModel, CUSTOM_MODEL_VALUE, type Agent } from "@background-agents/common"
 
 import { prisma } from "@/lib/db/prisma"
 import { decryptUserCredentials, getUserCredentials } from "@/lib/db/api-helpers"
@@ -143,8 +143,13 @@ export async function startJobExecution(
   // 6. Get user credentials
   let credentials = await getUserCredentials(job.userId)
 
-  // Shared-pool fallback for Claude Code
-  if (job.agent === "claude-code" && !credentials.CLAUDE_CODE_CREDENTIALS) {
+  // Shared-pool fallback for Claude Code (skipped for custom-endpoint runs,
+  // which use the user's own endpoint rather than the shared pool).
+  if (
+    job.agent === "claude-code" &&
+    job.model !== CUSTOM_MODEL_VALUE &&
+    !credentials.CLAUDE_CODE_CREDENTIALS
+  ) {
     try {
       credentials = {
         ...credentials,
@@ -174,7 +179,7 @@ export async function startJobExecution(
     repoPath,
     previewUrlPattern: previewUrlPattern ?? undefined,
     agent: job.agent as Agent,
-    model: job.model ?? undefined,
+    model: resolveCliModel(job.model ?? undefined, credentials),
     env: Object.keys(env).length > 0 ? env : undefined,
     mcpServers,
   })
@@ -277,7 +282,8 @@ export async function startJobExecution(
   })
   const usageMeta = buildUsageMeta(
     job.agent as Agent,
-    decryptUserCredentials(storedUser?.credentials as Record<string, unknown> | null)
+    decryptUserCredentials(storedUser?.credentials as Record<string, unknown> | null),
+    job.model ?? undefined
   )
 
   await prisma.message.createMany({

--- a/packages/web/app/api/user/settings/route.ts
+++ b/packages/web/app/api/user/settings/route.ts
@@ -21,6 +21,8 @@ import { DEFAULT_SETTINGS } from "@/lib/storage"
 interface SettingsResponse {
   settings: Settings
   credentialFlags: CredentialFlags
+  /** Plaintext values for non-secret fields the UI shows unmasked (custom Base URL / Model ID). */
+  credentialValues: Partial<Record<CredentialId, string>>
   /** ISO timestamp when the daily Claude limit resets, or null if not limited */
   claudeLimitResetAt: string | null
   /** Remaining Claude Code messages today, or null if not applicable */
@@ -69,6 +71,7 @@ export async function GET(): Promise<Response> {
     const response: SettingsResponse = {
       settings: readSettings(user?.settings),
       credentialFlags: effective.flags,
+      credentialValues: effective.credentialValues,
       claudeLimitResetAt: effective.limitResetAt?.toISOString() ?? null,
       claudeLimitRemaining: effective.limitRemaining,
       claudeLimitUsed: effective.limitUsed,
@@ -146,6 +149,7 @@ export async function PATCH(req: NextRequest): Promise<Response> {
     const response: SettingsResponse = {
       settings: newSettings,
       credentialFlags: effective.flags,
+      credentialValues: effective.credentialValues,
       claudeLimitResetAt: effective.limitResetAt?.toISOString() ?? null,
       claudeLimitRemaining: effective.limitRemaining,
       claudeLimitUsed: effective.limitUsed,

--- a/packages/web/app/api/user/settings/route.ts
+++ b/packages/web/app/api/user/settings/route.ts
@@ -21,7 +21,7 @@ import { DEFAULT_SETTINGS } from "@/lib/storage"
 interface SettingsResponse {
   settings: Settings
   credentialFlags: CredentialFlags
-  /** Plaintext values for non-secret fields the UI shows unmasked (custom Base URL / Model ID). */
+  /** Plaintext values for the custom-model fields the UI shows unmasked (Base URL / Model ID / Headers). */
   credentialValues: Partial<Record<CredentialId, string>>
   /** ISO timestamp when the daily Claude limit resets, or null if not limited */
   claudeLimitResetAt: string | null

--- a/packages/web/components/chat/AgentModelSelector.tsx
+++ b/packages/web/components/chat/AgentModelSelector.tsx
@@ -97,7 +97,9 @@ export function AgentModelSelector({
       if (newModelConfig && !hasCredentialsForModel(newModelConfig, credentialFlags, agent)) {
         // Open settings with the required key highlighted
         const requiredKey = newModelConfig.requiresKey
-        if (requiredKey && requiredKey !== "none") {
+        if (requiredKey === "custom") {
+          modals.openSettingsSection("custom-model")
+        } else if (requiredKey && requiredKey !== "none") {
           modals.openSettings(requiredKey as HighlightKey)
         }
       }
@@ -115,7 +117,9 @@ export function AgentModelSelector({
       if (newModelConfig && !hasCredentialsForModel(newModelConfig, credentialFlags, currentAgent)) {
         // Open settings with the required key highlighted
         const requiredKey = newModelConfig.requiresKey
-        if (requiredKey && requiredKey !== "none") {
+        if (requiredKey === "custom") {
+          modals.openSettingsSection("custom-model")
+        } else if (requiredKey && requiredKey !== "none") {
           modals.openSettings(requiredKey as HighlightKey)
         }
       }

--- a/packages/web/components/modals/SettingsModal.tsx
+++ b/packages/web/components/modals/SettingsModal.tsx
@@ -80,8 +80,8 @@ export function SettingsModal({ open, onClose, settings, credentialFlags, onSave
   const { setTheme } = useTheme()
   const { isDesktopApp, getClaudeLicenseAutoDetect, getLicenseDetectSettings, setLicenseDetectSettings } = useElectron()
 
-  // Plaintext values for non-secret fields (custom Base URL / Model ID) so they
-  // render unmasked and editable. Read from the shared settings query cache.
+  // Plaintext values for the custom-model fields (Base URL / Model ID / Headers)
+  // so they render unmasked and editable. Read from the shared settings query cache.
   const { data: settingsData } = useSettingsQuery()
   const credentialValues = settingsData?.credentialValues
 

--- a/packages/web/components/modals/SettingsModal.tsx
+++ b/packages/web/components/modals/SettingsModal.tsx
@@ -14,6 +14,7 @@ import {
   CREDENTIAL_KEYS,
   type CredentialId,
 } from "@/lib/credentials"
+import { useSettingsQuery } from "@/lib/query/hooks/useSettingsQuery"
 import {
   GeneralSection,
   ApiKeysSection,
@@ -79,6 +80,11 @@ export function SettingsModal({ open, onClose, settings, credentialFlags, onSave
   const { setTheme } = useTheme()
   const { isDesktopApp, getClaudeLicenseAutoDetect, getLicenseDetectSettings, setLicenseDetectSettings } = useElectron()
 
+  // Plaintext values for non-secret fields (custom Base URL / Model ID) so they
+  // render unmasked and editable. Read from the shared settings query cache.
+  const { data: settingsData } = useSettingsQuery()
+  const credentialValues = settingsData?.credentialValues
+
   // The "Local Sync" tab only exists in the desktop app.
   const sections = useMemo(() => getSections(isDesktopApp), [isDesktopApp])
 
@@ -99,9 +105,12 @@ export function SettingsModal({ open, onClose, settings, credentialFlags, onSave
 
   // Form state
   const [credValues, setCredValues] = useState<Record<CredentialId, string>>(() =>
-    initialCredValues(credentialFlags)
+    initialCredValues(credentialFlags, credentialValues)
   )
-  const initialCreds = useMemo(() => initialCredValues(credentialFlags), [credentialFlags])
+  const initialCreds = useMemo(
+    () => initialCredValues(credentialFlags, credentialValues),
+    [credentialFlags, credentialValues]
+  )
 
   // Resolve null preference against current credential flags so the dropdown
   // shows whatever new chats would actually use. Snapshotted off saved flags
@@ -144,7 +153,7 @@ export function SettingsModal({ open, onClose, settings, credentialFlags, onSave
   // Reset form when modal opens
   useEffect(() => {
     if (open) {
-      setCredValues(initialCredValues(credentialFlags))
+      setCredValues(initialCredValues(credentialFlags, credentialValues))
       setDefaultAgent(initialDefaultAgent)
       setDefaultModel(initialDefaultModel)
       setSelectedTheme(settings.theme)
@@ -155,7 +164,7 @@ export function SettingsModal({ open, onClose, settings, credentialFlags, onSave
       setNotificationSound(settings.notificationSound)
       setActiveSection(defaultSection)
     }
-  }, [open, settings, credentialFlags, initialDefaultAgent, initialDefaultModel, defaultSection])
+  }, [open, settings, credentialFlags, credentialValues, initialDefaultAgent, initialDefaultModel, defaultSection])
 
   // Refresh license detection
   const refreshLicenseDetect = useCallback(async () => {

--- a/packages/web/components/modals/SettingsModal.tsx
+++ b/packages/web/components/modals/SettingsModal.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from "react"
 import { useTheme } from "next-themes"
 import * as Dialog from "@radix-ui/react-dialog"
-import { X, Key, Sun, Bot, Settings as SettingsIcon, GitBranch, FlaskConical, FolderDown, Bell, Gauge } from "lucide-react"
+import { X, Key, Sun, Bot, Settings as SettingsIcon, GitBranch, FlaskConical, FolderDown, Bell, Gauge, Server } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { focusChatPrompt } from "@/components/ui/modal-header"
 import { useDragToClose } from "@/lib/hooks/useDragToClose"
@@ -17,6 +17,7 @@ import {
 import {
   GeneralSection,
   ApiKeysSection,
+  CustomModelSection,
   UsageSection,
   GitSection,
   NotificationsSection,
@@ -32,7 +33,7 @@ import {
 export type { HighlightKey }
 
 /** Settings modal section identifier */
-export type SectionKey = "general" | "api-keys" | "usage" | "git" | "notifications" | "local-sync" | "appearance" | "experimental"
+export type SectionKey = "general" | "api-keys" | "custom-model" | "usage" | "git" | "notifications" | "local-sync" | "appearance" | "experimental"
 
 interface SettingsModalProps {
   open: boolean
@@ -55,6 +56,7 @@ type SectionDef = { key: SectionKey; label: string; icon: typeof Bot }
 const baseSections: SectionDef[] = [
   { key: "general", label: "General", icon: SettingsIcon },
   { key: "api-keys", label: "API Keys", icon: Key },
+  { key: "custom-model", label: "Custom model", icon: Server },
   { key: "usage", label: "Usage", icon: Gauge },
   { key: "appearance", label: "Appearance", icon: Sun },
   { key: "git", label: "Git", icon: GitBranch },
@@ -365,6 +367,14 @@ export function SettingsModal({ open, onClose, settings, credentialFlags, onSave
             refreshLicenseDetect={refreshLicenseDetect}
             licenseDetectLoading={licenseDetectLoading}
             licenseDetectResult={licenseDetectResult}
+          />
+        )
+      case "custom-model":
+        return (
+          <CustomModelSection
+            isMobile={isMobile}
+            credValues={credValues}
+            setCredValue={setCredValue}
           />
         )
       case "usage":

--- a/packages/web/components/modals/settings/ApiKeysSection.tsx
+++ b/packages/web/components/modals/settings/ApiKeysSection.tsx
@@ -90,7 +90,7 @@ export function ApiKeysSection({
   return (
     <div>
       {isMobile && <MobileSectionHeader icon={Key} label="API Keys" />}
-      {CREDENTIAL_KEYS.map((field) => {
+      {CREDENTIAL_KEYS.filter((field) => field.group !== "custom-model").map((field) => {
         const isHighlighted =
           highlightKey === field.provider &&
           // Highlight only the first field for the matching provider.

--- a/packages/web/components/modals/settings/CustomModelSection.tsx
+++ b/packages/web/components/modals/settings/CustomModelSection.tsx
@@ -1,0 +1,117 @@
+"use client"
+
+import { Server } from "lucide-react"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { CREDENTIAL_KEYS, type CredentialId } from "@/lib/credentials"
+import { SettingsRow, PasswordInput, MobileSectionHeader } from "./shared"
+
+interface CustomModelSectionProps {
+  isMobile: boolean
+  credValues: Record<CredentialId, string>
+  setCredValue: (id: CredentialId, value: string) => void
+}
+
+/** Fields rendered as masked password inputs (the secret ones). */
+const SECRET_FIELDS = new Set<CredentialId>([
+  "CUSTOM_MODEL_API_KEY",
+  "CUSTOM_MODEL_AUTH_TOKEN",
+])
+
+/**
+ * "Custom model" tab: point runs at a custom Anthropic-compatible endpoint
+ * instead of the shared pool. Base URL plus at least one of API key / auth
+ * token are required (the Claude CLI refuses to start with no auth). When
+ * configured, a "Custom model" option appears in the chat model dropdown.
+ */
+export function CustomModelSection({
+  isMobile,
+  credValues,
+  setCredValue,
+}: CustomModelSectionProps) {
+  const fields = CREDENTIAL_KEYS.filter((f) => f.group === "custom-model")
+
+  const baseUrl = credValues["CUSTOM_MODEL_BASE_URL"]
+  const apiKey = credValues["CUSTOM_MODEL_API_KEY"]
+  const authToken = credValues["CUSTOM_MODEL_AUTH_TOKEN"]
+  // A field counts as "present" whether it holds a typed value or the "***"
+  // mask for an already-saved secret.
+  const hasBaseUrl = !!baseUrl
+  const hasAuth = !!apiKey || !!authToken
+  const showAuthWarning = hasBaseUrl && !hasAuth
+
+  return (
+    <div>
+      {isMobile && <MobileSectionHeader icon={Server} label="Custom model" />}
+
+      <p className="text-xs text-muted-foreground mb-2">
+        Route runs to a custom Anthropic-compatible endpoint (your own key, a
+        gateway, or a proxy) instead of the shared pool. Requires a Base URL and
+        at least one of API key / Auth token. Select &ldquo;Custom model&rdquo;
+        in the model dropdown to use it.
+      </p>
+
+      {fields.map((field) => {
+        const value = credValues[field.id]
+
+        if (field.multiline) {
+          return (
+            <SettingsRow
+              key={field.id}
+              label={field.label}
+              description="Optional. Authorization, x-api-key and anthropic-version are ignored."
+              stacked
+            >
+              <Textarea
+                value={value}
+                onChange={(e) => setCredValue(field.id, e.target.value)}
+                placeholder={field.placeholder}
+                rows={3}
+                autoComplete="off"
+                spellCheck={false}
+                data-lpignore="true"
+                data-1p-ignore="true"
+                data-bwignore="true"
+                data-form-type="other"
+                className="font-mono text-xs"
+              />
+            </SettingsRow>
+          )
+        }
+
+        if (SECRET_FIELDS.has(field.id)) {
+          return (
+            <SettingsRow key={field.id} label={field.label}>
+              <PasswordInput
+                value={value}
+                onChange={(v) => setCredValue(field.id, v)}
+                placeholder={field.placeholder}
+              />
+            </SettingsRow>
+          )
+        }
+
+        // Non-secret single-line fields (Base URL, Model name).
+        return (
+          <SettingsRow key={field.id} label={field.label}>
+            <Input
+              value={value}
+              onChange={(e) => setCredValue(field.id, e.target.value)}
+              placeholder={field.placeholder}
+              autoComplete="off"
+              spellCheck={false}
+              className="w-56 font-mono"
+            />
+          </SettingsRow>
+        )
+      })}
+
+      {showAuthWarning && (
+        <p className="mt-3 text-xs text-destructive">
+          Add an API key or an Auth token — the endpoint won&apos;t authenticate
+          without one.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/packages/web/components/modals/settings/CustomModelSection.tsx
+++ b/packages/web/components/modals/settings/CustomModelSection.tsx
@@ -4,7 +4,7 @@ import { Server } from "lucide-react"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { CREDENTIAL_KEYS, type CredentialId } from "@/lib/credentials"
-import { SettingsRow, PasswordInput, MobileSectionHeader } from "./shared"
+import { SettingsRow, MobileSectionHeader } from "./shared"
 
 interface CustomModelSectionProps {
   isMobile: boolean
@@ -12,17 +12,11 @@ interface CustomModelSectionProps {
   setCredValue: (id: CredentialId, value: string) => void
 }
 
-/** Fields rendered as masked password inputs (the secret ones). */
-const SECRET_FIELDS = new Set<CredentialId>([
-  "CUSTOM_MODEL_API_KEY",
-  "CUSTOM_MODEL_AUTH_TOKEN",
-])
-
 /**
  * "Custom model" tab: point runs at a custom Anthropic-compatible endpoint
- * instead of the shared pool. Base URL plus at least one of API key / auth
- * token are required (the Claude CLI refuses to start with no auth). When
- * configured, a "Custom model" option appears in the chat model dropdown.
+ * instead of the shared pool. Only the Base URL is required; authentication is
+ * supplied through the Headers field (x-api-key or Authorization). When a Base
+ * URL is set, a "Custom model" option appears in the chat model dropdown.
  */
 export function CustomModelSection({
   isMobile,
@@ -31,35 +25,34 @@ export function CustomModelSection({
 }: CustomModelSectionProps) {
   const fields = CREDENTIAL_KEYS.filter((f) => f.group === "custom-model")
 
-  const baseUrl = credValues["CUSTOM_MODEL_BASE_URL"]
-  const apiKey = credValues["CUSTOM_MODEL_API_KEY"]
-  const authToken = credValues["CUSTOM_MODEL_AUTH_TOKEN"]
-  // A field counts as "present" whether it holds a typed value or the "***"
-  // mask for an already-saved secret.
-  const hasBaseUrl = !!baseUrl
-  const hasAuth = !!apiKey || !!authToken
-  const showAuthWarning = hasBaseUrl && !hasAuth
-
   return (
     <div>
       {isMobile && <MobileSectionHeader icon={Server} label="Custom model" />}
 
       <p className="text-xs text-muted-foreground mb-2">
         Route runs to a custom Anthropic-compatible endpoint (your own key, a
-        gateway, or a proxy) instead of the shared pool. Requires a Base URL and
-        at least one of API key / Auth token. Select &ldquo;Custom model&rdquo;
-        in the model dropdown to use it.
+        gateway, or a proxy) instead of the shared pool. Only a Base URL is
+        required — add authentication (e.g. <code>x-api-key</code> or{" "}
+        <code>Authorization</code>) in the Headers field. Select &ldquo;Custom
+        model&rdquo; in the model dropdown to use it.
       </p>
 
       {fields.map((field) => {
         const value = credValues[field.id]
+        const label = field.required ? (
+          <>
+            {field.label} <span className="text-destructive">*</span>
+          </>
+        ) : (
+          field.label
+        )
 
         if (field.multiline) {
           return (
             <SettingsRow
               key={field.id}
-              label={field.label}
-              description="Optional. Authorization, x-api-key and anthropic-version are ignored."
+              label={label}
+              description={field.description}
               stacked
             >
               <Textarea
@@ -79,21 +72,8 @@ export function CustomModelSection({
           )
         }
 
-        if (SECRET_FIELDS.has(field.id)) {
-          return (
-            <SettingsRow key={field.id} label={field.label}>
-              <PasswordInput
-                value={value}
-                onChange={(v) => setCredValue(field.id, v)}
-                placeholder={field.placeholder}
-              />
-            </SettingsRow>
-          )
-        }
-
-        // Non-secret single-line fields (Base URL, Model name).
         return (
-          <SettingsRow key={field.id} label={field.label}>
+          <SettingsRow key={field.id} label={label} description={field.description}>
             <Input
               value={value}
               onChange={(e) => setCredValue(field.id, e.target.value)}
@@ -105,13 +85,6 @@ export function CustomModelSection({
           </SettingsRow>
         )
       })}
-
-      {showAuthWarning && (
-        <p className="mt-3 text-xs text-destructive">
-          Add an API key or an Auth token — the endpoint won&apos;t authenticate
-          without one.
-        </p>
-      )}
     </div>
   )
 }

--- a/packages/web/components/modals/settings/index.ts
+++ b/packages/web/components/modals/settings/index.ts
@@ -1,5 +1,6 @@
 export { GeneralSection } from "./GeneralSection"
 export { ApiKeysSection, type HighlightKey } from "./ApiKeysSection"
+export { CustomModelSection } from "./CustomModelSection"
 export { UsageSection } from "./UsageSection"
 export { GitSection } from "./GitSection"
 export { NotificationsSection } from "./NotificationsSection"

--- a/packages/web/components/modals/settings/shared.tsx
+++ b/packages/web/components/modals/settings/shared.tsx
@@ -11,11 +11,18 @@ import type { CredentialFlags } from "@/lib/types"
 /** Placeholder shown in API-key fields for credentials the server already has. */
 export const MASK = "***"
 
-/** Initial input values: "***" for credentials the server already has, "" otherwise. */
-export function initialCredValues(flags: CredentialFlags): Record<CredentialId, string> {
+/**
+ * Initial input values: a real plaintext value when the server returns one (for
+ * non-secret fields like the custom Base URL / Model ID), otherwise "***" for
+ * credentials the server has but won't echo back, or "" when unset.
+ */
+export function initialCredValues(
+  flags: CredentialFlags,
+  values?: Partial<Record<CredentialId, string>>
+): Record<CredentialId, string> {
   const out = {} as Record<CredentialId, string>
   for (const { id } of CREDENTIAL_KEYS) {
-    out[id] = flags[id] ? MASK : ""
+    out[id] = values?.[id] ?? (flags[id] ? MASK : "")
   }
   return out
 }

--- a/packages/web/components/modals/settings/shared.tsx
+++ b/packages/web/components/modals/settings/shared.tsx
@@ -12,9 +12,9 @@ import type { CredentialFlags } from "@/lib/types"
 export const MASK = "***"
 
 /**
- * Initial input values: a real plaintext value when the server returns one (for
- * non-secret fields like the custom Base URL / Model ID), otherwise "***" for
- * credentials the server has but won't echo back, or "" when unset.
+ * Initial input values: a real plaintext value when the server returns one (the
+ * custom-model fields, which are editable), otherwise "***" for credentials the
+ * server has but won't echo back, or "" when unset.
  */
 export function initialCredValues(
   flags: CredentialFlags,

--- a/packages/web/lib/credentials.ts
+++ b/packages/web/lib/credentials.ts
@@ -26,6 +26,12 @@ export interface CredentialField {
   placeholder?: string
   multiline?: boolean
   description?: string
+  /**
+   * Which settings tab renders this field. Defaults to "api-keys". Fields in
+   * the "custom-model" group are rendered on the dedicated Custom model tab and
+   * filtered out of the API Keys tab.
+   */
+  group?: "api-keys" | "custom-model"
 }
 
 export const CREDENTIAL_KEYS: readonly CredentialField[] = [
@@ -77,6 +83,43 @@ export const CREDENTIAL_KEYS: readonly CredentialField[] = [
     provider: "gemini",
     label: "Google AI (Gemini)",
     helpUrl: "https://aistudio.google.com/apikey",
+  },
+  // Custom Anthropic-compatible endpoint — rendered on the "Custom model" tab.
+  {
+    id: "CUSTOM_MODEL_BASE_URL",
+    provider: "anthropic",
+    label: "Base URL",
+    placeholder: "https://api.anthropic.com",
+    group: "custom-model",
+  },
+  {
+    id: "CUSTOM_MODEL_API_KEY",
+    provider: "anthropic",
+    label: "API key",
+    placeholder: "sk-ant-… (sent as x-api-key)",
+    group: "custom-model",
+  },
+  {
+    id: "CUSTOM_MODEL_AUTH_TOKEN",
+    provider: "anthropic",
+    label: "Auth token",
+    placeholder: "sent as Authorization: Bearer",
+    group: "custom-model",
+  },
+  {
+    id: "CUSTOM_MODEL_NAME",
+    provider: "anthropic",
+    label: "Model name",
+    placeholder: "Custom model",
+    group: "custom-model",
+  },
+  {
+    id: "CUSTOM_MODEL_HEADERS",
+    provider: "anthropic",
+    label: "Custom headers",
+    multiline: true,
+    placeholder: "One per line — Header-Name: value",
+    group: "custom-model",
   },
 ] as const
 

--- a/packages/web/lib/credentials.ts
+++ b/packages/web/lib/credentials.ts
@@ -26,6 +26,8 @@ export interface CredentialField {
   placeholder?: string
   multiline?: boolean
   description?: string
+  /** Marks a field the user must fill in. Rendered with a required indicator. */
+  required?: boolean
   /**
    * Which settings tab renders this field. Defaults to "api-keys". Fields in
    * the "custom-model" group are rendered on the dedicated Custom model tab and
@@ -85,40 +87,31 @@ export const CREDENTIAL_KEYS: readonly CredentialField[] = [
     helpUrl: "https://aistudio.google.com/apikey",
   },
   // Custom Anthropic-compatible endpoint — rendered on the "Custom model" tab.
+  // Required field comes first; auth is supplied through the headers field.
   {
     id: "CUSTOM_MODEL_BASE_URL",
     provider: "anthropic",
     label: "Base URL",
     placeholder: "https://api.anthropic.com",
-    group: "custom-model",
-  },
-  {
-    id: "CUSTOM_MODEL_API_KEY",
-    provider: "anthropic",
-    label: "API key",
-    placeholder: "sk-ant-… (sent as x-api-key)",
-    group: "custom-model",
-  },
-  {
-    id: "CUSTOM_MODEL_AUTH_TOKEN",
-    provider: "anthropic",
-    label: "Auth token",
-    placeholder: "sent as Authorization: Bearer",
+    required: true,
     group: "custom-model",
   },
   {
     id: "CUSTOM_MODEL_NAME",
     provider: "anthropic",
-    label: "Model name",
-    placeholder: "Custom model",
+    label: "Model ID",
+    placeholder: "claude-opus-4-1 (sent to --model)",
+    description: "The exact model ID the endpoint expects. Leave blank to use its default.",
     group: "custom-model",
   },
   {
     id: "CUSTOM_MODEL_HEADERS",
     provider: "anthropic",
-    label: "Custom headers",
+    label: "Headers",
     multiline: true,
-    placeholder: "One per line — Header-Name: value",
+    placeholder: "x-api-key: sk-ant-…\n# or: Authorization: Bearer <token>",
+    description:
+      "One per line — Header-Name: value. Put auth here: x-api-key or Authorization. anthropic-version is managed for you.",
     group: "custom-model",
   },
 ] as const

--- a/packages/web/lib/db/usage-limit.ts
+++ b/packages/web/lib/db/usage-limit.ts
@@ -50,7 +50,8 @@ export interface UsageLimitResult {
  */
 export async function checkSharedPoolUsage(
   userId: string,
-  agent: Agent
+  agent: Agent,
+  model?: string
 ): Promise<UsageLimitResult> {
   const provider = providerForAgent(agent)
   const resetAt = getNextUtcDayReset()
@@ -64,7 +65,9 @@ export async function checkSharedPoolUsage(
   const storedCreds = decryptUserCredentials(
     user?.credentials as Record<string, unknown> | null
   )
-  const pool = resolvePool(agent, storedCreds)
+  // A custom-endpoint run uses the user's own endpoint, not the shared pool, so
+  // it should never be rate-limited as shared.
+  const pool = resolvePool(agent, storedCreds, model)
 
   const budget = getProviderBudget(provider, plan)
 

--- a/packages/web/lib/query/hooks/useSettingsQuery.ts
+++ b/packages/web/lib/query/hooks/useSettingsQuery.ts
@@ -4,12 +4,13 @@ import { useQuery } from "@tanstack/react-query"
 import { useSession } from "next-auth/react"
 import { queryKeys } from "../keys"
 import { fetchSettings } from "@/lib/sync/api"
-import type { Settings, CredentialFlags } from "@/lib/types"
+import type { Settings, CredentialFlags, CredentialId } from "@/lib/types"
 import { DEFAULT_SETTINGS } from "@/lib/storage"
 
 export interface SettingsData {
   settings: Settings
   credentialFlags: CredentialFlags
+  credentialValues?: Partial<Record<CredentialId, string>>
   claudeLimitResetAt?: string | null
   claudeLimitRemaining?: number | null
   claudeLimitUsed?: number | null
@@ -33,6 +34,7 @@ export function useSettingsQuery() {
       return {
         settings: response.settings,
         credentialFlags: response.credentialFlags,
+        credentialValues: response.credentialValues,
         claudeLimitResetAt: response.claudeLimitResetAt,
         claudeLimitRemaining: response.claudeLimitRemaining,
         claudeLimitUsed: response.claudeLimitUsed,

--- a/packages/web/lib/query/hooks/useUpdateSettingsMutation.ts
+++ b/packages/web/lib/query/hooks/useUpdateSettingsMutation.ts
@@ -46,10 +46,19 @@ export function useUpdateSettingsMutation() {
       return { previousSettings }
     },
     onSuccess: (response) => {
-      // Update with server response (includes new credential flags)
+      // Update with the full server response. Must carry every field —
+      // dropping any (e.g. credentialValues or the claudeLimit* fields) would
+      // blank it in the cache until the next refetch.
       queryClient.setQueryData<SettingsData>(queryKeys.settings.all, {
         settings: response.settings,
         credentialFlags: response.credentialFlags,
+        credentialValues: response.credentialValues,
+        claudeLimitResetAt: response.claudeLimitResetAt,
+        claudeLimitRemaining: response.claudeLimitRemaining,
+        claudeLimitUsed: response.claudeLimitUsed,
+        claudeLimitTotal: response.claudeLimitTotal,
+        claudeIsPro: response.claudeIsPro,
+        claudeIsWeekly: response.claudeIsWeekly,
       })
     },
     onError: (err, _, context) => {

--- a/packages/web/lib/server/credential-flags.ts
+++ b/packages/web/lib/server/credential-flags.ts
@@ -20,8 +20,8 @@ import { flagsFromCredentials, CREDENTIAL_KEYS, type CredentialFlags, type Crede
 export interface EffectiveFlags {
   flags: CredentialFlags
   /**
-   * Plaintext values for non-secret credential fields the UI shows unmasked
-   * (the custom-model Base URL / Model ID). Secrets are never included.
+   * Plaintext values for the custom-model fields the UI shows unmasked and
+   * editable (Base URL / Model ID / Headers). Other credentials stay masked.
    */
   credentialValues: Partial<Record<CredentialId, string>>
   limitResetAt: Date | null
@@ -73,12 +73,13 @@ export async function getEffectiveCredentialFlags(userId: string): Promise<Effec
   // distinguish between user-owned keys and server-shared env keys.
   const flags = flagsFromCredentials(storedCreds)
 
-  // Echo back plaintext for the non-secret custom-model fields (single-line
-  // ones — Base URL / Model ID) so the UI can show them unmasked and editable.
-  // The multiline Headers field carries auth, so it stays masked.
+  // Echo back plaintext for all custom-model fields (Base URL, Model ID, and the
+  // Headers blob) so the UI can show them unmasked and editable. The Headers
+  // field can carry auth, so its contents are returned to the authenticated
+  // owner's own client — an accepted trade-off for editability.
   const credentialValues: Partial<Record<CredentialId, string>> = {}
   for (const f of CREDENTIAL_KEYS) {
-    if (f.group === "custom-model" && !f.multiline && storedCreds[f.id]) {
+    if (f.group === "custom-model" && storedCreds[f.id]) {
       credentialValues[f.id] = storedCreds[f.id]
     }
   }

--- a/packages/web/lib/server/credential-flags.ts
+++ b/packages/web/lib/server/credential-flags.ts
@@ -15,10 +15,15 @@ import {
   getNextUtcWeekReset,
   type Plan,
 } from "@/lib/server/usage-budgets"
-import { flagsFromCredentials, CREDENTIAL_KEYS, type CredentialFlags } from "@/lib/credentials"
+import { flagsFromCredentials, CREDENTIAL_KEYS, type CredentialFlags, type CredentialId } from "@/lib/credentials"
 
 export interface EffectiveFlags {
   flags: CredentialFlags
+  /**
+   * Plaintext values for non-secret credential fields the UI shows unmasked
+   * (the custom-model Base URL / Model ID). Secrets are never included.
+   */
+  credentialValues: Partial<Record<CredentialId, string>>
   limitResetAt: Date | null
   /** Remaining limited tokens (cache-excluded) for free users; null = unlimited. */
   limitRemaining: number | null
@@ -67,6 +72,16 @@ export async function getEffectiveCredentialFlags(userId: string): Promise<Effec
   // Build flags from the stored (user-provided) credentials so we can
   // distinguish between user-owned keys and server-shared env keys.
   const flags = flagsFromCredentials(storedCreds)
+
+  // Echo back plaintext for the non-secret custom-model fields (single-line
+  // ones — Base URL / Model ID) so the UI can show them unmasked and editable.
+  // The multiline Headers field carries auth, so it stays masked.
+  const credentialValues: Partial<Record<CredentialId, string>> = {}
+  for (const f of CREDENTIAL_KEYS) {
+    if (f.group === "custom-model" && !f.multiline && storedCreds[f.id]) {
+      credentialValues[f.id] = storedCreds[f.id]
+    }
+  }
 
   // Special-case: mark whether OPENCODE_API_KEY comes from the user's stored
   // credentials (user-owned) or only from the server environment (shared).
@@ -132,5 +147,5 @@ export async function getEffectiveCredentialFlags(userId: string): Promise<Effec
     }
   }
 
-  return { flags, limitResetAt, limitRemaining, limitUsed, limitTotal, isPro, isWeekly, plan }
+  return { flags, credentialValues, limitResetAt, limitRemaining, limitUsed, limitTotal, isPro, isWeekly, plan }
 }

--- a/packages/web/lib/server/shared-pool.ts
+++ b/packages/web/lib/server/shared-pool.ts
@@ -16,6 +16,7 @@
 
 import {
   agentToProvider,
+  CUSTOM_MODEL_VALUE,
   type Agent,
   type Credentials,
   type ProviderName,
@@ -41,10 +42,19 @@ export function providerForAgent(agent: Agent): ProviderName {
  * `storedCreds` MUST be the user's DB-stored credentials WITHOUT process.env
  * fallback, so server env keys correctly read as shared rather than user-owned.
  * Non-shared-pool agents are always "user".
+ *
+ * `model` lets a per-run custom-endpoint selection read as "user" even when the
+ * account has no stored Claude token (the run uses the user's own endpoint, not
+ * the shared pool). Omit it for account-level checks.
  */
-export function resolvePool(agent: Agent, storedCreds: Credentials): UsagePool {
+export function resolvePool(
+  agent: Agent,
+  storedCreds: Credentials,
+  model?: string
+): UsagePool {
   switch (agent) {
     case "claude-code":
+      if (model === CUSTOM_MODEL_VALUE) return "user"
       return storedCreds.CLAUDE_CODE_CREDENTIALS ? "user" : "shared"
     case "gemini":
       return storedCreds.GEMINI_API_KEY ? "user" : "shared"
@@ -66,8 +76,12 @@ export interface UsageMeta {
 }
 
 /** Build the metadata blob to stamp on the assistant message. */
-export function buildUsageMeta(agent: Agent, storedCreds: Credentials): UsageMeta {
-  return { pool: resolvePool(agent, storedCreds), provider: providerForAgent(agent) }
+export function buildUsageMeta(
+  agent: Agent,
+  storedCreds: Credentials,
+  model?: string
+): UsageMeta {
+  return { pool: resolvePool(agent, storedCreds, model), provider: providerForAgent(agent) }
 }
 
 /**

--- a/packages/web/lib/sync/api.ts
+++ b/packages/web/lib/sync/api.ts
@@ -7,7 +7,7 @@
  */
 
 import type { Chat, Message, Settings } from "@/lib/types"
-import type { Credentials, CredentialFlags } from "@/lib/credentials"
+import type { Credentials, CredentialFlags, CredentialId } from "@/lib/credentials"
 
 // =============================================================================
 // Types
@@ -60,6 +60,7 @@ export interface ChatWithMessagesResponse extends ChatResponse {
 export interface SettingsResponse {
   settings: Settings
   credentialFlags: CredentialFlags
+  credentialValues?: Partial<Record<CredentialId, string>>
   claudeLimitResetAt?: string | null
   claudeLimitRemaining?: number | null
   claudeLimitUsed?: number | null

--- a/packages/web/lib/types.ts
+++ b/packages/web/lib/types.ts
@@ -18,6 +18,7 @@ export {
   agentModels,
   agentLabels,
   agentSupportsPlanMode,
+  CUSTOM_MODEL_VALUE,
   getDefaultAgent,
   getDefaultModelForAgent,
   getModelLabel,


### PR DESCRIPTION
Lets users point Claude Code runs at a custom Anthropic-compatible endpoint (their own key, a gateway, or a proxy) instead of the shared pool. Implements GitHub issue #154.

- New CUSTOM_MODEL_* credentials (base URL, API key, auth token, headers, model name) stored encrypted in User.credentials like all other keys.
- New "Custom model" settings tab (CustomModelSection) for entering them; filtered out of the API Keys tab via a CredentialField.group field.
- getEnvForModel maps the config to standard ANTHROPIC_* env vars (ANTHROPIC_BASE_URL / ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN / ANTHROPIC_CUSTOM_HEADERS); resolveCliModel translates the "custom" dropdown sentinel to the configured model name.
- Custom headers are sanitized so they can't override Authorization, x-api-key, or anthropic-version.
- A "Custom model" option appears in the model dropdown, usable once a base URL plus at least one auth credential are set (the CLI refuses to start with no auth). Selecting it bypasses the shared pool and meters the run as "user" in both the chat and cron paths.
- Unit tests for the env mapping, header sanitization, model resolution, and credential gate.