### PR TITLE
feat: zero-downtime blue/green snapshot rotation

### DIFF
--- a/packages/sandbox-image/scripts/build-snapshot.ts
+++ b/packages/sandbox-image/scripts/build-snapshot.ts
@@ -1,8 +1,9 @@
 import { Daytona } from "@daytonaio/sdk"
-import { rebuildSnapshot } from "../src/index"
+import { rebuildSnapshot, rotateSnapshot } from "../src/index"
 
 // Rebuilds the named Daytona snapshot used for agent sandboxes.
-// Deletes any existing snapshot first so the template is fully refreshed.
+// Use --rotate for zero-downtime blue/green rotation.
+// Default (no flag): deletes existing snapshot first (brief downtime).
 async function main() {
   const apiKey = process.env.DAYTONA_API_KEY
   if (!apiKey) {
@@ -11,12 +12,23 @@ async function main() {
   }
 
   const daytona = new Daytona({ apiKey })
-  const snapshot = await rebuildSnapshot(daytona, {
-    deleteFirst: true,
-    onLog: (line) => console.log(line),
-  })
+  const args = process.argv.slice(2)
 
-  console.log(`Built snapshot: ${snapshot.name}`)
+  if (args.includes("--rotate")) {
+    const result = await rotateSnapshot(daytona, {
+      onLog: (line) => console.log(line),
+    })
+    console.log(`\nRotated snapshot: ${result.snapshot.name}`)
+    if (result.deactivatedName) {
+      console.log(`Deactivated old snapshot: ${result.deactivatedName}`)
+    }
+  } else {
+    const snapshot = await rebuildSnapshot(daytona, {
+      deleteFirst: true,
+      onLog: (line) => console.log(line),
+    })
+    console.log(`Built snapshot: ${snapshot.name}`)
+  }
 }
 
 main().catch((err) => {

--- a/packages/sandbox-image/src/image.ts
+++ b/packages/sandbox-image/src/image.ts
@@ -1,10 +1,37 @@
 import { Image } from "@daytonaio/sdk"
 
 /**
- * Snapshot name used for sandbox creation.
- * Must match what's registered with Daytona.
+ * Blue/green snapshot names for zero-downtime rotation.
+ * The cron alternates between these: builds the inactive one, then deletes
+ * the active one. The app calls getActiveSnapshotName() to discover which
+ * exists at runtime — no env var or config needed.
  */
 export const SNAPSHOT_NAME = "background-agents"
+export const SNAPSHOT_NAME_TEMP = "background-agents-temp"
+
+/** Both possible snapshot names (for lookups). */
+export const ALL_SNAPSHOT_NAMES = [SNAPSHOT_NAME, SNAPSHOT_NAME_TEMP] as const
+
+/**
+ * Discovers which snapshot is currently available by querying Daytona.
+ * Returns the first snapshot that exists, preferring the primary name.
+ * Throws if neither exists — caller should handle first-run bootstrap.
+ */
+export async function getActiveSnapshotName(
+  daytona: import("@daytonaio/sdk").Daytona
+): Promise<string> {
+  for (const name of ALL_SNAPSHOT_NAMES) {
+    try {
+      await daytona.snapshot.get(name)
+      return name
+    } catch {
+      // doesn't exist, try next
+    }
+  }
+  throw new Error(
+    `No snapshot found. Run "npm run build:snapshot" to create the initial snapshot.`
+  )
+}
 
 /**
  * Resource limits for the snapshot.

--- a/packages/sandbox-image/src/index.ts
+++ b/packages/sandbox-image/src/index.ts
@@ -3,7 +3,10 @@ export {
   AGENT_PACKAGES,
   TOKSCALE_VERSION,
   SNAPSHOT_NAME,
+  SNAPSHOT_NAME_TEMP,
+  ALL_SNAPSHOT_NAMES,
   SNAPSHOT_RESOURCES,
+  getActiveSnapshotName,
 } from "./image"
-export { rebuildSnapshot } from "./rebuild"
-export type { RebuildSnapshotOptions } from "./rebuild"
+export { rebuildSnapshot, rotateSnapshot } from "./rebuild"
+export type { RebuildSnapshotOptions, RotateSnapshotResult } from "./rebuild"

--- a/packages/sandbox-image/src/rebuild.ts
+++ b/packages/sandbox-image/src/rebuild.ts
@@ -1,5 +1,11 @@
 import { Daytona } from "@daytonaio/sdk"
-import { getAgentSandboxImage, SNAPSHOT_NAME, SNAPSHOT_RESOURCES } from "./image"
+import {
+  getAgentSandboxImage,
+  SNAPSHOT_NAME,
+  SNAPSHOT_NAME_TEMP,
+  ALL_SNAPSHOT_NAMES,
+  SNAPSHOT_RESOURCES,
+} from "./image"
 
 export interface RebuildSnapshotOptions {
   /**
@@ -51,4 +57,69 @@ export async function rebuildSnapshot(
     },
     onLog ? { onLogs: onLog } : undefined
   )
+}
+
+export interface RotateSnapshotResult {
+  /** The newly built snapshot (now the active one). */
+  snapshot: Awaited<ReturnType<Daytona["snapshot"]["create"]>>
+  /** The name of the snapshot that was deactivated (old one). Undefined on first run. */
+  deactivatedName?: string
+}
+
+/**
+ * Zero-downtime blue/green snapshot rotation.
+ *
+ * 1. Checks which snapshot currently exists (the "active" one).
+ * 2. Builds the *other* snapshot (so the active one stays available).
+ * 3. Deletes the old snapshot after the new one is ready.
+ *
+ * The app uses getActiveSnapshotName() to discover which snapshot to use —
+ * no env var or config update needed after rotation.
+ */
+export async function rotateSnapshot(
+  daytona: Daytona,
+  options: RebuildSnapshotOptions = {}
+): Promise<RotateSnapshotResult> {
+  const { onLog } = options
+
+  // Figure out which snapshot currently exists (active) and which to build (target).
+  let activeName: string | undefined
+  for (const name of ALL_SNAPSHOT_NAMES) {
+    try {
+      await daytona.snapshot.get(name)
+      activeName = name
+      break
+    } catch {
+      // doesn't exist
+    }
+  }
+
+  // If neither exists (first run), build the primary.
+  // If one exists, build the other.
+  const targetName = activeName === SNAPSHOT_NAME ? SNAPSHOT_NAME_TEMP : SNAPSHOT_NAME
+
+  onLog?.(`Active snapshot: ${activeName ?? "(none)"}`)
+  onLog?.(`Building new snapshot "${targetName}" (this can take several minutes)...`)
+
+  const snapshot = await daytona.snapshot.create(
+    {
+      name: targetName,
+      image: getAgentSandboxImage(),
+      resources: SNAPSHOT_RESOURCES,
+    },
+    onLog ? { onLogs: onLog } : undefined
+  )
+
+  // Clean up the old snapshot if one existed.
+  if (activeName) {
+    try {
+      onLog?.(`Deleting old snapshot "${activeName}"...`)
+      const old = await daytona.snapshot.get(activeName)
+      await daytona.snapshot.delete(old)
+    } catch (err) {
+      onLog?.(`Warning: failed to delete old snapshot "${activeName}": ${err}`)
+    }
+  }
+
+  return { snapshot, deactivatedName: activeName }
 }

--- a/packages/web/app/api/cron/rebuild-snapshot/route.ts
+++ b/packages/web/app/api/cron/rebuild-snapshot/route.ts
@@ -1,5 +1,5 @@
 import { Daytona } from "@daytonaio/sdk"
-import { rebuildSnapshot } from "@background-agents/sandbox-image"
+import { rotateSnapshot } from "@background-agents/sandbox-image"
 
 // Building the snapshot can take several minutes
 export const maxDuration = 300
@@ -25,19 +25,22 @@ export async function GET(req: Request) {
   const daytona = new Daytona({ apiKey })
 
   try {
-    const snapshot = await rebuildSnapshot(daytona)
+    const result = await rotateSnapshot(daytona, {
+      onLog: (line) => console.log(`[cron/rebuild-snapshot] ${line}`),
+    })
 
     return Response.json({
       success: true,
-      message: "Snapshot rebuilt successfully",
-      snapshotName: snapshot.name,
+      message: "Snapshot rotated successfully",
+      activeSnapshot: result.snapshot.name,
+      deactivatedSnapshot: result.deactivatedName ?? null,
       timestamp: new Date().toISOString(),
     })
   } catch (err) {
     console.error("[cron/rebuild-snapshot] failed:", err)
     return Response.json(
       {
-        error: "SNAPSHOT_BUILD_FAILED",
+        error: "SNAPSHOT_ROTATION_FAILED",
         message: err instanceof Error ? err.message : String(err),
       },
       { status: 500 }

--- a/packages/web/lib/sandbox.ts
+++ b/packages/web/lib/sandbox.ts
@@ -10,7 +10,7 @@ import type { Daytona, Sandbox } from "@daytonaio/sdk"
 import { randomUUID } from "crypto"
 import { createSandboxGit } from "@background-agents/daytona-git"
 import { installSkills, discoverInstalledSkills } from "@background-agents/skills/sandbox"
-import { TOKSCALE_VERSION } from "@background-agents/sandbox-image"
+import { TOKSCALE_VERSION, getActiveSnapshotName } from "@background-agents/sandbox-image"
 import { PATHS, SANDBOX_CONFIG } from "@/lib/constants"
 import { NEW_REPOSITORY } from "@/lib/types"
 import { prisma } from "@/lib/db/prisma"
@@ -191,7 +191,7 @@ export async function createSandboxForChat(
 
   const sandbox = await daytona.create({
     name: generateSandboxName(userId),
-    snapshot: SANDBOX_CONFIG.DEFAULT_SNAPSHOT,
+    snapshot: await getActiveSnapshotName(daytona),
     autoStopInterval: 5,
     autoDeleteInterval: 5760, // 4 days - auto-delete after being stopped for four days
     public: true,


### PR DESCRIPTION

#  Zero-downtime blue/green snapshot rotation
  ## Summary

  The Daytona snapshot used to create agent sandboxes was previously rebuilt in place: the cron
  deleted the existing snapshot and built a new one under the same name. During that window (which  can take several minutes) there was no usable snapshot, so any sandbox creation would fail.

  This PR introduces blue/green rotation across two alternating snapshot names so the active
  snapshot stays live throughout a rebuild.

###  How it works

  - Two snapshot names are used: background-agents (SNAPSHOT_NAME) and background-agents-temp
  (SNAPSHOT_NAME_TEMP).
  - rotateSnapshot():
    a. Detects which snapshot currently exists (the active one).
    b. Builds the other name, leaving the active snapshot available for sandbox creation the whole  time.
    c. Deletes the old snapshot only after the new one is ready (failure to delete is logged as a
  warning, not fatal).
    d. On first run (neither exists), it bootstraps the primary background-agents.
  - The app discovers the live snapshot at runtime via getActiveSnapshotName(daytona), which
  queries Daytona and returns the first existing name (preferring the primary). No env var or
  config change is needed after a rotation — the previous hardcoded
  SANDBOX_CONFIG.DEFAULT_SNAPSHOT is replaced with this lookup in createSandboxForChat.

 ### Changes

  - packages/sandbox-image/src/image.ts — add SNAPSHOT_NAME_TEMP, ALL_SNAPSHOT_NAMES, and
  getActiveSnapshotName() (throws with a helpful "run build:snapshot" message if neither exists).
  - packages/sandbox-image/src/rebuild.ts — add rotateSnapshot() and RotateSnapshotResult
  alongside the existing rebuildSnapshot().
  - packages/sandbox-image/src/index.ts — export the new symbols.
  - packages/web/app/api/cron/rebuild-snapshot/route.ts — cron now calls rotateSnapshot();
  response returns activeSnapshot + deactivatedSnapshot, and the error code becomes
  SNAPSHOT_ROTATION_FAILED.
  - packages/web/lib/sandbox.ts — createSandboxForChat resolves the snapshot via
  getActiveSnapshotName(daytona).
  - packages/sandbox-image/scripts/build-snapshot.ts — add a --rotate flag for zero-downtime
  rotation; default behavior (delete-first, brief downtime) is unchanged.

  
  ### Testing

  - [ ] First-run bootstrap: no snapshots exist → rotation builds background-agents.
  - [ ] Rotation from background-agents → builds background-agents-temp, then deletes
  background-agents.
  - [ ] Rotation back from background-agents-temp → builds background-agents, deletes temp.
  - [ ] Sandbox creation succeeds throughout a rotation (active snapshot stays available).
  - [ ] npm run build:snapshot --rotate and the plain (delete-first) variant both work.

Closes #228 