### PR TITLE
feat: show free shared-pool indicator in agent picker

### DIFF
--- a/packages/common/src/agents.ts
+++ b/packages/common/src/agents.ts
@@ -78,6 +78,10 @@ export type CredentialFlags = Partial<Record<CredentialId, boolean>> & {
   OPENCODE_API_KEY_SHARED?: boolean
   // Whether the OPENCODE_API_KEY is a user-provided credential stored in DB
   OPENCODE_API_KEY_USER?: boolean
+  // Whether the GEMINI_API_KEY originates from the server environment (shared)
+  GEMINI_API_KEY_SHARED?: boolean
+  // Whether the GEMINI_API_KEY is a user-provided credential stored in DB
+  GEMINI_API_KEY_USER?: boolean
 }
 export type Credentials = Partial<Record<CredentialId, string>>
 
@@ -413,6 +417,28 @@ export function hasOwnAnthropicCredentials(flags: CredentialFlags | null | undef
  */
 export function sharedClaudePoolEligible(flags: CredentialFlags | null | undefined): boolean {
   return !!flags?.CLAUDE_SHARED_POOL_AVAILABLE && !hasOwnAnthropicCredentials(flags)
+}
+
+/**
+ * Whether picking this agent would draw from a server-provided shared pool
+ * (free usage) instead of the user's own key. Used to surface a "free usage
+ * available" indicator in the agent picker. Returns false once the user stores
+ * their own key for that provider. Agents without a shared pool are always false.
+ */
+export function agentUsesSharedPool(
+  agent: Agent,
+  flags: CredentialFlags | null | undefined
+): boolean {
+  switch (agent) {
+    case "claude-code":
+      return sharedClaudePoolEligible(flags)
+    case "opencode":
+      return !!flags?.OPENCODE_API_KEY_SHARED
+    case "gemini":
+      return !!flags?.GEMINI_API_KEY_SHARED
+    default:
+      return false
+  }
 }
 
 /**

--- a/packages/common/src/agents.ts
+++ b/packages/common/src/agents.ts
@@ -9,8 +9,12 @@
 
 export type Agent = "claude-code" | "opencode" | "codex" | "copilot" | "eliza" | "gemini" | "goose" | "kilo" | "kimi" | "pi"
 
-/** All agent ids, in display order. */
-export const ALL_AGENTS: Agent[] = ["claude-code", "opencode", "codex", "copilot", "gemini", "goose", "kilo", "kimi", "pi", "eliza"]
+/**
+ * All agent ids, in display order. Agents backed by a server shared pool
+ * (claude-code, opencode, gemini) lead, followed by Kilo (free models, no
+ * shared pool), then the remaining providers.
+ */
+export const ALL_AGENTS: Agent[] = ["claude-code", "opencode", "gemini", "kilo", "codex", "copilot", "goose", "kimi", "pi", "eliza"]
 
 /** SDK provider names (must match ProviderName from SDK) */
 export type ProviderName = "claude" | "codex" | "copilot" | "eliza" | "opencode" | "gemini" | "goose" | "kilo" | "kimi" | "pi"
@@ -439,6 +443,21 @@ export function agentUsesSharedPool(
     default:
       return false
   }
+}
+
+/**
+ * Whether picking this agent gives free usage out of the box — either a
+ * server-provided shared pool (see agentUsesSharedPool) or always-free models
+ * that need no API key. Kilo qualifies via its free auto-router and free model
+ * tier, which stay available even when the user adds their own Kilo key. Used to
+ * surface the "Free usage available" green dot in the agent picker.
+ */
+export function agentHasFreeUsage(
+  agent: Agent,
+  flags: CredentialFlags | null | undefined
+): boolean {
+  if (agent === "kilo") return true
+  return agentUsesSharedPool(agent, flags)
 }
 
 /**

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -40,6 +40,7 @@ export {
   getDefaultAgent,
   hasOwnAnthropicCredentials,
   sharedClaudePoolEligible,
+  agentUsesSharedPool,
   hasCredentialsForModel,
   getDefaultModelForAgent,
   getAgentModels,

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -41,6 +41,7 @@ export {
   hasOwnAnthropicCredentials,
   sharedClaudePoolEligible,
   agentUsesSharedPool,
+  agentHasFreeUsage,
   hasCredentialsForModel,
   getDefaultModelForAgent,
   getAgentModels,

--- a/packages/web/components/chat/AgentModelSelector.tsx
+++ b/packages/web/components/chat/AgentModelSelector.tsx
@@ -5,7 +5,7 @@ import { ChevronDown, Key, Cpu } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useModals } from "@/lib/contexts"
 import type { Agent, ModelOption, CredentialFlags, Chat } from "@/lib/types"
-import { getAgentModels, agentLabels, getModelLabel, hasCredentialsForModel, agentUsesSharedPool, ALL_AGENTS } from "@/lib/types"
+import { getAgentModels, agentLabels, getModelLabel, hasCredentialsForModel, agentHasFreeUsage, ALL_AGENTS } from "@/lib/types"
 import { useSettingsQuery } from "@/lib/query/hooks/useSettingsQuery"
 import { AgentIcon } from "../icons/agent-icons"
 import { MobileSelect } from "../ui/MobileBottomSheet"
@@ -132,8 +132,9 @@ export function AgentModelSelector({
     value: agent,
     label: agentLabels[agent],
     icon: <AgentIcon agent={agent} className="h-5 w-5" />,
-    // Surface free shared-pool usage (only while the user has no own key for it).
-    description: agentUsesSharedPool(agent, credentialFlags) ? "Free usage available" : undefined,
+    // Surface free usage: shared-pool agents (until the user adds their own key)
+    // and agents with always-free models like Kilo.
+    description: agentHasFreeUsage(agent, credentialFlags) ? "Free usage available" : undefined,
   }))
 
   // Prepare model options for mobile bottom sheet
@@ -231,7 +232,7 @@ export function AgentModelSelector({
               >
                 <AgentIcon agent={agent} className="h-3.5 w-3.5" />
                 <span className="flex-1 truncate">{agentLabels[agent]}</span>
-                {agentUsesSharedPool(agent, credentialFlags) && (
+                {agentHasFreeUsage(agent, credentialFlags) && (
                   <span
                     className="h-2 w-2 shrink-0 rounded-full bg-green-500"
                     title="Free usage available"

--- a/packages/web/components/chat/AgentModelSelector.tsx
+++ b/packages/web/components/chat/AgentModelSelector.tsx
@@ -5,7 +5,7 @@ import { ChevronDown, Key, Cpu } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useModals } from "@/lib/contexts"
 import type { Agent, ModelOption, CredentialFlags, Chat } from "@/lib/types"
-import { getAgentModels, agentLabels, getModelLabel, hasCredentialsForModel, ALL_AGENTS } from "@/lib/types"
+import { getAgentModels, agentLabels, getModelLabel, hasCredentialsForModel, agentUsesSharedPool, ALL_AGENTS } from "@/lib/types"
 import { useSettingsQuery } from "@/lib/query/hooks/useSettingsQuery"
 import { AgentIcon } from "../icons/agent-icons"
 import { MobileSelect } from "../ui/MobileBottomSheet"
@@ -132,6 +132,8 @@ export function AgentModelSelector({
     value: agent,
     label: agentLabels[agent],
     icon: <AgentIcon agent={agent} className="h-5 w-5" />,
+    // Surface free shared-pool usage (only while the user has no own key for it).
+    description: agentUsesSharedPool(agent, credentialFlags) ? "Free usage available" : undefined,
   }))
 
   // Prepare model options for mobile bottom sheet
@@ -228,7 +230,14 @@ export function AgentModelSelector({
                 )}
               >
                 <AgentIcon agent={agent} className="h-3.5 w-3.5" />
-                {agentLabels[agent]}
+                <span className="flex-1 truncate">{agentLabels[agent]}</span>
+                {agentUsesSharedPool(agent, credentialFlags) && (
+                  <span
+                    className="h-2 w-2 shrink-0 rounded-full bg-green-500"
+                    title="Free usage available"
+                    aria-label="Free usage available"
+                  />
+                )}
               </button>
             ))}
           </div>

--- a/packages/web/lib/server/credential-flags.ts
+++ b/packages/web/lib/server/credential-flags.ts
@@ -82,7 +82,11 @@ export async function getEffectiveCredentialFlags(userId: string): Promise<Effec
   // show as available in the UI, not prompt for a key. Pool origin (shared vs
   // user) is still resolved separately from stored creds, so flagging the env
   // key here doesn't make it count as user-owned.
-  flags.GEMINI_API_KEY = !!storedCreds.GEMINI_API_KEY || !!process.env.GEMINI_API_KEY
+  const geminiFromDb = !!storedCreds.GEMINI_API_KEY
+  const geminiFromEnv = !geminiFromDb && !!process.env.GEMINI_API_KEY
+  flags.GEMINI_API_KEY_USER = geminiFromDb
+  flags.GEMINI_API_KEY_SHARED = geminiFromEnv
+  flags.GEMINI_API_KEY = geminiFromDb || geminiFromEnv
 
   if (await isSharedPoolAvailable()) {
     flags.CLAUDE_SHARED_POOL_AVAILABLE = true

--- a/packages/web/lib/types.ts
+++ b/packages/web/lib/types.ts
@@ -25,6 +25,7 @@ export {
   hasCredentialsForModel,
   sharedClaudePoolEligible,
   agentUsesSharedPool,
+  agentHasFreeUsage,
   ENDPOINT_TYPE_TO_AGENT,
   ENDPOINT_MODEL_PREFIX,
   findEndpoint,

--- a/packages/web/lib/types.ts
+++ b/packages/web/lib/types.ts
@@ -24,6 +24,7 @@ export {
   getModelLabel,
   hasCredentialsForModel,
   sharedClaudePoolEligible,
+  agentUsesSharedPool,
   ENDPOINT_TYPE_TO_AGENT,
   ENDPOINT_MODEL_PREFIX,
   findEndpoint,


### PR DESCRIPTION
Mark agents backed by a server shared pool (claude-code, gemini, opencode) with a green dot / 'Free usage available' hint, hidden once the user saves their own key. Adds gemini shared/user flag distinction and an agentUsesSharedPool helper.


<img width="217" height="347" alt="image" src="https://github.com/user-attachments/assets/2900b10d-f267-45e2-ada6-9690c52dd51f" />
