### PR TITLE
fix: parent history not shown in branch and send

### DIFF
--- a/packages/web/lib/hooks/useChatMessageSync.ts
+++ b/packages/web/lib/hooks/useChatMessageSync.ts
@@ -38,6 +38,8 @@ export function useChatMessageSync({
   updateChatsCache,
 }: UseChatMessageSyncArgs): ChatMessageSync {
   const messagesLoadFailed = useRef<Set<string>>(new Set())
+  
+  const fullyLoaded = useRef<Set<string>>(new Set())
 
   // Load messages for current chat when selected
   useEffect(() => {
@@ -46,8 +48,16 @@ export function useChatMessageSync({
     const chat = chats.find((c) => c.id === currentChatId)
     if (!chat) return
 
-    // Skip if messages already loaded or previous load failed
-    if (chat.messages.length > 0 || messagesLoadFailed.current.has(currentChatId)) {
+    // Skip if we've already fetched this chat or a previous load failed.
+    if (fullyLoaded.current.has(currentChatId) || messagesLoadFailed.current.has(currentChatId)) {
+      return
+    }
+
+    const inheritedLoaded = chat.messages.some((m) => m.inherited)
+    const alreadyLoaded =
+      chat.messages.length > 0 && (!chat.parentChatId || inheritedLoaded)
+    if (alreadyLoaded) {
+      fullyLoaded.current.add(currentChatId)
       return
     }
 
@@ -66,6 +76,10 @@ export function useChatMessageSync({
             }
           })
         )
+        // Mark loaded even when the parent had no displayable messages, so we
+        // don't re-fetch on every render (this effect re-runs whenever `chats`
+        // changes, e.g. during streaming).
+        fullyLoaded.current.add(currentChatId)
       } catch (err) {
         console.error("Failed to load chat messages:", err)
         messagesLoadFailed.current.add(currentChatId)


### PR DESCRIPTION

## Fix: Parent history not showing on Alt+Enter branches

  **Problem:** Branching with `/branch` correctly showed the parent chat's
  history, but branching with **Alt+Enter** (branch + send) did not.
  
  **Cause:** Inherited parent messages are only attached by the *full* chat
  fetch, which the load-on-select effect skipped whenever a chat already had  messages. Alt+Enter runs the message in the background, so the branch already
  had its own messages by the time it was opened — the fetch was skipped and the
  parent history never loaded. `/branch` opened an empty branch, so the fetch
  (and inherited history) always ran.

  **Fix:** In `useChatMessageSync.ts`, a chat now counts as "loaded" only when it
  has messages **and** (it has no parent **or** its inherited messages are already
  present). A branch still missing parent history triggers the full fetch even if
  its own messages arrived in the background. A `fullyLoaded` ref marks completion
  explicitly to avoid re-fetch loops.