### PR TITLE
Add logging for Claude credential refresh display history in admin tab

### DIFF
--- a/packages/web/app/api/admin/refresh-claude-creds/route.ts
+++ b/packages/web/app/api/admin/refresh-claude-creds/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server"
 import { requireAdmin, isAuthError } from "@/lib/db/api-helpers"
-import { setCookies } from "@/lib/claude-credentials"
+import { setCookies, listCcAuthRuns } from "@/lib/claude-credentials"
 import {
   refreshCredentials,
   refreshResultToResponse,
@@ -9,6 +9,20 @@ import {
 // Mirrors the cron route's budget — the first ccauth run in Daytona can take a
 // few minutes before the snapshot is cached.
 export const maxDuration = 300
+
+/**
+ * GET /api/admin/refresh-claude-creds
+ *
+ * Returns the recent credential-refresh audit log (cron + admin runs) for the
+ * admin "Credentials" tab, newest first.
+ */
+export async function GET() {
+  const auth = await requireAdmin()
+  if (isAuthError(auth)) return auth
+
+  const runs = await listCcAuthRuns(50)
+  return NextResponse.json({ runs })
+}
 
 /**
  * POST /api/admin/refresh-claude-creds
@@ -30,6 +44,7 @@ export async function POST(request: NextRequest) {
   }
   const force = body.force === true
   const cookies = typeof body.cookies === "string" ? body.cookies.trim() : ""
+  let cookiesUpdated = false
 
   if (cookies) {
     try {
@@ -41,8 +56,13 @@ export async function POST(request: NextRequest) {
       )
     }
     await setCookies(cookies)
+    cookiesUpdated = true
   }
 
-  const result = await refreshCredentials({ force })
+  const result = await refreshCredentials({
+    force,
+    trigger: "admin",
+    cookiesUpdated,
+  })
   return refreshResultToResponse(result)
 }

--- a/packages/web/app/api/cron/refresh-claude-creds/route.ts
+++ b/packages/web/app/api/cron/refresh-claude-creds/route.ts
@@ -1,14 +1,7 @@
-import { prisma } from "@/lib/db/prisma"
 import {
-  generateClaudeCredentials,
-  CLAUDE_CREDS_KEY,
-  CLAUDE_COOKIES_KEY,
-} from "@background-agents/claude-credentials"
-
-// Skip refresh while the live credential still has at least this much life.
-// Anthropic OAuth access tokens are 8h-lived, so 2h leaves us 6 hours of cron
-// retries before stale-token risk.
-const SKIP_THRESHOLD_MS = 2 * 60 * 60 * 1000
+  refreshCredentials,
+  refreshResultToResponse,
+} from "@/lib/server/refresh-claude-credentials"
 
 // Daytona's first build of the ccauth image can take a few minutes; after the
 // snapshot is cached, subsequent runs are fast. 300s fits Pro plan limits;
@@ -22,68 +15,12 @@ export async function GET(req: Request) {
     return new Response("Unauthorized", { status: 401 })
   }
 
-  const credsRow = await prisma.ccAuthInfo.findUnique({
-    where: { id: CLAUDE_CREDS_KEY },
-    select: { value: true },
-  })
-  if (credsRow) {
-    try {
-      const parsed = JSON.parse(credsRow.value) as {
-        claudeAiOauth?: { expiresAt?: number }
-      }
-      const expiresAt = parsed.claudeAiOauth?.expiresAt
-      if (
-        typeof expiresAt === "number" &&
-        expiresAt - Date.now() > SKIP_THRESHOLD_MS
-      ) {
-        return Response.json({ skipped: true, expiresAt })
-      }
-    } catch (err) {
-      // Malformed row — fall through and overwrite.
-      console.warn(
-        "[cron/refresh-claude-creds] Existing creds row unparseable:",
-        err,
-      )
-    }
-  }
+  // `?force=1` bypasses the skip-while-fresh threshold so a token can be
+  // regenerated on demand for testing. The hourly cron never sets it.
+  const force = ["1", "true"].includes(
+    new URL(req.url).searchParams.get("force") ?? "",
+  )
 
-  const cookiesRow = await prisma.ccAuthInfo.findUnique({
-    where: { id: CLAUDE_COOKIES_KEY },
-    select: { value: true },
-  })
-  if (!cookiesRow) {
-    return Response.json(
-      {
-        error: "COOKIES_UNAVAILABLE",
-        message: `CcAuthInfo row '${CLAUDE_COOKIES_KEY}' not found — seed it first with npm run seed:ccauth.`,
-      },
-      { status: 500 },
-    )
-  }
-
-  let creds
-  try {
-    creds = await generateClaudeCredentials(cookiesRow.value)
-  } catch (err) {
-    console.error("[cron/refresh-claude-creds] ccauth failed:", err)
-    return Response.json(
-      {
-        error: "CCAUTH_FAILED",
-        message: err instanceof Error ? err.message : String(err),
-      },
-      { status: 500 },
-    )
-  }
-
-  const value = JSON.stringify(creds)
-  await prisma.ccAuthInfo.upsert({
-    where: { id: CLAUDE_CREDS_KEY },
-    create: { id: CLAUDE_CREDS_KEY, value },
-    update: { value },
-  })
-
-  return Response.json({
-    refreshed: true,
-    expiresAt: creds.claudeAiOauth.expiresAt,
-  })
+  const result = await refreshCredentials({ force, trigger: "cron" })
+  return refreshResultToResponse(result)
 }

--- a/packages/web/components/admin/ClaudeCredentials.tsx
+++ b/packages/web/components/admin/ClaudeCredentials.tsx
@@ -1,18 +1,59 @@
 "use client"
 
 import { useState } from "react"
-import { KeyRound, RefreshCw, Zap, CheckCircle2, AlertCircle } from "lucide-react"
-import { useRefreshClaudeCredsMutation } from "@/lib/query/hooks"
+import {
+  KeyRound,
+  RefreshCw,
+  Zap,
+  CheckCircle2,
+  AlertCircle,
+  History,
+} from "lucide-react"
+import {
+  useRefreshClaudeCredsMutation,
+  useCcAuthRunsQuery,
+  type CcAuthRun,
+} from "@/lib/query/hooks"
 import { cn } from "@/lib/utils"
 
 type Outcome =
   | { ok: true; label: string; expiresAt?: number }
   | { ok: false; message: string }
 
+/** Human-friendly duration: "820 ms", "4.2 s", or "2 m 5 s". */
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms} ms`
+  const seconds = ms / 1000
+  if (seconds < 60) return `${seconds.toFixed(1)} s`
+  const m = Math.floor(seconds / 60)
+  const s = Math.round(seconds % 60)
+  return `${m} m ${s} s`
+}
+
+const STATUS_STYLES: Record<string, string> = {
+  refreshed: "border-green-500/30 bg-green-500/10 text-green-600 dark:text-green-400",
+  skipped: "border-muted-foreground/20 bg-muted text-muted-foreground",
+  error: "border-destructive/30 bg-destructive/10 text-destructive",
+}
+
+function StatusBadge({ status }: { status: string }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium capitalize",
+        STATUS_STYLES[status] ?? "border-muted-foreground/20 bg-muted text-muted-foreground",
+      )}
+    >
+      {status}
+    </span>
+  )
+}
+
 export function ClaudeCredentials() {
   const [cookies, setCookies] = useState("")
   const [outcome, setOutcome] = useState<Outcome | null>(null)
   const mutation = useRefreshClaudeCredsMutation()
+  const runsQuery = useCcAuthRunsQuery()
 
   const run = (force: boolean) => {
     setOutcome(null)
@@ -42,9 +83,11 @@ export function ClaudeCredentials() {
   const pendingForce = pending && mutation.variables?.force === true
   const pendingNormal = pending && mutation.variables?.force !== true
 
+  const runs = runsQuery.data?.runs ?? []
+
   return (
-    <section className="max-w-2xl space-y-6">
-      <div>
+    <section className="space-y-6">
+      <div className="max-w-2xl">
         <h2 className="text-lg font-semibold md:text-xl">Claude Credentials</h2>
         <p className="mt-1 text-sm text-muted-foreground">
           Regenerate the shared Claude OAuth token from the stored claude.ai
@@ -55,7 +98,7 @@ export function ClaudeCredentials() {
         </p>
       </div>
 
-      <div className="rounded-xl border bg-card p-4 md:p-6 shadow-sm space-y-4">
+      <div className="max-w-2xl rounded-xl border bg-card p-4 md:p-6 shadow-sm space-y-4">
         <div className="space-y-2">
           <label
             htmlFor="claude-cookies"
@@ -140,6 +183,125 @@ export function ClaudeCredentials() {
           </div>
         )}
       </div>
+
+      {/* Run history */}
+      <div className="rounded-xl border bg-card shadow-sm">
+        <div className="flex items-center justify-between gap-2 border-b p-4">
+          <div className="flex items-center gap-2">
+            <History className="h-4 w-4 text-muted-foreground" />
+            <h3 className="font-medium">Refresh history</h3>
+          </div>
+          <button
+            type="button"
+            onClick={() => runsQuery.refetch()}
+            disabled={runsQuery.isFetching}
+            className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground hover:bg-accent hover:text-foreground disabled:opacity-60"
+          >
+            <RefreshCw
+              className={cn("h-3.5 w-3.5", runsQuery.isFetching && "animate-spin")}
+            />
+            Reload
+          </button>
+        </div>
+
+        <RunHistory
+          runs={runs}
+          isLoading={runsQuery.isLoading}
+          isError={runsQuery.isError}
+        />
+      </div>
     </section>
+  )
+}
+
+function RunHistory({
+  runs,
+  isLoading,
+  isError,
+}: {
+  runs: CcAuthRun[]
+  isLoading: boolean
+  isError: boolean
+}) {
+  if (isLoading) {
+    return (
+      <div className="space-y-2 p-4">
+        {[1, 2, 3, 4, 5].map((i) => (
+          <div key={i} className="h-9 animate-pulse rounded-md bg-muted" />
+        ))}
+      </div>
+    )
+  }
+
+  if (isError) {
+    return (
+      <p className="p-6 text-center text-sm text-destructive">
+        Failed to load refresh history.
+      </p>
+    )
+  }
+
+  if (runs.length === 0) {
+    return (
+      <p className="p-6 text-center text-sm text-muted-foreground">
+        No refresh runs recorded yet.
+      </p>
+    )
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b text-left text-xs text-muted-foreground">
+            <th className="px-4 py-2 font-medium">When</th>
+            <th className="px-4 py-2 font-medium">Status</th>
+            <th className="px-4 py-2 font-medium">Trigger</th>
+            <th className="px-4 py-2 font-medium">Duration</th>
+            <th className="px-4 py-2 font-medium">Result</th>
+          </tr>
+        </thead>
+        <tbody>
+          {runs.map((r) => (
+            <tr key={r.id} className="border-b last:border-0 align-top">
+              <td className="whitespace-nowrap px-4 py-2.5 text-muted-foreground">
+                {new Date(r.createdAt).toLocaleString()}
+              </td>
+              <td className="px-4 py-2.5">
+                <StatusBadge status={r.status} />
+              </td>
+              <td className="px-4 py-2.5">
+                <span className="capitalize">{r.trigger}</span>
+                {r.forced && (
+                  <span className="ml-1.5 rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium uppercase text-primary">
+                    forced
+                  </span>
+                )}
+                {r.cookiesUpdated && (
+                  <span className="ml-1.5 rounded bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium uppercase text-amber-600 dark:text-amber-400">
+                    cookies
+                  </span>
+                )}
+              </td>
+              <td className="whitespace-nowrap px-4 py-2.5 tabular-nums">
+                {formatDuration(r.durationMs)}
+              </td>
+              <td className="px-4 py-2.5 text-muted-foreground">
+                {r.status === "error" ? (
+                  <span className="text-destructive">
+                    {r.code}
+                    {r.message ? `: ${r.message}` : ""}
+                  </span>
+                ) : r.expiresAt ? (
+                  <>Token expires {new Date(r.expiresAt).toLocaleString()}</>
+                ) : (
+                  "—"
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   )
 }

--- a/packages/web/lib/claude-credentials.ts
+++ b/packages/web/lib/claude-credentials.ts
@@ -77,3 +77,66 @@ export async function isSharedPoolAvailable(): Promise<boolean> {
   })
   return !!row
 }
+
+/** A single row of the credential-refresh audit log, serialized for the client. */
+export interface CcAuthRunView {
+  id: string
+  status: string
+  code: string | null
+  message: string | null
+  trigger: string
+  forced: boolean
+  cookiesUpdated: boolean
+  durationMs: number
+  expiresAt: string | null
+  createdAt: string
+}
+
+/**
+ * Appends a row to the credential-refresh audit log (see {@link CcAuthRunView}).
+ * `expiresAt` is passed as epoch-ms (as it flows through RefreshResult) and
+ * stored as a timestamp.
+ */
+export async function recordCcAuthRun(run: {
+  status: string
+  code?: string | null
+  message?: string | null
+  trigger: string
+  forced: boolean
+  cookiesUpdated: boolean
+  durationMs: number
+  expiresAt?: number | null
+}): Promise<void> {
+  await prisma.ccAuthRun.create({
+    data: {
+      status: run.status,
+      code: run.code ?? null,
+      message: run.message ?? null,
+      trigger: run.trigger,
+      forced: run.forced,
+      cookiesUpdated: run.cookiesUpdated,
+      durationMs: run.durationMs,
+      expiresAt: run.expiresAt != null ? new Date(run.expiresAt) : null,
+    },
+  })
+}
+
+/** Returns the most recent credential-refresh runs, newest first. */
+export async function listCcAuthRuns(limit = 50): Promise<CcAuthRunView[]> {
+  const rows = await prisma.ccAuthRun.findMany({
+    orderBy: { createdAt: "desc" },
+    take: limit,
+  })
+  return rows.map((r) => ({
+    id: r.id,
+    status: r.status,
+    code: r.code,
+    message: r.message,
+    trigger: r.trigger,
+    forced: r.forced,
+    cookiesUpdated: r.cookiesUpdated,
+    durationMs: r.durationMs,
+    expiresAt: r.expiresAt ? r.expiresAt.toISOString() : null,
+    createdAt: r.createdAt.toISOString(),
+  }))
+}

--- a/packages/web/lib/query/hooks/index.ts
+++ b/packages/web/lib/query/hooks/index.ts
@@ -28,3 +28,5 @@ export type {
   RefreshClaudeCredsParams,
   RefreshClaudeCredsResult,
 } from "./useRefreshClaudeCredsMutation"
+export { useCcAuthRunsQuery } from "./useCcAuthRunsQuery"
+export type { CcAuthRun } from "./useCcAuthRunsQuery"

--- a/packages/web/lib/query/hooks/useCcAuthRunsQuery.ts
+++ b/packages/web/lib/query/hooks/useCcAuthRunsQuery.ts
@@ -1,0 +1,40 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+import { useSession } from "next-auth/react"
+import { queryKeys } from "../keys"
+import { adminRetry, fetchAdminJson } from "./adminQuery"
+
+/** One row of the Claude credential-refresh audit log. */
+export interface CcAuthRun {
+  id: string
+  status: "skipped" | "refreshed" | "error" | string
+  code: string | null
+  message: string | null
+  trigger: string
+  forced: boolean
+  cookiesUpdated: boolean
+  durationMs: number
+  expiresAt: string | null
+  createdAt: string
+}
+
+interface CcAuthRunsResponse {
+  runs: CcAuthRun[]
+}
+
+export function useCcAuthRunsQuery() {
+  const { status } = useSession()
+
+  return useQuery({
+    queryKey: queryKeys.admin.ccAuthRuns(),
+    queryFn: () =>
+      fetchAdminJson<CcAuthRunsResponse>(
+        "/api/admin/refresh-claude-creds",
+        "ccauth runs",
+      ),
+    enabled: status === "authenticated",
+    staleTime: 15 * 1000,
+    retry: adminRetry,
+  })
+}

--- a/packages/web/lib/query/hooks/useRefreshClaudeCredsMutation.ts
+++ b/packages/web/lib/query/hooks/useRefreshClaudeCredsMutation.ts
@@ -1,6 +1,7 @@
 "use client"
 
-import { useMutation } from "@tanstack/react-query"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { queryKeys } from "../keys"
 
 export interface RefreshClaudeCredsParams {
   /** Bypass the skip-while-fresh threshold and regenerate the token now. */
@@ -37,5 +38,16 @@ async function refreshClaudeCreds(
 }
 
 export function useRefreshClaudeCredsMutation() {
-  return useMutation({ mutationFn: refreshClaudeCreds })
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: refreshClaudeCreds,
+    // Every refresh appends an audit-log row — refresh the log view regardless
+    // of success/failure (failed runs are logged too).
+    onSettled: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.admin.ccAuthRuns(),
+      })
+    },
+  })
 }

--- a/packages/web/lib/query/keys.ts
+++ b/packages/web/lib/query/keys.ts
@@ -54,6 +54,7 @@ export const queryKeys = {
     users: (page: number, search?: string, sortField?: string, sortOrder?: string) =>
       [...queryKeys.admin.all, "users", { page, search, sortField, sortOrder }] as const,
     topUsers: (range: string) => [...queryKeys.admin.all, "topUsers", range] as const,
+    ccAuthRuns: () => [...queryKeys.admin.all, "ccAuthRuns"] as const,
   },
 }
 

--- a/packages/web/lib/server/refresh-claude-credentials.ts
+++ b/packages/web/lib/server/refresh-claude-credentials.ts
@@ -20,6 +20,7 @@ import {
   readCredentials,
   writeCredentials,
   getCookies,
+  recordCcAuthRun,
 } from "@/lib/claude-credentials"
 
 // Skip refresh while the live credential still has at least this much life.
@@ -50,9 +51,40 @@ export type RefreshResult =
  *   - CCAUTH_FAILED       — ccauth couldn't mint a token (often expired cookies).
  */
 export async function refreshCredentials(
-  opts: { force?: boolean } = {},
+  opts: {
+    force?: boolean
+    /** Who triggered this run, recorded in the audit log. Defaults to "cron". */
+    trigger?: "cron" | "admin"
+    /** Whether the caller rotated the stored cookies just before this run. */
+    cookiesUpdated?: boolean
+  } = {},
 ): Promise<RefreshResult> {
-  if (!opts.force) {
+  const startedAt = Date.now()
+  const result = await runRefresh(opts.force ?? false)
+  const durationMs = Date.now() - startedAt
+
+  // Append to the audit log powering the admin "Credentials" tab. Never let a
+  // logging failure mask the actual refresh outcome.
+  try {
+    await recordCcAuthRun({
+      status: result.status,
+      code: result.status === "error" ? result.code : null,
+      message: result.status === "error" ? result.message : null,
+      trigger: opts.trigger ?? "cron",
+      forced: opts.force ?? false,
+      cookiesUpdated: opts.cookiesUpdated ?? false,
+      durationMs,
+      expiresAt: result.status === "error" ? null : result.expiresAt,
+    })
+  } catch (err) {
+    console.error("[refresh-claude-credentials] Failed to record run:", err)
+  }
+
+  return result
+}
+
+async function runRefresh(force: boolean): Promise<RefreshResult> {
+  if (!force) {
     const existing = await readCredentials()
     if (existing) {
       try {

--- a/packages/web/prisma/migrations/20260704000000_add_ccauth_run/migration.sql
+++ b/packages/web/prisma/migrations/20260704000000_add_ccauth_run/migration.sql
@@ -1,0 +1,21 @@
+-- Audit log of every Claude credential refresh attempt (cron + admin panel).
+-- Powers the "Credentials" admin tab: refresh history, durations, and failures.
+
+-- CreateTable
+CREATE TABLE "CcAuthRun" (
+    "id" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "code" TEXT,
+    "message" TEXT,
+    "trigger" TEXT NOT NULL,
+    "forced" BOOLEAN NOT NULL DEFAULT false,
+    "cookiesUpdated" BOOLEAN NOT NULL DEFAULT false,
+    "durationMs" INTEGER NOT NULL,
+    "expiresAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "CcAuthRun_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "CcAuthRun_createdAt_idx" ON "CcAuthRun"("createdAt");

--- a/packages/web/prisma/schema.prisma
+++ b/packages/web/prisma/schema.prisma
@@ -279,6 +279,30 @@ model CcAuthInfo {
 }
 
 // =============================================================================
+// CcAuthRun - audit log of every Claude credential refresh attempt
+// =============================================================================
+// One row per call to refreshCredentials() (hourly cron or admin panel action).
+// Powers the "Credentials" admin tab so operators can see refresh history,
+// durations, and failures at a glance. `durationMs` is the wall-clock time of
+// the whole attempt (the ccauth run in Daytona dominates real refreshes; skips
+// are near-instant).
+
+model CcAuthRun {
+  id             String    @id @default(cuid())
+  status         String // "skipped" | "refreshed" | "error"
+  code           String? // error code when status = "error": "COOKIES_UNAVAILABLE" | "CCAUTH_FAILED"
+  message        String?   @db.Text // error message when status = "error"
+  trigger        String // "cron" | "admin"
+  forced         Boolean   @default(false) // whether the skip-while-fresh threshold was bypassed
+  cookiesUpdated Boolean   @default(false) // whether this run also rotated the stored cookies
+  durationMs     Int // wall-clock duration of the attempt
+  expiresAt      DateTime? // resulting token expiry, when known (skipped/refreshed)
+  createdAt      DateTime  @default(now())
+
+  @@index([createdAt])
+}
+
+// =============================================================================
 // ActivityLog - tracks user actions for admin analytics
 // =============================================================================
 


### PR DESCRIPTION
Implement logging for Claude credential refresh operations and display the refresh history in the admin tab to improve monitoring and auditability.