### PR TITLE
Feat/kimi code

### DIFF
--- a/packages/agent-configuration/README.md
+++ b/packages/agent-configuration/README.md
@@ -78,7 +78,7 @@ All agents block the same core set of dangerous operations:
 
 ## MCP Setup
 
-Writes per-agent MCP server configs into the sandbox before the agent CLI starts. Currently supported agents: `claude-code`, `codex`, `gemini`, `opencode`, `goose`, `copilot`, `kilo`.
+Writes per-agent MCP server configs into the sandbox before the agent CLI starts. Currently supported agents: `claude-code`, `codex`, `gemini`, `opencode`, `goose`, `copilot`, `kilo`, `kimi`.
 
 ```ts
 import { setupMcpForAgent } from '@background-agents/agent-configuration'

--- a/packages/agent-configuration/src/mcp/index.ts
+++ b/packages/agent-configuration/src/mcp/index.ts
@@ -42,6 +42,7 @@ const MCP_SUPPORTED_AGENTS = [
   "goose",
   "copilot",
   "kilo",
+  "kimi",
 ] as const
 
 type McpSupportedAgent = (typeof MCP_SUPPORTED_AGENTS)[number]
@@ -207,6 +208,27 @@ function generateKiloConfig(servers: AgentMcpServer[]): McpConfigFile {
   }
 }
 
+/**
+ * Kimi Code: ~/.kimi-code/mcp.json — `mcpServers.<name>` with `url` + bearer
+ * `headers`. Kimi infers Streamable-HTTP from the presence of `url` (no `type`
+ * field). This is a separate file from config.toml (providers/models), so the
+ * two never collide; the user-level path is auto-loaded on startup.
+ */
+function generateKimiConfig(servers: AgentMcpServer[]): McpConfigFile {
+  const mcpServers: Record<string, unknown> = {}
+  for (const s of servers) {
+    mcpServers[s.name] = {
+      url: s.url,
+      headers: { Authorization: `Bearer ${s.bearerToken}` },
+    }
+  }
+  return {
+    filePath: "/home/daytona/.kimi-code/mcp.json",
+    content: JSON.stringify({ mcpServers }, null, 2),
+    format: "json",
+  }
+}
+
 function generateMcpConfigForAgent(
   agent: string,
   servers: AgentMcpServer[]
@@ -229,6 +251,8 @@ function generateMcpConfigForAgent(
       return generateCopilotConfig(servers)
     case "kilo":
       return generateKiloConfig(servers)
+    case "kimi":
+      return generateKimiConfig(servers)
   }
 }
 

--- a/packages/common/src/agent-icons.tsx
+++ b/packages/common/src/agent-icons.tsx
@@ -195,6 +195,30 @@ export function KiloIcon({ className }: AgentIconProps) {
   )
 }
 
+// Kimi icon - placeholder lettermark (replace with the official Kimi Code logo)
+export function KimiIcon({ className }: AgentIconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={cn("h-4 w-4", className)}
+    >
+      <text
+        x="12"
+        y="17"
+        textAnchor="middle"
+        fontSize="16"
+        fontWeight="700"
+        fontFamily="system-ui, sans-serif"
+        fill="currentColor"
+      >
+        K
+      </text>
+    </svg>
+  )
+}
+
 // Pi icon - Official Pi Coding Agent logo
 // Source: https://shittycodingagent.ai/logo.svg
 export function PiIcon({ className }: AgentIconProps) {
@@ -239,6 +263,8 @@ export function AgentIcon({ agent, className }: { agent: Agent; className?: stri
       return <GooseIcon className={className} />
     case "kilo":
       return <KiloIcon className={className} />
+    case "kimi":
+      return <KimiIcon className={className} />
     case "pi":
       return <PiIcon className={className} />
     default:

--- a/packages/common/src/agents.ts
+++ b/packages/common/src/agents.ts
@@ -7,13 +7,13 @@
 // Agent Types
 // =============================================================================
 
-export type Agent = "claude-code" | "opencode" | "codex" | "copilot" | "eliza" | "gemini" | "goose" | "kilo" | "pi"
+export type Agent = "claude-code" | "opencode" | "codex" | "copilot" | "eliza" | "gemini" | "goose" | "kilo" | "kimi" | "pi"
 
 /** All agent ids, in display order. */
-export const ALL_AGENTS: Agent[] = ["claude-code", "opencode", "codex", "copilot", "gemini", "goose", "kilo", "pi", "eliza"]
+export const ALL_AGENTS: Agent[] = ["claude-code", "opencode", "codex", "copilot", "gemini", "goose", "kilo", "kimi", "pi", "eliza"]
 
 /** SDK provider names (must match ProviderName from SDK) */
-export type ProviderName = "claude" | "codex" | "copilot" | "eliza" | "opencode" | "gemini" | "goose" | "kilo" | "pi"
+export type ProviderName = "claude" | "codex" | "copilot" | "eliza" | "opencode" | "gemini" | "goose" | "kilo" | "kimi" | "pi"
 
 /** Display labels for each agent */
 export const agentLabels: Record<Agent, string> = {
@@ -25,6 +25,7 @@ export const agentLabels: Record<Agent, string> = {
   "gemini": "Gemini",
   "goose": "Goose",
   "kilo": "Kilo",
+  "kimi": "Kimi Code",
   "pi": "Pi",
 }
 
@@ -38,6 +39,7 @@ export const agentToProvider: Record<Agent, ProviderName> = {
   "gemini": "gemini",
   "goose": "goose",
   "kilo": "kilo",
+  "kimi": "kimi",
   "pi": "pi",
 }
 
@@ -46,7 +48,7 @@ export const agentToProvider: Record<Agent, ProviderName> = {
 // =============================================================================
 
 /** Provider an API key is associated with. */
-export type ProviderId = "anthropic" | "github" | "openai" | "opencode" | "gemini" | "kilo"
+export type ProviderId = "anthropic" | "github" | "openai" | "opencode" | "gemini" | "kilo" | "kimi"
 
 /**
  * Credential identifiers. The id doubles as the env var name we inject
@@ -60,6 +62,7 @@ export type CredentialId =
   | "OPENCODE_API_KEY"
   | "GEMINI_API_KEY"
   | "KILO_API_KEY"
+  | "KIMI_API_KEY"
   // Custom Anthropic-compatible endpoint ("Custom model" tab). Stored encrypted
   // like every other credential; mapped to the standard ANTHROPIC_* env vars at
   // injection time (see getEnvForModel / buildCustomModelEnv). Auth (API key or
@@ -92,6 +95,7 @@ const PROVIDER_ENV: Record<ProviderId, CredentialId[]> = {
   opencode: ["OPENCODE_API_KEY"],
   gemini: ["GEMINI_API_KEY"],
   kilo: ["KILO_API_KEY"],
+  kimi: ["KIMI_API_KEY"],
 }
 
 // =============================================================================
@@ -290,6 +294,15 @@ export const agentModels: Record<Agent, ModelOption[]> = {
     { value: "kilo/mistralai/devstral-medium", label: "Devstral Medium", requiresKey: "kilo" },
     { value: "kilo/x-ai/grok-4.20", label: "Grok 4.20", requiresKey: "kilo" },
   ],
+  "kimi": [
+    // Moonshot (Kimi) models, routed through the user's KIMI_API_KEY against
+    // https://api.moonshot.ai/v1. Each value must match a [models."<id>"] entry
+    // declared in the generated ~/.kimi-code/config.toml (see the kimi agent).
+    { value: "kimi-k2.7-code", label: "Kimi K2.7 Code (Recommended)", requiresKey: "kimi" },
+    { value: "kimi-k2.7-code-highspeed", label: "Kimi K2.7 Code Highspeed", requiresKey: "kimi" },
+    { value: "kimi-k2.6", label: "Kimi K2.6", requiresKey: "kimi" },
+    { value: "kimi-k2.5", label: "Kimi K2.5", requiresKey: "kimi" },
+  ],
   "pi": [
     // Anthropic models (default provider)
     { value: "claude-sonnet-4-5", label: "Claude Sonnet 4.5 (Recommended)", requiresKey: "anthropic" },
@@ -318,6 +331,7 @@ export const defaultAgentModel: Record<Agent, string> = {
   "gemini": "gemini-2.5-flash",
   "goose": "gpt-4o",
   "kilo": "kilo/kilo-auto/free", // Free auto-router, no API key needed
+  "kimi": "kimi-k2.7-code",
   "pi": "claude-sonnet-4-5",
 }
 
@@ -331,6 +345,7 @@ export const agentSupportsPlanMode: Record<Agent, boolean> = {
   "gemini": true,
   "goose": true,
   "kilo": false,
+  "kimi": false,
   "pi": false,
 }
 

--- a/packages/sandbox-image/src/image.ts
+++ b/packages/sandbox-image/src/image.ts
@@ -27,6 +27,7 @@ export const AGENT_PACKAGES = {
   codex: "@openai/codex",
   copilot: "@github/copilot",
   kilo: "@kilocode/cli",
+  kimi: "", // kimi uses a shell script installer, not npm
   opencode: "opencode-ai",
   gemini: "@google/gemini-cli",
   pi: "@mariozechner/pi-coding-agent",
@@ -113,6 +114,16 @@ export function getAgentSandboxImage(): Image {
         "npm install -g @kilocode/cli"
       )
       .runCommands(
+        // Install Kimi Code CLI (Moonshot). Shell-script installer, not npm —
+        // run with HOME pointed at the daytona user so the `kimi` binary lands
+        // in /home/daytona/.kimi-code/bin, then hand ownership to the daytona
+        // user. KIMI_NO_MODIFY_PATH avoids the installer editing .profile; the
+        // dir is added to PATH via .bashrc below.
+        "export HOME=/home/daytona KIMI_NO_MODIFY_PATH=1 && " +
+          "curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash && " +
+          "chown -R daytona:daytona /home/daytona/.kimi-code"
+      )
+      .runCommands(
         // Install tokscale (token/cost metering). Binary embeds at build time
         // via @tokscale/cli's platform optionalDependency — no runtime download.
         `npm install -g tokscale@${TOKSCALE_VERSION}`
@@ -148,7 +159,7 @@ export function getAgentSandboxImage(): Image {
           "chown -R daytona:daytona /opt/pty-server"
       )
       .runCommands(
-        'echo \'export PATH="$HOME/.local/bin:$PATH"\' >> /home/daytona/.bashrc'
+        'echo \'export PATH="$HOME/.local/bin:$HOME/.kimi-code/bin:$PATH"\' >> /home/daytona/.bashrc'
       )
       // Set the default user to daytona
       .dockerfileCommands(["USER daytona"])

--- a/packages/sdk/scripts/generate-jsonl-references.ts
+++ b/packages/sdk/scripts/generate-jsonl-references.ts
@@ -52,6 +52,10 @@ const GEMINI_API_KEY =
   process.env.TEST_GOOGLE_API_KEY ||
   process.env.GEMINI_API_KEY ||
   process.env.GOOGLE_API_KEY
+const KIMI_API_KEY =
+  process.env.TEST_KIMI_API_KEY ||
+  process.env.KIMI_API_KEY ||
+  process.env.MOONSHOT_API_KEY
 
 if (!DAYTONA_API_KEY) {
   console.error("Error: DAYTONA_API_KEY is required")
@@ -112,6 +116,12 @@ const providers: ProviderConfig[] = [
     name: "pi",
     apiKeyEnvVar: "ANTHROPIC_API_KEY",
     apiKey: ANTHROPIC_API_KEY,
+  },
+  {
+    name: "kimi",
+    apiKeyEnvVar: "KIMI_API_KEY",
+    apiKey: KIMI_API_KEY,
+    model: "kimi-k2.7-code",
   },
 ]
 

--- a/packages/sdk/src/agents/index.ts
+++ b/packages/sdk/src/agents/index.ts
@@ -12,6 +12,7 @@ import { elizaAgent } from "./eliza/index"
 import { geminiAgent } from "./gemini/index"
 import { gooseAgent } from "./goose/index"
 import { kiloAgent } from "./kilo/index"
+import { kimiAgent } from "./kimi/index"
 import { opencodeAgent } from "./opencode/index"
 import { piAgent } from "./pi/index"
 
@@ -23,6 +24,7 @@ registry.register(elizaAgent)
 registry.register(geminiAgent)
 registry.register(gooseAgent)
 registry.register(kiloAgent)
+registry.register(kimiAgent)
 registry.register(opencodeAgent)
 registry.register(piAgent)
 
@@ -34,6 +36,7 @@ export { elizaAgent } from "./eliza/index"
 export { geminiAgent } from "./gemini/index"
 export { gooseAgent } from "./goose/index"
 export { kiloAgent } from "./kilo/index"
+export { kimiAgent } from "./kimi/index"
 export { opencodeAgent } from "./opencode/index"
 export { piAgent } from "./pi/index"
 
@@ -45,6 +48,7 @@ export { ELIZA_TOOL_MAPPINGS } from "./eliza/tools"
 export { GEMINI_TOOL_MAPPINGS } from "./gemini/tools"
 export { GOOSE_TOOL_MAPPINGS } from "./goose/tools"
 export { KILO_TOOL_MAPPINGS } from "./kilo/tools"
+export { KIMI_TOOL_MAPPINGS } from "./kimi/tools"
 export { OPENCODE_TOOL_MAPPINGS } from "./opencode/tools"
 export { PI_TOOL_MAPPINGS } from "./pi/tools"
 
@@ -56,5 +60,6 @@ export { parseElizaLine } from "./eliza/parser"
 export { parseGeminiLine } from "./gemini/parser"
 export { parseGooseLine } from "./goose/parser"
 export { parseKiloLine } from "./kilo/parser"
+export { parseKimiLine } from "./kimi/parser"
 export { parseOpencodeLine } from "./opencode/parser"
 export { parsePiLine } from "./pi/parser"

--- a/packages/sdk/src/agents/kimi/index.ts
+++ b/packages/sdk/src/agents/kimi/index.ts
@@ -1,0 +1,147 @@
+/**
+ * Kimi Code CLI Agent Definition
+ *
+ * Kimi Code (Moonshot AI) is a Claude-Code-shaped CLI: it supports headless
+ * `-p` runs, `--output-format stream-json`, `-m <model>`, and `--session <id>`.
+ *
+ * Unlike the other agents, Kimi does NOT read API keys from the shell
+ * environment automatically — it only reads credentials from
+ * ~/.kimi-code/config.toml. We therefore write a small static config in setup()
+ * that declares a Moonshot ("kimi") provider whose api_key is sourced from the
+ * KIMI_API_KEY environment variable (the [providers.kimi.env] sub-table). The
+ * key itself is still injected as an env var like every other provider, so the
+ * secret never lands in a file.
+ */
+
+import type {
+  AgentDefinition,
+  CommandSpec,
+  ParseContext,
+  RunOptions,
+} from "../../core/agent"
+import type { CodeAgentSandbox } from "../../types/provider"
+import type { Event } from "../../types/events"
+import { parseKimiLine } from "./parser"
+import { KIMI_TOOL_MAPPINGS } from "./tools"
+import { quote } from "../../utils/shell"
+
+/** Kimi config directory (daytona user home) */
+const KIMI_CONFIG_DIR = "/home/daytona/.kimi-code"
+/** Kimi config file */
+const KIMI_CONFIG_FILE = "/home/daytona/.kimi-code/config.toml"
+/** Default Moonshot API base URL */
+const KIMI_DEFAULT_BASE_URL = "https://api.moonshot.ai/v1"
+
+/**
+ * Moonshot models exposed to Kimi Code. Each must be declared in config.toml
+ * with a max_context_size or the CLI refuses to use it. ids match the Moonshot
+ * /v1/models catalog and the values in agentModels.kimi (@background-agents/common).
+ */
+const KIMI_MODELS: { id: string; context: number }[] = [
+  { id: "kimi-k2.7-code", context: 262144 },
+  { id: "kimi-k2.7-code-highspeed", context: 262144 },
+  { id: "kimi-k2.6", context: 262144 },
+  { id: "kimi-k2.5", context: 262144 },
+]
+/** Default model — must be one of KIMI_MODELS. */
+const KIMI_DEFAULT_MODEL = "kimi-k2.7-code"
+
+/**
+ * config.toml that wires a Moonshot ("kimi") provider reading its API key from
+ * the KIMI_API_KEY environment variable (the [providers.kimi.env] sub-table),
+ * plus a [models."<id>"] entry per exposed model. Static (no secret) — safe to
+ * write verbatim into the sandbox.
+ */
+const KIMI_CONFIG_TOML = `default_model = "${KIMI_DEFAULT_MODEL}"
+
+[providers.kimi]
+type = "kimi"
+base_url = "${KIMI_DEFAULT_BASE_URL}"
+
+[providers.kimi.env]
+api_key = "KIMI_API_KEY"
+${KIMI_MODELS.map(
+  (m) => `
+[models."${m.id}"]
+provider = "kimi"
+model = "${m.id}"
+max_context_size = ${m.context}`
+).join("\n")}
+`
+
+/**
+ * Kimi agent-specific setup: write ~/.kimi-code/config.toml so the CLI knows to
+ * read its credentials from the injected KIMI_API_KEY env var.
+ */
+async function kimiSetup(
+  sandbox: CodeAgentSandbox,
+  _env: Record<string, string>
+): Promise<void> {
+  if (!sandbox.executeCommand) return
+
+  // Write the config via a heredoc to avoid shell-escaping the TOML body.
+  await sandbox.executeCommand(
+    `mkdir -p '${KIMI_CONFIG_DIR}' && cat > '${KIMI_CONFIG_FILE}' <<'KIMI_EOF'\n${KIMI_CONFIG_TOML}KIMI_EOF\nchmod 600 '${KIMI_CONFIG_FILE}'`,
+    30
+  )
+}
+
+/**
+ * Kimi Code CLI agent definition.
+ *
+ * Interacts with the Kimi CLI, which outputs JSON lines in stream-json format
+ * (same shape as Claude Code).
+ */
+export const kimiAgent: AgentDefinition = {
+  name: "kimi",
+
+  toolMappings: KIMI_TOOL_MAPPINGS,
+
+  capabilities: {
+    // Kimi has no --system-prompt flag; rely on the synthetic prefix instead.
+    supportsSystemPrompt: false,
+    supportsResume: true,
+    supportsPlanMode: false,
+    setup: kimiSetup,
+  },
+
+  buildCommand(options: RunOptions): CommandSpec {
+    const args: string[] = []
+
+    // Note: prompt mode (-p) runs non-interactively and auto-approves actions on
+    // its own — the CLI rejects both --yolo and --auto when combined with -p.
+
+    // Model alias (e.g. "kimi/kimi-k2-0905-preview")
+    if (options.model) {
+      args.push("-m", options.model)
+    }
+
+    // Resume a specific session
+    if (options.sessionId) {
+      args.push("-S", options.sessionId)
+    }
+
+    // Stream JSON output for prompt mode
+    args.push("--output-format", "stream-json")
+
+    // Prompt is the VALUE of -p / --prompt (not a positional arg)
+    if (options.prompt) {
+      args.push("-p", options.prompt)
+    }
+
+    // Kimi's installer drops the binary at ~/.kimi-code/bin/kimi and only adds
+    // it to ~/.profile, which the job runner's non-interactive shell may not
+    // source — wrap in bash and prepend the dir explicitly.
+    const kimiCmd = ["kimi", ...args].map(quote).join(" ")
+
+    return {
+      cmd: "bash",
+      args: ["-c", `export PATH="$HOME/.kimi-code/bin:$PATH" && ${kimiCmd}`],
+      env: { ...options.env },
+    }
+  },
+
+  parse(line: string, _context: ParseContext): Event | Event[] | null {
+    return parseKimiLine(line, this.toolMappings)
+  },
+}

--- a/packages/sdk/src/agents/kimi/parser.ts
+++ b/packages/sdk/src/agents/kimi/parser.ts
@@ -12,11 +12,21 @@
  *
  * The trailing `meta`/session.resume_hint line is the end-of-turn marker and the
  * only place the session id appears.
+ *
+ * Fatal failures are NOT emitted as JSON — Kimi prints a plain-text line like
+ *   error: failed to run prompt: provider.rate_limit: 429 … insufficient balance …
+ * then exits. We detect that line and emit a classified end-error so the UI
+ * shows an actionable message (e.g. the user is out of credits) instead of a
+ * generic process-crash.
  */
 
 import type { Event } from "../../types/events"
 import { createToolStartEvent } from "../../core/tools"
 import { safeJsonParse } from "../../utils/json"
+import { resolveAgentError } from "../../utils/errors"
+
+/** Matches Kimi's plain-text fatal error line (`error: <detail>`). */
+const KIMI_ERROR_LINE = /^error:\s*(.+)$/i
 
 interface KimiToolCall {
   type?: string
@@ -38,7 +48,14 @@ export function parseKimiLine(
   toolMappings: Record<string, string>
 ): Event | Event[] | null {
   const json = safeJsonParse<KimiLine>(line)
-  if (!json) return null
+  if (!json) {
+    // Non-JSON line: the only ones we care about are Kimi's fatal error lines.
+    const m = KIMI_ERROR_LINE.exec(line.trim())
+    if (m) {
+      return { type: "end", error: resolveAgentError(m[1], "kimi") }
+    }
+    return null
+  }
 
   // End-of-turn marker — also carries the resumable session id.
   if (json.role === "meta") {

--- a/packages/sdk/src/agents/kimi/parser.ts
+++ b/packages/sdk/src/agents/kimi/parser.ts
@@ -1,0 +1,76 @@
+/**
+ * Kimi CLI output parser
+ *
+ * Kimi Code's `--output-format stream-json` emits one complete chat-completion
+ * style message per line (NOT Claude's stream-json shape):
+ *
+ *   {"role":"assistant","content":"…","tool_calls":[
+ *       {"type":"function","id":"Bash_0",
+ *        "function":{"name":"Bash","arguments":"{\"command\":\"ls\"}"}}]}
+ *   {"role":"tool","tool_call_id":"Bash_0","content":"…"}
+ *   {"role":"meta","type":"session.resume_hint","session_id":"session_…", …}
+ *
+ * The trailing `meta`/session.resume_hint line is the end-of-turn marker and the
+ * only place the session id appears.
+ */
+
+import type { Event } from "../../types/events"
+import { createToolStartEvent } from "../../core/tools"
+import { safeJsonParse } from "../../utils/json"
+
+interface KimiToolCall {
+  type?: string
+  id?: string
+  function?: { name?: string; arguments?: string }
+}
+
+interface KimiLine {
+  role?: "assistant" | "tool" | "meta" | "user" | "system"
+  type?: string
+  content?: string
+  tool_calls?: KimiToolCall[]
+  tool_call_id?: string
+  session_id?: string
+}
+
+export function parseKimiLine(
+  line: string,
+  toolMappings: Record<string, string>
+): Event | Event[] | null {
+  const json = safeJsonParse<KimiLine>(line)
+  if (!json) return null
+
+  // End-of-turn marker — also carries the resumable session id.
+  if (json.role === "meta") {
+    if (json.type === "session.resume_hint") {
+      const events: Event[] = []
+      if (json.session_id) events.push({ type: "session", id: json.session_id })
+      events.push({ type: "end" })
+      return events
+    }
+    return null
+  }
+
+  // Tool result line.
+  if (json.role === "tool") {
+    return { type: "tool_end", output: json.content }
+  }
+
+  // Assistant turn: optional text content followed by zero or more tool calls.
+  if (json.role === "assistant") {
+    const events: Event[] = []
+    if (json.content) {
+      events.push({ type: "token", text: json.content })
+    }
+    for (const call of json.tool_calls ?? []) {
+      const name = call.function?.name
+      if (!name) continue
+      const input = safeJsonParse<unknown>(call.function?.arguments ?? "") ?? {}
+      events.push(createToolStartEvent(name, input, toolMappings))
+    }
+    if (events.length === 0) return null
+    return events.length === 1 ? events[0] : events
+  }
+
+  return null
+}

--- a/packages/sdk/src/agents/kimi/tools.ts
+++ b/packages/sdk/src/agents/kimi/tools.ts
@@ -1,0 +1,16 @@
+/**
+ * Kimi tool name mappings
+ *
+ * Kimi Code is a Claude-Code-shaped CLI (same stream-json output), so its tool
+ * names match Claude's. Maps Kimi CLI tool names to canonical tool names.
+ */
+
+export const KIMI_TOOL_MAPPINGS: Record<string, string> = {
+  Write: "write",
+  Read: "read",
+  Edit: "edit",
+  Glob: "glob",
+  Grep: "grep",
+  Bash: "shell",
+  WebSearch: "web_search",
+}

--- a/packages/sdk/src/sandbox/daytona.ts
+++ b/packages/sdk/src/sandbox/daytona.ts
@@ -79,10 +79,14 @@ export function adaptDaytonaSandbox(
         return
       }
 
-      // For goose, also check in ~/.local/bin which is the default install location
-      const checkCommand = name === "goose"
-        ? `which ${name} || test -x "$HOME/.local/bin/${name}"`
-        : `which ${name}`
+      // goose and kimi install outside the default PATH; check their known
+      // binary locations too (goose: ~/.local/bin, kimi: ~/.kimi-code/bin).
+      const checkCommand =
+        name === "goose"
+          ? `which ${name} || test -x "$HOME/.local/bin/${name}"`
+          : name === "kimi"
+            ? `which ${name} || test -x "$HOME/.kimi-code/bin/${name}"`
+            : `which ${name}`
       const checkResult = await sandbox.process.executeCommand(checkCommand)
       if (checkResult.exitCode === 0) return
 
@@ -110,6 +114,14 @@ export function adaptDaytonaSandbox(
 
       if (name === "gemini") {
         await sandbox.process.executeCommand("mkdir -p ~/.gemini", undefined, undefined, 30)
+      }
+
+      // Kimi installs to ~/.kimi-code/bin; ensure it's on PATH for later runs.
+      if (name === "kimi") {
+        await sandbox.process.executeCommand(
+          `grep -q 'HOME/.kimi-code/bin' ~/.bashrc || echo 'export PATH="$HOME/.kimi-code/bin:$PATH"' >> ~/.bashrc`,
+          undefined, undefined, 10
+        )
       }
 
       // For goose, add ~/.local/bin to PATH and create default config

--- a/packages/sdk/src/types/provider.ts
+++ b/packages/sdk/src/types/provider.ts
@@ -8,7 +8,7 @@ import type { SandboxJobs } from "@background-agents/sandbox-jobs"
  * Supported agent names.
  * Used by ensureProvider() to install the correct CLI.
  */
-export type ProviderName = "claude" | "codex" | "copilot" | "eliza" | "goose" | "kilo" | "opencode" | "gemini" | "pi"
+export type ProviderName = "claude" | "codex" | "copilot" | "eliza" | "goose" | "kilo" | "kimi" | "opencode" | "gemini" | "pi"
 
 /**
  * Sandbox interface required by the SDK.

--- a/packages/sdk/src/utils/install.ts
+++ b/packages/sdk/src/utils/install.ts
@@ -12,6 +12,7 @@ const PROVIDER_PACKAGES: Record<ProviderName, string> = {
   eliza: "", // eliza is built-in, no installation needed
   goose: "", // goose uses shell script installer, not npm
   kilo: "@kilocode/cli",
+  kimi: "", // kimi uses a shell script installer, not npm
   opencode: "opencode",
   gemini: "@google/gemini-cli",
   pi: "@mariozechner/pi-coding-agent",
@@ -28,6 +29,9 @@ const PROVIDER_SHELL_INSTALLERS: Partial<Record<ProviderName, string>> = {
   // 3. Extract to temp dir and move binary to ~/.local/bin
   // Use --no-same-owner and --no-same-permissions to avoid permission issues
   goose: `mkdir -p ~/.local/bin ~/.goose_tmp && curl -fsSL "https://github.com/block/goose/releases/download/stable/goose-x86_64-unknown-linux-gnu.tar.bz2" | tar -xjf - --no-same-owner --no-same-permissions -C ~/.goose_tmp && mv ~/.goose_tmp/goose ~/.local/bin/goose && chmod +x ~/.local/bin/goose && rm -rf ~/.goose_tmp`,
+  // Kimi Code: official install script. Drops the `kimi` binary into the user's
+  // local bin (PATH must include ~/.local/bin). Runs non-interactively.
+  kimi: `curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash`,
 }
 
 /**

--- a/packages/sdk/tests/fixtures/jsonl-reference/README.md
+++ b/packages/sdk/tests/fixtures/jsonl-reference/README.md
@@ -14,6 +14,8 @@ Raw JSONL output captured from actual AI coding agent CLI runs. These are **not 
 | `gemini.jsonl` | Gemini | Google Gemini CLI |
 | `goose.jsonl` | Goose | Block's Goose AI coding agent CLI |
 | `kilo.jsonl` | Kilo | Kilo CLI — OpenCode fork with its own gateway |
+| `kimi.jsonl` | Kimi Code | Moonshot Kimi Code CLI — chat-completion-shaped stream-json |
+| `kimi-error.jsonl` | Kimi Code | Kimi's plain-text fatal-error output (out-of-credits / 429 insufficient balance) |
 | `opencode.jsonl` | OpenCode | OpenCode CLI |
 | `pi.jsonl` | Pi | Pi Coding Agent CLI |
 

--- a/packages/sdk/tests/fixtures/jsonl-reference/kimi-error.jsonl
+++ b/packages/sdk/tests/fixtures/jsonl-reference/kimi-error.jsonl
@@ -1,0 +1,2 @@
+error: failed to run prompt: provider.rate_limit: 429 Your account org-REDACTED <ak-REDACTED> is suspended due to insufficient balance, please recharge your account or check your plan and billing details
+See log: /home/daytona/.kimi-code/logs/kimi-code.log

--- a/packages/sdk/tests/fixtures/jsonl-reference/kimi.jsonl
+++ b/packages/sdk/tests/fixtures/jsonl-reference/kimi.jsonl
@@ -1,0 +1,7 @@
+{"role":"assistant","content":"2 + 2 = 4\n\n","tool_calls":[{"type":"function","id":"Bash_0","function":{"name":"Bash","arguments":"{\"command\":\"ls\"}"}},{"type":"function","id":"Write_1","function":{"name":"Write","arguments":"{\"path\":\"hello.txt\",\"content\":\"Hello, World!\"}"}}]}
+{"role":"tool","tool_call_id":"Bash_0","content":"Command executed successfully."}
+{"role":"tool","tool_call_id":"Write_1","content":"Wrote 13 bytes to hello.txt"}
+{"role":"assistant","tool_calls":[{"type":"function","id":"Read_2","function":{"name":"Read","arguments":"{\"path\":\"hello.txt\"}"}}]}
+{"role":"tool","tool_call_id":"Read_2","content":"1\tHello, World!\n<system>1 line read from file starting from line 1. Total lines in file: 1. End of file reached.</system>"}
+{"role":"assistant","content":"Done.\n\n1. **2 + 2 = 4**\n2. `ls` output: *(empty — no files in the current directory)*\n3. Created `hello.txt`\n4. Content of `hello.txt`: `Hello, World!`"}
+{"role":"meta","type":"session.resume_hint","session_id":"session_247aaf4e-a401-44f8-8905-ba96a4a97c31","command":"kimi -r session_247aaf4e-a401-44f8-8905-ba96a4a97c31","content":"To resume this session: kimi -r session_247aaf4e-a401-44f8-8905-ba96a4a97c31"}

--- a/packages/sdk/tests/parsers.test.ts
+++ b/packages/sdk/tests/parsers.test.ts
@@ -11,6 +11,7 @@ import {
   parseGeminiLine,
   parseGooseLine,
   parseKiloLine,
+  parseKimiLine,
   parseOpencodeLine,
   parsePiLine,
   CLAUDE_TOOL_MAPPINGS,
@@ -20,6 +21,7 @@ import {
   GEMINI_TOOL_MAPPINGS,
   GOOSE_TOOL_MAPPINGS,
   KILO_TOOL_MAPPINGS,
+  KIMI_TOOL_MAPPINGS,
   OPENCODE_TOOL_MAPPINGS,
   PI_TOOL_MAPPINGS,
 } from "../src/agents/index.js"
@@ -2032,5 +2034,93 @@ describe("parseKiloLine", () => {
   it("returns null for unknown event types", () => {
     const ctx = createContext()
     expect(parseKiloLine('{"type": "unknown"}', mappings, ctx)).toBeNull()
+  })
+})
+
+describe("parseKimiLine", () => {
+  const mappings = KIMI_TOOL_MAPPINGS
+
+  it("returns null for non-JSON, non-error lines", () => {
+    expect(parseKimiLine("not json", mappings)).toBeNull()
+    expect(parseKimiLine("", mappings)).toBeNull()
+    // The log-path line Kimi prints after an error must be ignored.
+    expect(
+      parseKimiLine("See log: /home/daytona/.kimi-code/logs/kimi-code.log", mappings)
+    ).toBeNull()
+  })
+
+  it("emits token + tool_start events from an assistant message", () => {
+    const event = parseKimiLine(
+      '{"role":"assistant","content":"Hi","tool_calls":[{"type":"function","id":"Bash_0","function":{"name":"Bash","arguments":"{\\"command\\":\\"ls\\"}"}}]}',
+      mappings
+    )
+    expect(event).toEqual([
+      { type: "token", text: "Hi" },
+      { type: "tool_start", name: "shell", input: { command: "ls" } },
+    ])
+  })
+
+  it("emits tool_end from a tool result line", () => {
+    expect(
+      parseKimiLine('{"role":"tool","tool_call_id":"Bash_0","content":"ok"}', mappings)
+    ).toEqual({ type: "tool_end", output: "ok" })
+  })
+
+  it("emits session + end from the resume_hint meta line", () => {
+    expect(
+      parseKimiLine(
+        '{"role":"meta","type":"session.resume_hint","session_id":"session_abc"}',
+        mappings
+      )
+    ).toEqual([{ type: "session", id: "session_abc" }, { type: "end" }])
+  })
+
+  // ─── Fixture-driven ──────────────────────────────────────────────────────
+
+  it("success stream: parses the reference fixture into tokens, tools and one end", () => {
+    const fs = require("fs")
+    const path = require("path")
+    const fixture = fs.readFileSync(
+      path.join(__dirname, "fixtures/jsonl-reference/kimi.jsonl"),
+      "utf-8"
+    )
+    const lines = fixture.split("\n").filter(Boolean)
+    const tokens: string[] = []
+    const types: string[] = []
+    let sessionId: string | undefined
+    for (const line of lines) {
+      const ev = parseKimiLine(line, mappings)
+      if (!ev) continue
+      for (const e of Array.isArray(ev) ? ev : [ev]) {
+        types.push(e.type)
+        if (e.type === "token") tokens.push((e as { text: string }).text)
+        if (e.type === "session") sessionId = (e as { id: string }).id
+      }
+    }
+    expect(tokens.join("")).toContain("2 + 2 = 4")
+    expect(types).toContain("tool_start")
+    expect(types).toContain("tool_end")
+    expect(sessionId).toMatch(/^session_/)
+    expect(types.filter((t) => t === "end")).toHaveLength(1)
+  })
+
+  it("out-of-credits stream: surfaces a classified balance error (not a silent crash)", () => {
+    const fs = require("fs")
+    const path = require("path")
+    const fixture = fs.readFileSync(
+      path.join(__dirname, "fixtures/jsonl-reference/kimi-error.jsonl"),
+      "utf-8"
+    )
+    const lines = fixture.split("\n").filter(Boolean)
+    const events = lines
+      .map((l: string) => parseKimiLine(l, mappings))
+      .filter(Boolean)
+      .flat() as { type: string; error?: string }[]
+    const end = events.find((e) => e.type === "end")
+    expect(end).toBeDefined()
+    // The raw provider detail is preserved …
+    expect(end!.error).toContain("insufficient balance")
+    // … and an actionable hint is appended (balance category).
+    expect(end!.error).toContain("add credits")
   })
 })

--- a/packages/web/lib/credentials.ts
+++ b/packages/web/lib/credentials.ts
@@ -81,6 +81,13 @@ export const CREDENTIAL_KEYS: readonly CredentialField[] = [
     placeholder: "kilo-...",
   },
   {
+    id: "KIMI_API_KEY",
+    provider: "kimi",
+    label: "Kimi (Moonshot)",
+    helpUrl: "https://platform.moonshot.ai/console/api-keys",
+    placeholder: "sk-...",
+  },
+  {
     id: "GEMINI_API_KEY",
     provider: "gemini",
     label: "Google AI (Gemini)",


### PR DESCRIPTION
# Add Kimi Code (Moonshot) as a new agent

  Adds [Kimi Code](https://github.com/MoonshotAI/kimi-code) (Moonshot AI's `kimi` CLI) as a fully  integrated agent. Users add their Moonshot API key in the API-keys modal and can run Kimi like
  any other agent, with MCP servers and token tracking working out of the box.
  
  Closes #150 

  ## What's included

  ### Agent
  - New SDK agent at `packages/sdk/src/agents/kimi/` (index/parser/tools), registered in the agent  registry.
  - **Dedicated parser** — Kimi's `--output-format stream-json` is chat-completion shaped
  (`role`/`content`/`tool_calls`/`tool_call_id`, with a final `session.resume_hint` meta line
  carrying the session id), *not* Claude's stream-json, so it gets its own `parseKimiLine`.
  - **Auth via config, secret stays out of the file** — Kimi only reads credentials from
  `~/.kimi-code/config.toml`, not the shell env. The agent's `setup()` writes a static config
  declaring a Moonshot `kimi` provider whose `api_key` is sourced from the `KIMI_API_KEY` env var
  (`[providers.kimi.env]`), plus a `[models."<id>"]` entry per exposed model (required by the
  CLI). The key is injected as an env var like every other provider.
  - **Invocation** — `kimi -p <prompt> --output-format stream-json -m <id> [-S <session>]`. No
  `--system-prompt` flag; `--yolo`/`--auto` are rejected in prompt mode.
  - **Install/PATH** — the installer drops the binary at `~/.kimi-code/bin`; handled in the agent
  command, `daytona.ensureProvider`, and the sandbox image (`KIMI_NO_MODIFY_PATH`).
  - Registered provider name, `KIMI_API_KEY` credential, model catalog (default `kimi-k2.7-code`,
  plus `kimi-k2.7-code-highspeed`, `kimi-k2.6`, `kimi-k2.5`), agent label, icon, and the web
  API-keys field.

  ### MCP support
  - Kimi added to `setupMcpForAgent` (`MCP_SUPPORTED_AGENTS` + `generateKimiConfig`).
  - Writes `~/.kimi-code/mcp.json` — `mcpServers.<name>` with `url` + `headers.Authorization:
  Bearer <token>` (Kimi infers Streamable-HTTP from `url`). Separate from `config.toml`, so it
  never collides with the provider/model config.
  - **Smithery** and **GitHub** MCP both flow through this same writer (only URL/token source
  differ).

  ### Token tracking
  - No code changes required — `tokscale` (the pinned `3.1.2` already in the snapshot) natively
  supports the `kimi` client, and the existing provider-agnostic metering pipeline
  (`meterAssistantTurn` → `meterTurnUsage`) attributes it automatically. `provider` is a plain
  `String` column, Kimi models are treated as paid (cost recorded), and there's no shared-pool
  budget cap (correct — Kimi runs on the user's own key).

  ### Error surfacing (out of credits)
  - Kimi prints fatal failures as a **plain-text** line (`error: failed to run prompt:
  provider.rate_limit: 429 … insufficient balance …`) and exits, which previously degraded into a
  generic `agent_crashed`.
  - `parseKimiLine` now detects `error:` lines and emits a `{ type: "end", error }` run through
  the shared `resolveAgentError` classifier. Its **balance** category appends an actionable hint
  ("switch to a free model or add credits"), and the event flows through the web's
  `endEvent.error` path to render a clean error turn — **no web changes needed**.

  ## Tests
  - New `parseKimiLine` test block (Kimi was previously untested): fixture-driven over
  `kimi.jsonl` (success) and a new `kimi-error.jsonl` (out-of-credits, ids redacted) asserting the  balance error is surfaced rather than swallowed. All 161 parser tests pass.

  ## Verification (live, in real Daytona sandboxes)
  - ✅ **Agent**: end-to-end run install → config → auth → model → run → parse → clean end. All
  models confirmed working.
  - ✅ **MCP**: drove the real `setupMcpForAgent` path with a live Smithery Connect server — Kimi
  auto-loaded `mcp.json`, connected, and called `mcp__sequentialthinking__sequentialthinking`.
  GitHub uses the identical writer/schema/Bearer path.
  - ✅ **Token tracking**: after a real turn, `tokscale models --json --group-by session,model`
  reported the Kimi session with `client: "kimi"`, `model: "kimi-k2.7-code"`, `provider:
  "moonshot"`, real tokens + cost, and a `sessionId` exactly matching what the parser records.
  - ✅ **Error surfacing**: reproduced the real `429 insufficient balance` failure; the new parser  path produces the classified balance error.

  ## Notes
  - The agent icon is a placeholder "K" lettermark; swap in the official Kimi logo when available.  - Reference fixtures added under `packages/sdk/tests/fixtures/jsonl-reference/` (`kimi.jsonl`,
  `kimi-error.jsonl`).
