### PR TITLE
Enhance Gemini error handling and add failure fixture

### DIFF
--- a/packages/sdk/scripts/generate-jsonl-references.ts
+++ b/packages/sdk/scripts/generate-jsonl-references.ts
@@ -76,7 +76,16 @@ interface ProviderConfig {
   apiKeyEnvVar: string
   apiKey: string | undefined
   model?: string
+  /** Output basename (without .jsonl); defaults to `name`. */
+  outputName?: string
 }
+
+// Optional overrides for capturing failure fixtures (e.g. gemini-error.jsonl):
+//   GEMINI_MODEL=gemini-2.5-pro JSONL_OUTPUT_NAME=gemini-error \
+//     npm run generate:jsonl-refs -w @background-agents/sdk -- gemini
+// Run the Pro model with a FREE-tier GEMINI_API_KEY to capture the quota error.
+const GEMINI_MODEL = process.env.GEMINI_MODEL
+const JSONL_OUTPUT_NAME = process.env.JSONL_OUTPUT_NAME
 
 const providers: ProviderConfig[] = [
   {
@@ -93,6 +102,7 @@ const providers: ProviderConfig[] = [
     name: "gemini",
     apiKeyEnvVar: "GEMINI_API_KEY",
     apiKey: GEMINI_API_KEY,
+    model: GEMINI_MODEL,
   },
   {
     name: "goose",
@@ -204,7 +214,7 @@ async function generateReferenceForProvider(
     const rawJsonl = rawOutput
 
     // Write to file
-    const outputPath = join(FIXTURES_DIR, `${config.name}.jsonl`)
+    const outputPath = join(FIXTURES_DIR, `${config.outputName ?? config.name}.jsonl`)
     writeFileSync(outputPath, rawJsonl, "utf8")
     console.log(`  Written to: ${outputPath}`)
 
@@ -256,6 +266,10 @@ async function main() {
   for (const config of providers) {
     if (filterProvider && config.name !== filterProvider) {
       continue
+    }
+    // JSONL_OUTPUT_NAME only makes sense for a single filtered provider.
+    if (JSONL_OUTPUT_NAME && filterProvider === config.name) {
+      config.outputName = JSONL_OUTPUT_NAME
     }
     await generateReferenceForProvider(daytona, config)
   }

--- a/packages/sdk/src/agents/gemini/parser.ts
+++ b/packages/sdk/src/agents/gemini/parser.ts
@@ -9,7 +9,23 @@
  *   { type: "message", role, content, delta? }
  *   { type: "tool_use", tool_name, tool_id, parameters }   ← tool starts
  *   { type: "tool_result", tool_id, status, output? }      ← tool ends
- *   { type: "result", status, stats }                      ← turn end
+ *   { type: "result", status, error?, stats }              ← turn end
+ *
+ * Failure handling (verified against a real out-of-quota run — see
+ * tests/fixtures/jsonl-reference/gemini-error.jsonl). When a run fails (out of
+ * quota, a paid/Pro model on a free key, bad API key, …) the Gemini CLI:
+ *   1. prints the real reason as a *plain-text* JS error dump on stdout, e.g.
+ *      `Error when talking to Gemini API … TerminalQuotaError: You exceeded
+ *      your current quota …`, then
+ *   2. emits a `result` with `status: "error"`, but whose `error` object is a
+ *      generic `{ type: "unknown", message: "[API Error: …]" }` — the actual
+ *      reason is NOT in the JSON.
+ * The old parser ignored the plain-text line and collapsed *every* `result` to a
+ * bare `end`, so the turn ended with no output and no error — a silent stop. We
+ * now surface the rich plain-text reason as a classified `end.error`, and fall
+ * back to the (generic) `result.error` / non-success status if the text dump is
+ * ever absent. A defensive `error`-event branch is also kept for CLI versions /
+ * configs that emit one as JSON.
  *
  * Legacy schema (older CLI versions — kept for compatibility):
  *   { type: "assistant.delta", text }
@@ -23,6 +39,28 @@ import type { Event } from "../../types/events"
 import type { ParseContext } from "../../core/agent"
 import { createToolStartEvent, normalizeToolName } from "../../core/tools"
 import { safeJsonParse } from "../../utils/json"
+import {
+  classifyAgentError,
+  extractErrorMessage,
+  resolveAgentError,
+} from "../../utils/errors"
+
+/**
+ * Conservative match for Gemini's plain-text fatal line (the failure never made
+ * it into the JSON stream). Deliberately narrow so the harmless "YOLO mode is
+ * enabled" banner — which is also non-JSON — is never mistaken for an error.
+ */
+const GEMINI_ERROR_LINE =
+  /^error[:\s]|\b(quota exceeded|insufficient\s+balance|resource_exhausted|permission_denied)\b/i
+
+/**
+ * Strip noise from Gemini's plain-text error line before it reaches the user:
+ * the "Full report available at: <sandbox tmp path>" fragment points at a file
+ * inside a throwaway sandbox, so it is useless to surface.
+ */
+function cleanGeminiErrorLine(line: string): string {
+  return line.replace(/Full report available at:\s*\S+\s*/i, "").trim()
+}
 
 /**
  * Raw event types from Gemini's JSON stream
@@ -46,7 +84,17 @@ interface GeminiMessage {
 
 interface GeminiResult {
   type: "result"
-  status: string
+  status?: string
+  /** Present when the turn failed; shape mirrors json-mode `{ type, message, code }`. */
+  error?: unknown
+}
+
+/** Standalone error event (API/system error; may be fatal or a warning). */
+interface GeminiErrorEvent {
+  type: "error"
+  message?: string
+  code?: string | number
+  error?: unknown
 }
 
 /** Current Gemini CLI: tool invocation */
@@ -90,6 +138,7 @@ type GeminiEvent =
   | GeminiAssistantDelta
   | GeminiMessage
   | GeminiResult
+  | GeminiErrorEvent
   | GeminiToolUse
   | GeminiToolResult
   | GeminiToolStart
@@ -111,6 +160,13 @@ export function parseGeminiLine(
 ): Event | Event[] | null {
   const json = safeJsonParse<GeminiEvent>(line)
   if (!json) {
+    // Non-JSON line. Most are the harmless YOLO banner; a fatal failure that
+    // never reached the JSON stream prints a plain-text error line instead.
+    const trimmed = line.trim()
+    if (!context.state.geminiEnded && GEMINI_ERROR_LINE.test(trimmed)) {
+      context.state.geminiEnded = true
+      return { type: "end", error: resolveAgentError(cleanGeminiErrorLine(trimmed), "gemini") }
+    }
     return null
   }
 
@@ -133,8 +189,43 @@ export function parseGeminiLine(
     return null
   }
 
-  // Result event — marks turn completion
+  // Standalone error event. Per the headless docs these can be non-fatal
+  // ("Non-fatal warnings and system errors"), so we normally stash the detail
+  // and let the terminal `result` event decide. But a *recognized* fatal error
+  // (quota, auth, balance, unavailable model) may be the last line before a
+  // clean process exit with no `result` — surface it now so the turn never ends
+  // silently.
+  if (json.type === "error") {
+    const payload = json.error ?? json
+    const message = resolveAgentError(payload, "gemini")
+    context.state.geminiError = message
+    const category = classifyAgentError(extractErrorMessage(payload)).category
+    if (!context.state.geminiEnded && category !== "unknown") {
+      context.state.geminiEnded = true
+      return { type: "end", error: message }
+    }
+    return null
+  }
+
+  // Result event — marks turn completion. A non-"success" status (or an attached
+  // error object, or a stashed error event) means the turn failed; emit the
+  // classified detail rather than a bare end that looks like a silent success.
   if (json.type === "result") {
+    if (context.state.geminiEnded) return null
+    const failed =
+      typeof json.status === "string" && json.status.toLowerCase() !== "success"
+    const stashed =
+      typeof context.state.geminiError === "string"
+        ? (context.state.geminiError as string)
+        : undefined
+    if (failed || json.error != null || stashed) {
+      context.state.geminiEnded = true
+      const error =
+        json.error != null
+          ? resolveAgentError(json.error, "gemini")
+          : (stashed ?? `Gemini ended with status "${json.status ?? "error"}"`)
+      return { type: "end", error }
+    }
     return { type: "end" }
   }
 

--- a/packages/sdk/tests/fixtures/jsonl-reference/README.md
+++ b/packages/sdk/tests/fixtures/jsonl-reference/README.md
@@ -12,6 +12,7 @@ Raw JSONL output captured from actual AI coding agent CLI runs. These are **not 
 | `copilot-gpt-5-mini.jsonl` | GitHub Copilot | Copilot CLI with gpt-5-mini (free tier) — emits only `assistant.message_delta` (all `ephemeral: true`), no `assistant.message` |
 | `eliza.jsonl` | Eliza | Built-in deterministic test agent |
 | `gemini.jsonl` | Gemini | Google Gemini CLI |
+| `gemini-error.jsonl` | Gemini | Gemini CLI failing a run — a Pro model on a free key / out of quota (429 `TerminalQuotaError`). The real reason is a **plain-text** JS error dump on stdout; the trailing `result` has `status: "error"` but only a generic `{ type: "unknown", message: "[API Error: …]" }` |
 | `goose.jsonl` | Goose | Block's Goose AI coding agent CLI |
 | `kilo.jsonl` | Kilo | Kilo CLI — OpenCode fork with its own gateway |
 | `kimi.jsonl` | Kimi Code | Moonshot Kimi Code CLI — chat-completion-shaped stream-json |
@@ -32,3 +33,15 @@ npm run generate:jsonl-refs -w @background-agents/sdk
 Requires `DAYTONA_API_KEY` and provider-specific API keys (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`).
 
 **Note:** The Eliza agent is deterministic and does not require an API key.
+
+### Capturing a failure fixture (e.g. `gemini-error.jsonl`)
+
+`gemini-error.jsonl` is the `error` event + failing `result` Gemini emits when a
+Pro model is requested on a free-tier key. To re-capture it for real, run the
+Pro model with a **free-tier** `GEMINI_API_KEY` and override the model + output
+name:
+
+```bash
+GEMINI_MODEL=gemini-2.5-pro JSONL_OUTPUT_NAME=gemini-error \
+  npm run generate:jsonl-refs -w @background-agents/sdk -- gemini
+```

--- a/packages/sdk/tests/fixtures/jsonl-reference/gemini-error.jsonl
+++ b/packages/sdk/tests/fixtures/jsonl-reference/gemini-error.jsonl
@@ -1,0 +1,35 @@
+Warning: 256-color support not detected. Using a terminal with at least 256-color support is recommended for a better visual experience.
+YOLO mode is enabled. All tool calls will be automatically approved.
+YOLO mode is enabled. All tool calls will be automatically approved.
+{"type":"init","timestamp":"2026-06-30T21:18:24.988Z","session_id":"9face645-ec72-4895-b349-f82f420ba5f4","model":"gemini-2.5-pro"}
+{"type":"message","timestamp":"2026-06-30T21:18:24.989Z","role":"user","content":"Please do the following:\n1. Tell me what 2 + 2 equals\n2. List the files in the current directory using ls\n3. Create a file called hello.txt with the content \"Hello, World!\"\n4. Read the file you just created\nKeep your responses brief."}
+Error when talking to Gemini API Full report available at: /tmp/gemini-client-error-Turn.run-sendMessageStream-2026-06-30T21-18-25-124Z.json TerminalQuotaError: You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. 
+* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_input_token_count, limit: 0, model: gemini-2.5-pro
+* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 0, model: gemini-2.5-pro
+* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 0, model: gemini-2.5-pro
+* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_input_token_count, limit: 0, model: gemini-2.5-pro
+Please retry in 34.89668959s.
+    at classifyGoogleError (file:///usr/local/share/nvm/versions/node/v25.9.0/lib/node_modules/@google/gemini-cli/bundle/chunk-VLV2BYPM.js:297581:12)
+    at retryWithBackoff (file:///usr/local/share/nvm/versions/node/v25.9.0/lib/node_modules/@google/gemini-cli/bundle/chunk-VLV2BYPM.js:298310:31)
+    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
+    at async GeminiChat.makeApiCallAndProcessStream (file:///usr/local/share/nvm/versions/node/v25.9.0/lib/node_modules/@google/gemini-cli/bundle/chunk-VLV2BYPM.js:321564:28)
+    at async GeminiChat.streamWithRetries (file:///usr/local/share/nvm/versions/node/v25.9.0/lib/node_modules/@google/gemini-cli/bundle/chunk-VLV2BYPM.js:321382:29)
+    at async Turn.run (file:///usr/local/share/nvm/versions/node/v25.9.0/lib/node_modules/@google/gemini-cli/bundle/chunk-VLV2BYPM.js:322128:24)
+    at async GeminiClient.processTurn (file:///usr/local/share/nvm/versions/node/v25.9.0/lib/node_modules/@google/gemini-cli/bundle/chunk-VLV2BYPM.js:335620:22)
+    at async GeminiClient.sendMessageStream (file:///usr/local/share/nvm/versions/node/v25.9.0/lib/node_modules/@google/gemini-cli/bundle/chunk-VLV2BYPM.js:335717:14)
+    at async file:///usr/local/share/nvm/versions/node/v25.9.0/lib/node_modules/@google/gemini-cli/bundle/gemini-FSMCKCVD.js:23725:26
+    at async main (file:///usr/local/share/nvm/versions/node/v25.9.0/lib/node_modules/@google/gemini-cli/bundle/gemini-FSMCKCVD.js:29133:5) {
+  cause: {
+    code: 429,
+    message: 'You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n' +
+      '* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_input_token_count, limit: 0, model: gemini-2.5-pro\n' +
+      '* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 0, model: gemini-2.5-pro\n' +
+      '* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 0, model: gemini-2.5-pro\n' +
+      '* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_input_token_count, limit: 0, model: gemini-2.5-pro\n' +
+      'Please retry in 34.89668959s.',
+    details: [ [Object], [Object], [Object] ]
+  },
+  retryDelayMs: undefined,
+  reason: undefined
+}
+{"type":"result","timestamp":"2026-06-30T21:18:25.144Z","status":"error","error":{"type":"unknown","message":"[API Error: An unknown error occurred.]"},"stats":{"total_tokens":0,"input_tokens":0,"output_tokens":0,"cached":0,"input":0,"duration_ms":0,"tool_calls":0,"models":{"gemini-2.5-pro":{"total_tokens":0,"input_tokens":0,"output_tokens":0,"cached":0,"input":0}}}}

--- a/packages/sdk/tests/parsers/gemini.test.ts
+++ b/packages/sdk/tests/parsers/gemini.test.ts
@@ -160,5 +160,102 @@ describe("parseGeminiLine", () => {
     const ctx = createContext()
     expect(parseGeminiLine('{"type": "unknown"}', mappings, ctx)).toBeNull()
   })
+
+  // ─── Failure handling ──────────────────────────────────────────────────────
+
+  it("ends with a classified error when a recognized fatal error event arrives", () => {
+    const ctx = createContext()
+    const event = parseGeminiLine(
+      JSON.stringify({
+        type: "error",
+        message: "[429] You exceeded your current quota — RESOURCE_EXHAUSTED",
+        code: 429,
+      }),
+      mappings,
+      ctx
+    )
+    expect(event).toMatchObject({ type: "end" })
+    expect((event as { error?: string }).error).toContain("exceeded your current quota")
+    // rate-limit category appends an actionable hint
+    expect((event as { error?: string }).error).toContain("retry")
+  })
+
+  it("stashes a non-fatal error event and surfaces it on the failing result", () => {
+    const ctx = createContext()
+    // An error with no recognizable category should not end the turn on its own…
+    const mid = parseGeminiLine(
+      JSON.stringify({ type: "error", message: "transient backend warning" }),
+      mappings,
+      ctx
+    )
+    expect(mid).toBeNull()
+    // …but the terminal result carries it through instead of a silent end.
+    const end = parseGeminiLine(
+      JSON.stringify({ type: "result", status: "error", stats: {} }),
+      mappings,
+      ctx
+    )
+    expect(end).toEqual({ type: "end", error: "transient backend warning" })
+  })
+
+  it("ends with the error object detail when result.status is not success", () => {
+    const ctx = createContext()
+    const event = parseGeminiLine(
+      JSON.stringify({
+        type: "result",
+        status: "error",
+        error: { type: "ApiError", code: 429, message: "insufficient balance" },
+        stats: {},
+      }),
+      mappings,
+      ctx
+    )
+    expect(event).toMatchObject({ type: "end" })
+    expect((event as { error?: string }).error).toContain("insufficient balance")
+    expect((event as { error?: string }).error).toContain("add credits")
+  })
+
+  it("does not treat the YOLO banner line as an error", () => {
+    const ctx = createContext()
+    expect(
+      parseGeminiLine("YOLO mode is enabled. All tool calls will be automatically approved.", mappings, ctx)
+    ).toBeNull()
+  })
+
+  it("recognizes a plain-text fatal line that never reached the JSON stream", () => {
+    const ctx = createContext()
+    const event = parseGeminiLine(
+      "Error: quota exceeded for model gemini-2.5-pro (RESOURCE_EXHAUSTED)",
+      mappings,
+      ctx
+    )
+    expect(event).toMatchObject({ type: "end" })
+    expect((event as { error?: string }).error).toContain("quota exceeded")
+  })
+
+  // ─── Fixture-driven ──────────────────────────────────────────────────────
+
+  it("pro-model-on-free-key stream: surfaces a classified quota error (not a silent end)", () => {
+    const fs = require("fs")
+    const path = require("path")
+    const fixture = fs.readFileSync(
+      path.join(__dirname, "../fixtures/jsonl-reference/gemini-error.jsonl"),
+      "utf-8"
+    )
+    const ctx = createContext()
+    const events = fixture
+      .split("\n")
+      .filter(Boolean)
+      .map((l: string) => parseGeminiLine(l, mappings, ctx))
+      .filter(Boolean)
+      .flat() as { type: string; error?: string }[]
+    const ends = events.filter((e) => e.type === "end")
+    // Exactly one end, and it carries the failure detail + an actionable hint…
+    expect(ends).toHaveLength(1)
+    expect(ends[0].error).toContain("exceeded your current quota")
+    expect(ends[0].error).toMatch(/add credits|retry/)
+    // …with the useless sandbox tmp-file path stripped out.
+    expect(ends[0].error).not.toContain("Full report available at")
+  })
 })
 


### PR DESCRIPTION
 ## Surface Gemini errors instead of stopping silently

  ### Problem  When a Gemini run fails (out of quota, a Pro model used with a free-tier key, bad API key), the turn ended with no output and
  no error — a silent stop.
  ### Cause
  The Gemini parser ignored Gemini's plain-text error dump and collapsed *every* `result` event into a bare `end`, discarding
  the failure. (Verified against a real out-of-quota run: the actual reason is printed as a plain-text `TerminalQuotaError`,
  while the JSON `result.error` is only a generic `[API Error: …]`.)

  ### Fix
  - `gemini/parser.ts`: detect the plain-text fatal line (primary path for the real reason), handle non-success `result` as a
  fallback, strip the useless sandbox tmp-path, and emit a classified `end.error` with an actionable hint. Guard against
  double-ends.
  - Added `gemini-error.jsonl` fixture (captured from a real run) + parser tests.
  - `generate-jsonl-references.ts`: `GEMINI_MODEL` / `JSONL_OUTPUT_NAME` overrides so the failure fixture is reproducible.
  - README fixture docs.

  ### ScreenShot
  
<img width="834" height="308" alt="image" src="https://github.com/user-attachments/assets/778568b6-cbeb-4f85-a865-158f44713a3d" />
