### PR TITLE
Feat/share chat

### DIFF
--- a/packages/web/app/api/chats/[chatId]/route.ts
+++ b/packages/web/app/api/chats/[chatId]/route.ts
@@ -43,6 +43,7 @@ interface ChatWithMessagesResponse {
   model: string | null
   planModeEnabled: boolean
   displayName: string | null
+  shareId: string | null
   status: string
   parentChatId: string | null
   needsSync: boolean
@@ -125,6 +126,7 @@ export async function GET(
       model: chat.model,
       planModeEnabled: chat.planModeEnabled,
       displayName: chat.displayName,
+      shareId: chat.shareId,
       status: chat.status,
       parentChatId: chat.parentChatId,
       needsSync: chat.needsSync,

--- a/packages/web/app/api/chats/[chatId]/route.ts
+++ b/packages/web/app/api/chats/[chatId]/route.ts
@@ -236,6 +236,7 @@ export async function PATCH(
       model: updatedChat.model,
       planModeEnabled: updatedChat.planModeEnabled,
       displayName: updatedChat.displayName,
+      shareId: updatedChat.shareId,
       status: updatedChat.status,
       parentChatId: updatedChat.parentChatId,
       needsSync: updatedChat.needsSync,

--- a/packages/web/app/api/chats/[chatId]/share/route.ts
+++ b/packages/web/app/api/chats/[chatId]/share/route.ts
@@ -1,0 +1,77 @@
+import { randomBytes } from "crypto"
+import { NextRequest } from "next/server"
+import { prisma } from "@/lib/db/prisma"
+import {
+  requireAuth,
+  isAuthError,
+  getChatWithAuth,
+  notFound,
+  internalError,
+} from "@/lib/db/api-helpers"
+
+// =============================================================================
+// POST /api/chats/[chatId]/share — enable (or return existing) public share
+// =============================================================================
+//
+// Generates an unguessable shareId so the chat is viewable read-only at
+// /share/<shareId> without auth. Idempotent: if already shared, returns the
+// existing token.
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ chatId: string }> }
+): Promise<Response> {
+  const auth = await requireAuth()
+  if (isAuthError(auth)) return auth
+  const { userId } = auth
+  const { chatId } = await params
+
+  try {
+    const chat = await getChatWithAuth(chatId, userId)
+    if (!chat) return notFound("Chat not found")
+
+    let shareId = chat.shareId
+    if (!shareId) {
+      // 32 hex chars (~128 bits) — long and unguessable.
+      shareId = randomBytes(16).toString("hex")
+      await prisma.chat.update({
+        where: { id: chatId },
+        data: { shareId },
+      })
+    }
+
+    return Response.json({ shareId })
+  } catch (error) {
+    return internalError(error)
+  }
+}
+
+// =============================================================================
+// DELETE /api/chats/[chatId]/share — revoke the public share
+// =============================================================================
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ chatId: string }> }
+): Promise<Response> {
+  const auth = await requireAuth()
+  if (isAuthError(auth)) return auth
+  const { userId } = auth
+  const { chatId } = await params
+
+  try {
+    const chat = await getChatWithAuth(chatId, userId)
+    if (!chat) return notFound("Chat not found")
+
+    if (chat.shareId) {
+      await prisma.chat.update({
+        where: { id: chatId },
+        data: { shareId: null },
+      })
+    }
+
+    return Response.json({ shareId: null })
+  } catch (error) {
+    return internalError(error)
+  }
+}

--- a/packages/web/app/api/chats/route.ts
+++ b/packages/web/app/api/chats/route.ts
@@ -33,6 +33,7 @@ interface ChatResponse {
   model: string | null
   planModeEnabled: boolean
   displayName: string | null
+  shareId: string | null
   status: string
   parentChatId: string | null
   needsSync: boolean
@@ -91,6 +92,7 @@ export async function GET(req: NextRequest): Promise<Response> {
       model: chat.model,
       planModeEnabled: chat.planModeEnabled,
       displayName: chat.displayName,
+      shareId: chat.shareId,
       status: chat.status,
       parentChatId: chat.parentChatId,
       needsSync: chat.needsSync,
@@ -202,6 +204,7 @@ export async function POST(req: NextRequest): Promise<Response> {
       model: chat.model,
       planModeEnabled: chat.planModeEnabled,
       displayName: chat.displayName,
+      shareId: chat.shareId,
       status: chat.status,
       parentChatId: chat.parentChatId,
       needsSync: chat.needsSync,

--- a/packages/web/app/api/share/[shareId]/route.ts
+++ b/packages/web/app/api/share/[shareId]/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest } from "next/server"
+import { notFound, internalError } from "@/lib/db/api-helpers"
+import { getSharedChat } from "@/lib/server/shared-chat"
+
+// =============================================================================
+// GET /api/share/[shareId] — public, read-only view of a shared chat
+// =============================================================================
+//
+// No auth: anyone with the unguessable token can read it. The payload is
+// sanitized in getSharedChat() — sandbox/session ids, env vars, branch, and
+// tool-call `filePath`s are stripped so nothing private leaks to viewers.
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ shareId: string }> }
+): Promise<Response> {
+  const { shareId } = await params
+
+  try {
+    const chat = await getSharedChat(shareId)
+    if (!chat) return notFound("Shared chat not found")
+    return Response.json(chat)
+  } catch (error) {
+    return internalError(error)
+  }
+}

--- a/packages/web/app/share/[shareId]/page.tsx
+++ b/packages/web/app/share/[shareId]/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from "next"
+import { notFound } from "next/navigation"
+import { getSharedChat } from "@/lib/server/shared-chat"
+import { SharedChatView } from "@/components/share/SharedChatView"
+
+// Shared chats are dynamic (live view of the chat's current messages) and
+// should not be indexed by search engines.
+export const dynamic = "force-dynamic"
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ shareId: string }>
+}): Promise<Metadata> {
+  const { shareId } = await params
+  const chat = await getSharedChat(shareId)
+  return {
+    title: chat?.displayName ? `${chat.displayName} · Shared chat` : "Shared chat",
+    robots: { index: false, follow: false },
+  }
+}
+
+export default async function SharedChatPage({
+  params,
+}: {
+  params: Promise<{ shareId: string }>
+}) {
+  const { shareId } = await params
+  const chat = await getSharedChat(shareId)
+  if (!chat) notFound()
+
+  return <SharedChatView chat={chat} />
+}

--- a/packages/web/components/AppModals.tsx
+++ b/packages/web/components/AppModals.tsx
@@ -199,11 +199,13 @@ export function AppModals({
       {/* Mobile Commands Menu */}
       {isMobile && (
         <MobileCommandsMenu
+          key={currentChat?.id ?? "none"}
           open={modals.mobileCommandsOpen}
           onClose={() => modals.setMobileCommandsOpen(false)}
           onSlashCommand={onSlashCommand}
           hasLinkedRepo={!!(currentChat && currentChat.repo !== NEW_REPOSITORY)}
           inConflict={!!(gitDialogs.rebaseConflict?.inRebase || gitDialogs.rebaseConflict?.inMerge)}
+          chat={currentChat}
         />
       )}
 

--- a/packages/web/components/MobileCommandsMenu.tsx
+++ b/packages/web/components/MobileCommandsMenu.tsx
@@ -1,9 +1,12 @@
 "use client"
 
-import { GitMerge, GitBranch, GitPullRequest, GitCommitVertical, GitBranchPlus, XCircle } from "lucide-react"
+import { useState } from "react"
+import { GitMerge, GitBranch, GitPullRequest, GitCommitVertical, GitBranchPlus, XCircle, Share2, ChevronLeft, Copy, Check, Link2Off, Loader2 } from "lucide-react"
 import { MobileBottomSheet } from "./ui/MobileBottomSheet"
 import { cn } from "@/lib/utils"
 import { SLASH_COMMANDS, ABORT_COMMAND, type SlashCommand } from "@background-agents/common"
+import { useShareChat } from "@/lib/hooks/useShareChat"
+import type { Chat } from "@/lib/types"
 import type { SlashCommandType } from "./SlashCommandMenu"
 
 const ICON_MAP: Record<string, React.ComponentType<{ className?: string }>> = {
@@ -42,6 +45,8 @@ interface MobileCommandsMenuProps {
   hasLinkedRepo?: boolean
   /** Whether we're in a merge/rebase conflict */
   inConflict?: boolean
+  /** Current chat — enables the Share action. */
+  chat?: Chat | null
 }
 
 export function MobileCommandsMenu({
@@ -50,7 +55,16 @@ export function MobileCommandsMenu({
   onSlashCommand,
   hasLinkedRepo = false,
   inConflict = false,
+  chat,
 }: MobileCommandsMenuProps) {
+  // The sheet has two views: the command list and the share panel.
+  const [view, setView] = useState<"commands" | "share">("commands")
+
+  const handleClose = () => {
+    setView("commands")
+    onClose()
+  }
+
   // Build commands list based on context
   const commands: CommandItem[] = []
 
@@ -68,61 +82,167 @@ export function MobileCommandsMenu({
   }
 
   const handleSelect = (id: CommandItem["id"]) => {
-    onClose()
+    handleClose()
     onSlashCommand(id)
   }
 
   return (
     <MobileBottomSheet
       open={open}
-      onClose={onClose}
-      title="Commands"
+      onClose={handleClose}
+      title={view === "share" ? "Share chat" : "Commands"}
       height="auto"
     >
-      <div className="py-2">
-        {commands.length > 0 ? (
-          <>
-            {/* Git Commands Section */}
-            {hasLinkedRepo && (
+      {view === "share" && chat ? (
+        <ShareSheet chat={chat} onBack={() => setView("commands")} />
+      ) : (
+        <div className="py-2">
+          {commands.length > 0 ? (
+            <>
+              {/* Git Commands Section */}
+              {hasLinkedRepo && (
+                <div className="px-4 py-2 text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                  Git Commands
+                </div>
+              )}
+              {commands.map((command) => (
+                <button
+                  key={command.id}
+                  onClick={() => handleSelect(command.id)}
+                  className={cn(
+                    "flex items-center gap-3 w-full px-4 py-4 text-left transition-colors touch-target",
+                    "hover:bg-accent active:bg-accent",
+                    command.variant === "destructive" && "text-destructive"
+                  )}
+                >
+                  <span className={cn(
+                    "shrink-0",
+                    command.variant === "destructive" ? "text-destructive" : "text-muted-foreground"
+                  )}>
+                    {command.icon}
+                  </span>
+                  <div className="flex-1 min-w-0">
+                    <div className="text-base font-medium">{command.label}</div>
+                    <div className={cn(
+                      "text-sm",
+                      command.variant === "destructive" ? "text-destructive/70" : "text-muted-foreground"
+                    )}>
+                      {command.description}
+                    </div>
+                  </div>
+                </button>
+              ))}
+
+            </>
+          ) : (
+            <div className="px-4 py-2 text-xs font-medium text-muted-foreground uppercase tracking-wider">
+              Actions
+            </div>
+          )}
+
+          {/* Share action — available whenever there's a chat to share. */}
+          {chat && (
+            <>
               <div className="px-4 py-2 text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                Git Commands
+                Actions
               </div>
-            )}
-            {commands.map((command) => (
               <button
-                key={command.id}
-                onClick={() => handleSelect(command.id)}
-                className={cn(
-                  "flex items-center gap-3 w-full px-4 py-4 text-left transition-colors touch-target",
-                  "hover:bg-accent active:bg-accent",
-                  command.variant === "destructive" && "text-destructive"
-                )}
+                onClick={() => setView("share")}
+                className="flex items-center gap-3 w-full px-4 py-4 text-left transition-colors touch-target hover:bg-accent active:bg-accent"
               >
-                <span className={cn(
-                  "shrink-0",
-                  command.variant === "destructive" ? "text-destructive" : "text-muted-foreground"
-                )}>
-                  {command.icon}
+                <span className="shrink-0 text-muted-foreground">
+                  <Share2 className="h-5 w-5" />
                 </span>
                 <div className="flex-1 min-w-0">
-                  <div className="text-base font-medium">{command.label}</div>
-                  <div className={cn(
-                    "text-sm",
-                    command.variant === "destructive" ? "text-destructive/70" : "text-muted-foreground"
-                  )}>
-                    {command.description}
+                  <div className="text-base font-medium">Share chat</div>
+                  <div className="text-sm text-muted-foreground">
+                    {chat.shareId ? "Public link is active" : "Create a public read-only link"}
                   </div>
                 </div>
               </button>
-            ))}
-
-          </>
-        ) : (
-          <div className="px-4 py-2 text-xs font-medium text-muted-foreground uppercase tracking-wider">
-            Actions
-          </div>
-        )}
-      </div>
+            </>
+          )}
+        </div>
+      )}
     </MobileBottomSheet>
+  )
+}
+
+// =============================================================================
+// ShareSheet — the share panel shown inside the mobile commands sheet
+// =============================================================================
+
+function ShareSheet({ chat, onBack }: { chat: Chat; onBack: () => void }) {
+  const { shareId, busy, copied, shareUrl, enableShare, revokeShare, copyLink } =
+    useShareChat(chat.id, chat.shareId)
+
+  return (
+    <div className="px-4 py-3">
+      <button
+        onClick={onBack}
+        className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <ChevronLeft className="h-4 w-4" />
+        Back
+      </button>
+
+      {shareId ? (
+        <>
+          <p className="mt-3 text-sm text-muted-foreground">
+            Anyone with this link can view this chat read-only. New messages stay
+            visible as the chat continues.
+          </p>
+          <div className="mt-3 flex items-center gap-2">
+            <input
+              readOnly
+              value={shareUrl}
+              onFocus={(e) => e.currentTarget.select()}
+              className="flex-1 min-w-0 rounded-md border border-border bg-muted px-2 py-2 text-sm text-foreground outline-none"
+            />
+            <button
+              onClick={copyLink}
+              className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-border text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+              aria-label="Copy link"
+            >
+              {copied ? (
+                <Check className="h-4 w-4 text-green-500" />
+              ) : (
+                <Copy className="h-4 w-4" />
+              )}
+            </button>
+          </div>
+          <button
+            onClick={revokeShare}
+            disabled={busy}
+            className="mt-4 flex items-center gap-2 text-sm text-destructive hover:text-destructive/80 transition-colors disabled:opacity-50"
+          >
+            {busy ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Link2Off className="h-4 w-4" />
+            )}
+            Stop sharing
+          </button>
+        </>
+      ) : (
+        <>
+          <p className="mt-3 text-sm text-muted-foreground">
+            Create a public link so anyone can view this chat read-only.
+          </p>
+          <button
+            onClick={enableShare}
+            disabled={busy}
+            className="mt-4 flex items-center justify-center gap-2 w-full rounded-md bg-foreground px-3 py-2.5 text-sm font-medium text-background hover:bg-foreground/90 transition-colors disabled:opacity-50"
+          >
+            {busy ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Share2 className="h-4 w-4" />
+            )}
+            Create public link
+          </button>
+        </>
+      )}
+    </div>
   )
 }

--- a/packages/web/components/chat/ChatHeader.tsx
+++ b/packages/web/components/chat/ChatHeader.tsx
@@ -8,6 +8,7 @@ import { useElectron } from "@/lib/hooks/useElectron"
 import { useRepoFolderButton } from "@/lib/hooks/useLocalSync"
 import { useModals, useGit } from "@/lib/contexts"
 import { Input } from "../ui/input"
+import { ShareButton } from "./ShareButton"
 import type { Chat } from "@/lib/types"
 import type { RebaseConflictState } from "@background-agents/common"
 
@@ -192,6 +193,7 @@ export function ChatHeader({
         style={isDesktopApp ? { WebkitAppRegion: "no-drag" } as React.CSSProperties : undefined}
       >
         <FolderSyncButton repo={chat.repo} />
+        <ShareButton chatId={chat.id} initialShareId={chat.shareId} />
         {onOpenCommandPalette && (
           <button
             onClick={onOpenCommandPalette}

--- a/packages/web/components/chat/ChatHeader.tsx
+++ b/packages/web/components/chat/ChatHeader.tsx
@@ -193,7 +193,7 @@ export function ChatHeader({
         style={isDesktopApp ? { WebkitAppRegion: "no-drag" } as React.CSSProperties : undefined}
       >
         <FolderSyncButton repo={chat.repo} />
-        <ShareButton chatId={chat.id} initialShareId={chat.shareId} />
+        <ShareButton key={chat.id} chatId={chat.id} initialShareId={chat.shareId} />
         {onOpenCommandPalette && (
           <button
             onClick={onOpenCommandPalette}

--- a/packages/web/components/chat/ShareButton.tsx
+++ b/packages/web/components/chat/ShareButton.tsx
@@ -1,0 +1,160 @@
+"use client"
+
+import { useState } from "react"
+import { Share2, Copy, Check, Loader2, Globe, Link2Off } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { notify } from "@/lib/notify"
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from "@/components/ui/popover"
+
+// =============================================================================
+// ShareButton — create / copy / revoke a public read-only link for a chat
+// =============================================================================
+//
+// The public link (/share/<shareId>) shows the chat's current messages
+// read-only — tool calls and outputs are visible, but file references render
+// as plain text rather than links. It's a live view: new messages appear on
+// the link as the chat continues.
+
+interface ShareButtonProps {
+  chatId: string
+  /** Current share token from the chat row (null/undefined = not shared). */
+  initialShareId?: string | null
+}
+
+export function ShareButton({ chatId, initialShareId }: ShareButtonProps) {
+  const [open, setOpen] = useState(false)
+  const [shareId, setShareId] = useState<string | null>(initialShareId ?? null)
+  const [busy, setBusy] = useState(false)
+  const [copied, setCopied] = useState(false)
+
+  const shareUrl =
+    shareId && typeof window !== "undefined"
+      ? `${window.location.origin}/share/${shareId}`
+      : ""
+
+  const enableShare = async () => {
+    setBusy(true)
+    try {
+      const res = await fetch(`/api/chats/${chatId}/share`, { method: "POST" })
+      if (!res.ok) throw new Error("Failed to create link")
+      const data = (await res.json()) as { shareId: string }
+      setShareId(data.shareId)
+    } catch {
+      notify({ title: "Couldn't create share link" })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const revokeShare = async () => {
+    setBusy(true)
+    try {
+      const res = await fetch(`/api/chats/${chatId}/share`, { method: "DELETE" })
+      if (!res.ok) throw new Error("Failed to revoke link")
+      setShareId(null)
+    } catch {
+      notify({ title: "Couldn't revoke share link" })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const copyLink = async () => {
+    if (!shareUrl) return
+    try {
+      await navigator.clipboard.writeText(shareUrl)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      notify({ title: "Couldn't copy link" })
+    }
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          className={cn(
+            "flex h-7 w-7 items-center justify-center rounded-md transition-colors cursor-pointer",
+            shareId
+              ? "text-green-500 hover:bg-green-500/10"
+              : "text-muted-foreground hover:bg-accent hover:text-foreground"
+          )}
+          title={shareId ? "Chat is shared publicly" : "Share chat"}
+          aria-label="Share chat"
+        >
+          <Share2 className="h-4 w-4" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-80">
+        <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+          <Globe className="h-4 w-4 text-muted-foreground" />
+          Share chat
+        </div>
+
+        {shareId ? (
+          <>
+            <p className="mt-2 text-xs text-muted-foreground">
+              Anyone with this link can view this chat read-only. New messages
+              stay visible as the chat continues.
+            </p>
+            <div className="mt-3 flex items-center gap-2">
+              <input
+                readOnly
+                value={shareUrl}
+                onFocus={(e) => e.currentTarget.select()}
+                className="flex-1 min-w-0 rounded-md border border-border bg-muted px-2 py-1.5 text-xs text-foreground outline-none"
+              />
+              <button
+                onClick={copyLink}
+                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-border text-muted-foreground hover:bg-accent hover:text-foreground transition-colors cursor-pointer"
+                title="Copy link"
+                aria-label="Copy link"
+              >
+                {copied ? (
+                  <Check className="h-3.5 w-3.5 text-green-500" />
+                ) : (
+                  <Copy className="h-3.5 w-3.5" />
+                )}
+              </button>
+            </div>
+            <button
+              onClick={revokeShare}
+              disabled={busy}
+              className="mt-3 flex items-center gap-1.5 text-xs text-destructive hover:text-destructive/80 transition-colors cursor-pointer disabled:opacity-50"
+            >
+              {busy ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Link2Off className="h-3.5 w-3.5" />
+              )}
+              Stop sharing
+            </button>
+          </>
+        ) : (
+          <>
+            <p className="mt-2 text-xs text-muted-foreground">
+              Create a public link so anyone can view this chat read-only.
+            </p>
+            <button
+              onClick={enableShare}
+              disabled={busy}
+              className="mt-3 flex items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs font-medium text-background hover:bg-foreground/90 transition-colors cursor-pointer disabled:opacity-50"
+            >
+              {busy ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Share2 className="h-3.5 w-3.5" />
+              )}
+              Create public link
+            </button>
+          </>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/packages/web/components/chat/ShareButton.tsx
+++ b/packages/web/components/chat/ShareButton.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react"
 import { Share2, Copy, Check, Loader2, Globe, Link2Off } from "lucide-react"
 import { cn } from "@/lib/utils"
-import { notify } from "@/lib/notify"
+import { useShareChat } from "@/lib/hooks/useShareChat"
 import {
   Popover,
   PopoverTrigger,
@@ -27,52 +27,8 @@ interface ShareButtonProps {
 
 export function ShareButton({ chatId, initialShareId }: ShareButtonProps) {
   const [open, setOpen] = useState(false)
-  const [shareId, setShareId] = useState<string | null>(initialShareId ?? null)
-  const [busy, setBusy] = useState(false)
-  const [copied, setCopied] = useState(false)
-
-  const shareUrl =
-    shareId && typeof window !== "undefined"
-      ? `${window.location.origin}/share/${shareId}`
-      : ""
-
-  const enableShare = async () => {
-    setBusy(true)
-    try {
-      const res = await fetch(`/api/chats/${chatId}/share`, { method: "POST" })
-      if (!res.ok) throw new Error("Failed to create link")
-      const data = (await res.json()) as { shareId: string }
-      setShareId(data.shareId)
-    } catch {
-      notify({ title: "Couldn't create share link" })
-    } finally {
-      setBusy(false)
-    }
-  }
-
-  const revokeShare = async () => {
-    setBusy(true)
-    try {
-      const res = await fetch(`/api/chats/${chatId}/share`, { method: "DELETE" })
-      if (!res.ok) throw new Error("Failed to revoke link")
-      setShareId(null)
-    } catch {
-      notify({ title: "Couldn't revoke share link" })
-    } finally {
-      setBusy(false)
-    }
-  }
-
-  const copyLink = async () => {
-    if (!shareUrl) return
-    try {
-      await navigator.clipboard.writeText(shareUrl)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 1500)
-    } catch {
-      notify({ title: "Couldn't copy link" })
-    }
-  }
+  const { shareId, busy, copied, shareUrl, enableShare, revokeShare, copyLink } =
+    useShareChat(chatId, initialShareId)
 
   return (
     <Popover open={open} onOpenChange={setOpen}>

--- a/packages/web/components/share/SharedChatView.tsx
+++ b/packages/web/components/share/SharedChatView.tsx
@@ -1,0 +1,71 @@
+"use client"
+
+import { Github } from "lucide-react"
+import type { Message } from "@/lib/types"
+import type { SharedChat } from "@/lib/server/shared-chat"
+import { MessageBubble } from "@/components/MessageBubble"
+
+// =============================================================================
+// SharedChatView — public, read-only rendering of a shared chat
+// =============================================================================
+//
+// Reuses MessageBubble but never passes `onOpenFile`, so tool-call file
+// references render as plain text (e.g. "Read: main.py") instead of clickable
+// links. There is no input, no sidebar — viewing only.
+
+interface SharedChatViewProps {
+  chat: SharedChat
+}
+
+export function SharedChatView({ chat }: SharedChatViewProps) {
+  const title = chat.displayName || "Shared chat"
+
+  return (
+    <div className="flex flex-col min-h-screen bg-background">
+      {/* Header */}
+      <header className="border-b border-border">
+        <div className="max-w-3xl mx-auto w-full px-6 py-4 flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <h1 className="text-sm font-medium text-foreground truncate">{title}</h1>
+            {chat.repo && (
+              <a
+                href={`https://github.com/${chat.repo}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-0.5 flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors w-fit"
+              >
+                <Github className="h-3 w-3 shrink-0" />
+                <span className="truncate">{chat.repo}</span>
+              </a>
+            )}
+          </div>
+          <span className="shrink-0 rounded-full border border-border px-2 py-0.5 text-xs text-muted-foreground">
+            Read-only
+          </span>
+        </div>
+      </header>
+
+      {/* Messages */}
+      <main className="flex-1 overflow-y-auto py-6 px-6">
+        <div className="max-w-3xl mx-auto w-full space-y-6">
+          {chat.messages.length === 0 ? (
+            <p className="text-sm text-muted-foreground text-center py-12">
+              This chat has no messages yet.
+            </p>
+          ) : (
+            chat.messages.map((message) => (
+              <MessageBubble
+                key={message.id}
+                // SharedMessage carries the same fields MessageBubble reads;
+                // JSONB tool data is already sanitized server-side.
+                message={message as unknown as Message}
+                repo={chat.repo ?? undefined}
+                // No onOpenFile / onForcePush: file references render as text.
+              />
+            ))
+          )}
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/packages/web/components/share/SharedChatView.tsx
+++ b/packages/web/components/share/SharedChatView.tsx
@@ -21,9 +21,12 @@ export function SharedChatView({ chat }: SharedChatViewProps) {
   const title = chat.displayName || "Shared chat"
 
   return (
-    <div className="flex flex-col min-h-screen bg-background">
+    // Fixed viewport height + min-h-0 on the scroll region: the app shell sets
+    // `body { overflow: hidden }`, so the page itself can't scroll — the
+    // messages area must be its own scroll container.
+    <div className="flex flex-col h-screen bg-background">
       {/* Header */}
-      <header className="border-b border-border">
+      <header className="border-b border-border shrink-0">
         <div className="max-w-3xl mx-auto w-full px-6 py-4 flex items-center justify-between gap-3">
           <div className="min-w-0">
             <h1 className="text-sm font-medium text-foreground truncate">{title}</h1>
@@ -46,7 +49,7 @@ export function SharedChatView({ chat }: SharedChatViewProps) {
       </header>
 
       {/* Messages */}
-      <main className="flex-1 overflow-y-auto py-6 px-6">
+      <main className="flex-1 min-h-0 overflow-y-auto py-6 px-6">
         <div className="max-w-3xl mx-auto w-full space-y-6">
           {chat.messages.length === 0 ? (
             <p className="text-sm text-muted-foreground text-center py-12">

--- a/packages/web/lib/db/api-helpers.ts
+++ b/packages/web/lib/db/api-helpers.ts
@@ -295,6 +295,7 @@ export async function getChatWithAuth(
   model: string | null
   planModeEnabled: boolean
   displayName: string | null
+  shareId: string | null
   status: string
   parentChatId: string | null
   needsSync: boolean

--- a/packages/web/lib/hooks/useShareChat.ts
+++ b/packages/web/lib/hooks/useShareChat.ts
@@ -1,0 +1,63 @@
+"use client"
+
+import { useState } from "react"
+import { notify } from "@/lib/notify"
+
+// =============================================================================
+// useShareChat — create / copy / revoke a chat's public read-only link
+// =============================================================================
+//
+// Shared by the desktop ShareButton (popover) and the mobile commands sheet.
+// Callers should key the host component by chatId so internal state resets when
+// the user switches chats.
+
+export function useShareChat(chatId: string, initialShareId?: string | null) {
+  const [shareId, setShareId] = useState<string | null>(initialShareId ?? null)
+  const [busy, setBusy] = useState(false)
+  const [copied, setCopied] = useState(false)
+
+  const shareUrl =
+    shareId && typeof window !== "undefined"
+      ? `${window.location.origin}/share/${shareId}`
+      : ""
+
+  const enableShare = async () => {
+    setBusy(true)
+    try {
+      const res = await fetch(`/api/chats/${chatId}/share`, { method: "POST" })
+      if (!res.ok) throw new Error("Failed to create link")
+      const data = (await res.json()) as { shareId: string }
+      setShareId(data.shareId)
+    } catch {
+      notify({ title: "Couldn't create share link" })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const revokeShare = async () => {
+    setBusy(true)
+    try {
+      const res = await fetch(`/api/chats/${chatId}/share`, { method: "DELETE" })
+      if (!res.ok) throw new Error("Failed to revoke link")
+      setShareId(null)
+    } catch {
+      notify({ title: "Couldn't revoke share link" })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const copyLink = async () => {
+    if (!shareUrl) return
+    try {
+      await navigator.clipboard.writeText(shareUrl)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      notify({ title: "Couldn't copy link" })
+    }
+  }
+
+  return { shareId, busy, copied, shareUrl, enableShare, revokeShare, copyLink }
+}

--- a/packages/web/lib/hooks/useShareChat.ts
+++ b/packages/web/lib/hooks/useShareChat.ts
@@ -16,10 +16,16 @@ export function useShareChat(chatId: string, initialShareId?: string | null) {
   const [busy, setBusy] = useState(false)
   const [copied, setCopied] = useState(false)
 
-  const shareUrl =
-    shareId && typeof window !== "undefined"
-      ? `${window.location.origin}/share/${shareId}`
+  // Build the link against the hosted backend origin when one is configured
+  // (the Electron desktop app sets BACKGROUND_AGENTS_API_URL — without this the
+  // link would be a useless `app://./share/...`). On the plain web app this is
+  // empty, so we fall back to the current origin (correct host in prod).
+  const origin =
+    typeof window !== "undefined"
+      ? (window as { BACKGROUND_AGENTS_API_URL?: string }).BACKGROUND_AGENTS_API_URL ||
+        window.location.origin
       : ""
+  const shareUrl = shareId && origin ? `${origin}/share/${shareId}` : ""
 
   const enableShare = async () => {
     setBusy(true)

--- a/packages/web/lib/server/shared-chat.ts
+++ b/packages/web/lib/server/shared-chat.ts
@@ -1,0 +1,99 @@
+import { prisma } from "@/lib/db/prisma"
+import { NEW_REPOSITORY } from "@/lib/types"
+
+// =============================================================================
+// Shared-chat data loading + sanitization
+// =============================================================================
+//
+// Used by both the public API route (/api/share/[shareId]) and the public page
+// (/share/[shareId]). The payload is deliberately minimal: only what's needed
+// to render the conversation read-only. Sandbox/session ids, env vars, branch,
+// and tool-call `filePath`s are stripped so nothing private or sandbox-local
+// leaks to viewers.
+
+export interface SharedMessage {
+  id: string
+  role: string
+  content: string
+  timestamp: number
+  messageType: string | null
+  isError: boolean
+  toolCalls: unknown
+  contentBlocks: unknown
+  uploadedFiles: unknown
+  linkBranch: string | null
+  metadata: unknown
+  agent: string | null
+  model: string | null
+}
+
+export interface SharedChat {
+  displayName: string | null
+  /** "owner/repo" for a real repo, or null for a local/private repo. */
+  repo: string | null
+  messages: SharedMessage[]
+}
+
+/** Drop `filePath` from a single tool call so absolute sandbox paths never
+ *  reach the public payload (the renderer also won't link them). */
+function sanitizeToolCall(tc: unknown): Record<string, unknown> | null {
+  if (!tc || typeof tc !== "object") return null
+  const { filePath: _filePath, ...rest } = tc as Record<string, unknown>
+  return rest
+}
+
+function sanitizeToolCalls(value: unknown): unknown {
+  if (!Array.isArray(value)) return value
+  return value.map(sanitizeToolCall).filter(Boolean)
+}
+
+/** Strip `filePath` from tool calls nested inside content blocks. */
+function sanitizeContentBlocks(value: unknown): unknown {
+  if (!Array.isArray(value)) return value
+  return value.map((block) => {
+    if (
+      block &&
+      typeof block === "object" &&
+      (block as Record<string, unknown>).type === "tool_calls"
+    ) {
+      const b = block as Record<string, unknown>
+      return { ...b, toolCalls: sanitizeToolCalls(b.toolCalls) }
+    }
+    return block
+  })
+}
+
+/** Load a publicly-shared chat by its share token, sanitized for public view.
+ *  Returns null if no chat has that token. */
+export async function getSharedChat(shareId: string): Promise<SharedChat | null> {
+  const chat = await prisma.chat.findUnique({
+    where: { shareId },
+    select: { id: true, displayName: true, repo: true },
+  })
+  if (!chat) return null
+
+  const messages = await prisma.message.findMany({
+    where: { chatId: chat.id },
+    orderBy: { timestamp: "asc" },
+  })
+
+  return {
+    displayName: chat.displayName,
+    repo: chat.repo === NEW_REPOSITORY ? null : chat.repo,
+    messages: messages.map((m) => ({
+      id: m.id,
+      role: m.role,
+      content: m.content,
+      timestamp: Number(m.timestamp),
+      messageType: m.messageType,
+      isError: m.isError,
+      toolCalls: sanitizeToolCalls(m.toolCalls),
+      contentBlocks: sanitizeContentBlocks(m.contentBlocks),
+      uploadedFiles: m.uploadedFiles,
+      linkBranch: m.linkBranch,
+      metadata: m.metadata,
+      agent: m.agent,
+      model: m.model,
+    })),
+  }
+}

--- a/packages/web/lib/sync/api.ts
+++ b/packages/web/lib/sync/api.ts
@@ -26,6 +26,7 @@ export interface ChatResponse {
   model: string | null
   planModeEnabled: boolean
   displayName: string | null
+  shareId?: string | null
   status: string
   parentChatId: string | null
   needsSync: boolean
@@ -238,6 +239,7 @@ export function toChatType(serverChat: ChatResponse): Chat {
     model: serverChat.model || undefined,
     planModeEnabled: serverChat.planModeEnabled,
     displayName: serverChat.displayName,
+    shareId: serverChat.shareId ?? null,
     status: serverChat.status as Chat["status"],
     parentChatId: serverChat.parentChatId || undefined,
     needsSync: serverChat.needsSync,

--- a/packages/web/lib/types.ts
+++ b/packages/web/lib/types.ts
@@ -163,6 +163,10 @@ export interface Chat {
   // Display name (auto-generated from first prompt)
   displayName: string | null
 
+  /** Public share token. When set, the chat is viewable read-only at
+   *  /share/<shareId> without auth. Null/undefined = private. */
+  shareId?: string | null
+
   /** When this chat was branched from another chat, the parent's id. */
   parentChatId?: string
 

--- a/packages/web/prisma/migrations/20260626000000_add_chat_share_id/migration.sql
+++ b/packages/web/prisma/migrations/20260626000000_add_chat_share_id/migration.sql
@@ -1,0 +1,6 @@
+-- Public sharing: an unguessable token that makes a chat viewable read-only at
+-- /share/<shareId> without authentication. Null = private.
+ALTER TABLE "Chat" ADD COLUMN "shareId" TEXT;
+
+-- Unique so a shareId maps to exactly one chat.
+CREATE UNIQUE INDEX "Chat_shareId_key" ON "Chat"("shareId");

--- a/packages/web/prisma/schema.prisma
+++ b/packages/web/prisma/schema.prisma
@@ -136,6 +136,11 @@ model Chat {
   displayName String?
   status      String  @default("pending") // pending, creating, ready, running, error
 
+  // Public sharing: when set, this chat is viewable (read-only) at
+  // /share/<shareId> without authentication. Null = private. The token is
+  // unguessable and distinct from `id` so the private id never leaks.
+  shareId String? @unique
+
   // Branching support
   parentChatId String?
   parentChat   Chat?   @relation("ChatBranches", fields: [parentChatId], references: [id], onDelete: SetNull)


### PR DESCRIPTION
# Shareable read-only public chat links
  Lets users share a chat via a public link. Visitors see a **read-only** view of
  the conversation — tool calls and their outputs are shown, but file references  (e.g. `Read: main.py`) render as plain text instead of clickable links. Regular
  markdown links stay clickable.

  ## Behavior

  - **Live link** (not a snapshot): the public page reflects the chat's current
    messages, so new messages appear on the link as the chat continues.
  - Toggle from the chat header (desktop) or the mobile commands sheet: create a
    link, copy it, or stop sharing (revokes the token).
  - Sharing is off by default; a chat is only public once a link is created.

  ## Changes

  ### Database
  - `Chat.shareId String? @unique` — an unguessable token (16 random bytes, hex).
    Null = private. Distinct from `id` so the private id never leaks.
  - Migration `20260626000000_add_chat_share_id`.

  ### API
  - `POST /api/chats/[chatId]/share` — owner-only; creates (or returns existing)
    `shareId`. `DELETE` revokes it.
  - `GET /api/share/[shareId]` — **no auth**; returns a sanitized payload via
    `lib/server/shared-chat.ts`.
  - `shareId` is now included in the chat list / detail / PATCH responses and the
    client `toChatType` mapping, so the share state survives a page refresh.

  ### Sanitization (what visitors can/can't see)
  - Included: chat title, repo (`owner/repo`, read-only label), messages, tool
    calls + outputs, uploaded file names.
  - Stripped: `filePath` on every tool call (defense-in-depth beyond not linking
    them), plus sandbox id, session id, env vars, and branch — none of these are
    in the public payload.

  ### Frontend
  - Public page `app/share/[shareId]/page.tsx` + `SharedChatView` — reuses
    `MessageBubble` **without `onOpenFile`**, so file references render as text.
    No input, no sidebar. `noindex`, and the messages area is its own scroll
    container (the app shell sets `body { overflow: hidden }`).
  - `ShareButton` (desktop `ChatHeader`) — popover to create / copy / revoke.
  - Mobile: Share action added to the kebab `MobileCommandsMenu` bottom sheet
    (create / copy / stop sharing).
  - `useShareChat` hook holds the shared create/copy/revoke logic. The link is
    built against the hosted backend origin when one is configured
    (`BACKGROUND_AGENTS_API_URL`) so it's correct in the Electron desktop app, and
    falls back to `window.location.origin` on the web (correct host in prod).

  ## Migration / deploy notes
  - Run `npm run prisma:migrate` to apply the new column locally; the Prisma
    client is already regenerated. Prod applies it via the existing
    `prisma migrate deploy` prebuild step.

  