### PR TITLE
Feat/shared pool green dots

### DIFF
--- a/packages/common/src/agents.ts
+++ b/packages/common/src/agents.ts
@@ -627,6 +627,22 @@ export function hasCredentialsForModel(
 }
 
 /**
+ * The provider key a given agent+model requires ("anthropic" / "gemini" / …),
+ * "none" for no-key models, or undefined when the model isn't in the agent's
+ * list. The lookup is agent-scoped because the same model id can require a
+ * different key under different agents. Used server-side to decide which shared
+ * pool a run draws from (e.g. a Gemini model under Pi/Droid uses the shared
+ * Gemini key — see resolvePool / providerForRun).
+ */
+export function modelRequiresKey(
+  agent: Agent,
+  model: string | undefined
+): ProviderId | "none" | undefined {
+  if (!model) return undefined
+  return (agentModels[agent] ?? []).find((m) => m.value === model)?.requiresKey
+}
+
+/**
  * Get the default model for an agent based on available credentials.
  * Falls back to free models if no API keys are configured.
  */

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -47,6 +47,7 @@ export {
   agentSharedPoolExhausted,
   agentIsReady,
   hasCredentialsForModel,
+  modelRequiresKey,
   getDefaultModelForAgent,
   resolveModelForAgent,
   resolveAgent,

--- a/packages/web/app/api/shared-pool/route.ts
+++ b/packages/web/app/api/shared-pool/route.ts
@@ -1,0 +1,26 @@
+import { getSharedPoolFlags } from "@/lib/server/credential-flags"
+import { internalError } from "@/lib/db/api-helpers"
+import type { CredentialFlags } from "@/lib/credentials"
+
+interface SharedPoolResponse {
+  /** Server-config-only flags (shared pools available to everyone, no user context). */
+  credentialFlags: CredentialFlags
+}
+
+// =============================================================================
+// GET - Public shared-pool availability (no auth)
+// =============================================================================
+//
+// Exposes only booleans about which shared pools the server has configured, so
+// logged-out visitors can see the agent picker's shared-pool "ready" dots
+// before signing in. Never returns key values or any user-specific data.
+
+export async function GET(): Promise<Response> {
+  try {
+    const credentialFlags = await getSharedPoolFlags()
+    const response: SharedPoolResponse = { credentialFlags }
+    return Response.json(response)
+  } catch (error) {
+    return internalError(error)
+  }
+}

--- a/packages/web/lib/db/usage-limit.ts
+++ b/packages/web/lib/db/usage-limit.ts
@@ -15,7 +15,7 @@ import type { Agent, ProviderName } from "@background-agents/common"
 
 import { prisma } from "./prisma"
 import { sumSharedUsage, countSharedMessages } from "./token-usage"
-import { isSharedPoolAgent, providerForAgent, resolvePool } from "@/lib/server/shared-pool"
+import { providerForRun, resolvePool } from "@/lib/server/shared-pool"
 import { decryptUserCredentials } from "./api-helpers"
 import {
   getProviderBudget,
@@ -53,7 +53,7 @@ export async function checkSharedPoolUsage(
   agent: Agent,
   model?: string
 ): Promise<UsageLimitResult> {
-  const provider = providerForAgent(agent)
+  const provider = providerForRun(agent, model)
   const resetAt = getNextUtcDayReset()
 
   const user = await prisma.user.findUnique({
@@ -65,8 +65,9 @@ export async function checkSharedPoolUsage(
   const storedCreds = decryptUserCredentials(
     user?.credentials as Record<string, unknown> | null
   )
-  // A custom-endpoint run uses the user's own endpoint, not the shared pool, so
-  // it should never be rate-limited as shared.
+  // resolvePool folds in the model: custom endpoints and own-key runs read as
+  // "user" (never rate-limited), and a Gemini model under a BYOK agent (Pi,
+  // Droid) reads as the shared Gemini pool.
   const pool = resolvePool(agent, storedCreds, model)
 
   const budget = getProviderBudget(provider, plan)
@@ -80,8 +81,10 @@ export async function checkSharedPoolUsage(
     resetAt,
   }
 
-  // Not a shared-pool run → unlimited.
-  if (!isSharedPoolAgent(agent) || pool === "user") {
+  // Not a shared-pool run → unlimited. resolvePool returns "shared" only for a
+  // genuine shared-pool run (incl. a Gemini model under Pi/Droid), so gating on
+  // the resolved pool covers every case without an agent allowlist.
+  if (pool === "user") {
     return { ...base, allowed: true, limit: null, remaining: null }
   }
 

--- a/packages/web/lib/query/hooks/useSettingsQuery.ts
+++ b/packages/web/lib/query/hooks/useSettingsQuery.ts
@@ -1,9 +1,10 @@
 "use client"
 
-import { useQuery } from "@tanstack/react-query"
+import { useEffect } from "react"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useSession } from "next-auth/react"
 import { queryKeys } from "../keys"
-import { fetchSettings } from "@/lib/sync/api"
+import { fetchSettings, fetchSharedPoolFlags } from "@/lib/sync/api"
 import type { Settings, CredentialFlags, CustomEndpoint } from "@/lib/types"
 import { DEFAULT_SETTINGS } from "@/lib/storage"
 
@@ -21,15 +22,36 @@ export interface SettingsData {
 
 /**
  * Fetches user settings and credential flags.
- * Only enabled when authenticated.
+ *
+ * Authenticated: the full user settings + effective credential flags.
+ * Logged out: only the public shared-pool flags (server config, no user data),
+ * so the agent picker can still show shared-pool "ready" dots before sign-in.
+ * The auth state is part of the query key so login/logout refetches the right
+ * source.
  */
 export function useSettingsQuery() {
   const { data: session, status } = useSession()
   const isAuthenticated = status === "authenticated" && !!session?.user?.id
+  const queryClient = useQueryClient()
+
+  // The data source flips with auth (authed settings vs public shared-pool
+  // flags), but the cache key stays queryKeys.settings.all so the optimistic
+  // writers (settings mutation, Claude-usage decrement) keep hitting it. Refetch
+  // on the transition so a login/logout swaps the data instead of serving the
+  // previous state until it goes stale.
+  useEffect(() => {
+    if (status === "loading") return
+    queryClient.invalidateQueries({ queryKey: queryKeys.settings.all })
+  }, [isAuthenticated, status, queryClient])
 
   return useQuery({
     queryKey: queryKeys.settings.all,
     queryFn: async (): Promise<SettingsData> => {
+      if (!isAuthenticated) {
+        // Logged out: settings stay at defaults; only shared-pool flags are real.
+        const { credentialFlags } = await fetchSharedPoolFlags()
+        return { settings: DEFAULT_SETTINGS, credentialFlags }
+      }
       const response = await fetchSettings()
       return {
         settings: response.settings,
@@ -43,7 +65,9 @@ export function useSettingsQuery() {
         claudeIsWeekly: response.claudeIsWeekly,
       }
     },
-    enabled: isAuthenticated,
+    // Wait until NextAuth resolves so we don't fetch the anon endpoint for a
+    // user who is actually signed in (which would flash the wrong dots).
+    enabled: status !== "loading",
     staleTime: 60 * 1000, // 1 minute - settings don't change often
     // Provide default values while loading
     placeholderData: {

--- a/packages/web/lib/server/credential-flags.ts
+++ b/packages/web/lib/server/credential-flags.ts
@@ -45,6 +45,37 @@ export interface EffectiveFlags {
  *
  * The resulting flags can be passed directly to getDefaultAgent/hasCredentialsForModel.
  */
+/**
+ * Server-config-only credential flags — the shared pools available to everyone,
+ * derived purely from server env / rotating credential state with no user
+ * context. Safe to expose to logged-out visitors so the agent picker can show
+ * the shared-pool "ready" dots (Claude Code, Gemini, OpenCode) before sign-in.
+ *
+ * Only booleans about server configuration are returned — never key values.
+ * getEffectiveCredentialFlags layers the user's own stored credentials and the
+ * daily-limit state on top of these same signals for an authenticated user.
+ */
+export async function getSharedPoolFlags(): Promise<CredentialFlags> {
+  const flags: CredentialFlags = {}
+
+  // Server env keys back the shared OpenCode / Gemini pools. Mark both the
+  // presence flag (so hasCredentialsForModel treats the provider as available)
+  // and the `_SHARED` origin flag (so the UI knows it isn't a user-owned key).
+  if (process.env.OPENCODE_API_KEY) {
+    flags.OPENCODE_API_KEY = true
+    flags.OPENCODE_API_KEY_SHARED = true
+  }
+  if (process.env.GEMINI_API_KEY) {
+    flags.GEMINI_API_KEY = true
+    flags.GEMINI_API_KEY_SHARED = true
+  }
+  if (await isSharedPoolAvailable()) {
+    flags.CLAUDE_SHARED_POOL_AVAILABLE = true
+  }
+
+  return flags
+}
+
 export async function getEffectiveCredentialFlags(userId: string): Promise<EffectiveFlags> {
   const user = await prisma.user.findUnique({
     where: { id: userId },

--- a/packages/web/lib/server/shared-pool.ts
+++ b/packages/web/lib/server/shared-pool.ts
@@ -17,6 +17,7 @@
 import {
   agentToProvider,
   ENDPOINT_MODEL_PREFIX,
+  modelRequiresKey,
   type Agent,
   type Credentials,
   type ProviderName,
@@ -34,6 +35,18 @@ export function isSharedPoolAgent(agent: Agent): agent is SharedPoolAgent {
 /** Internal provider id for an agent (stored as TokenUsage.provider). */
 export function providerForAgent(agent: Agent): ProviderName {
   return agentToProvider[agent]
+}
+
+/**
+ * Internal provider a specific run is billed to. Usually the agent's own
+ * provider, but a Gemini model selected under a BYOK agent (Pi, Droid) runs on
+ * the shared Gemini key, so it meters against the Gemini pool. Mirrors the
+ * Gemini rule in {@link resolvePool}, so the two stay in agreement about which
+ * runs count as shared Gemini usage.
+ */
+export function providerForRun(agent: Agent, model?: string): ProviderName {
+  if (modelRequiresKey(agent, model) === "gemini") return "gemini"
+  return providerForAgent(agent)
 }
 
 /**
@@ -63,6 +76,11 @@ export function resolvePool(
     case "opencode":
       return storedCreds.OPENCODE_API_KEY ? "user" : "shared"
     default:
+      // A Gemini model under a BYOK agent (Pi, Droid) runs on the shared Gemini
+      // key unless the user stored their own — meter those as the Gemini pool.
+      if (modelRequiresKey(agent, model) === "gemini") {
+        return storedCreds.GEMINI_API_KEY ? "user" : "shared"
+      }
       return "user"
   }
 }
@@ -83,7 +101,7 @@ export function buildUsageMeta(
   storedCreds: Credentials,
   model?: string
 ): UsageMeta {
-  return { pool: resolvePool(agent, storedCreds, model), provider: providerForAgent(agent) }
+  return { pool: resolvePool(agent, storedCreds, model), provider: providerForRun(agent, model) }
 }
 
 /**

--- a/packages/web/lib/sync/api.ts
+++ b/packages/web/lib/sync/api.ts
@@ -210,6 +210,14 @@ export async function fetchSettings(): Promise<SettingsResponse> {
 }
 
 /**
+ * Fetch the public shared-pool flags (no auth). Used for logged-out visitors so
+ * the agent picker can show shared-pool "ready" dots before sign-in.
+ */
+export async function fetchSharedPoolFlags(): Promise<{ credentialFlags: CredentialFlags }> {
+  return fetchApi<{ credentialFlags: CredentialFlags }>("/api/shared-pool")
+}
+
+/**
  * Update user settings
  */
 export async function updateSettings(data: {


### PR DESCRIPTION
# Shared pools for logged-out users + Pi/Droid Gemini

## Goal
Two things:
1. Show the agent-picker "ready" (green) dots for the server's **shared pools**
   (Claude Code, Gemini, OpenCode) to **logged-out** visitors — not just after sign-in.
2. Let **Pi** and **Droid** run their Gemini models on the shared Gemini key, so they
   also go green — and **meter** that usage against the shared Gemini daily budget.

## Why it wasn't working before
- When logged out, `useSettingsQuery` was **disabled**, so `credentialFlags` stayed `{}`.
  The shared-pool flags are computed server-side and needed a signed-in `userId`, so
  the picker only ever showed the always-free agents (OpenCode's no-key models, Kilo).
- Pi/Droid Gemini runs were classified by **agent**, so they counted as the agent's own
  "user" pool — they'd have bypassed the shared Gemini budget (a free-usage loophole).

## Changes

### 1. Expose shared-pool flags without auth
- **`credential-flags.ts`** — new `getSharedPoolFlags()`: returns only server-config
  booleans (`CLAUDE_SHARED_POOL_AVAILABLE`, `GEMINI_API_KEY`/`_SHARED`,
  `OPENCODE_API_KEY`/`_SHARED`). No user data, never key values.
- **`app/api/shared-pool/route.ts`** — new public `GET` (no auth) returning those flags.
- **`lib/sync/api.ts`** — `fetchSharedPoolFlags()` client helper.
- **`useSettingsQuery.ts`** — when logged out, fetch the public flags instead of doing
  nothing. Keeps the same cache key (so the settings-mutation / usage-decrement writers
  still hit it) and refetches on login/logout so the data source swaps cleanly.

### 2. Pi/Droid Gemini → shared Gemini pool (metered)
- **`common/agents.ts`** (+ `index.ts` barrel) — new `modelRequiresKey(agent, model)`:
  looks up which provider key a given agent+model needs.
- **`shared-pool.ts`** — `resolvePool` and new `providerForRun` now treat a **Gemini
  model under any BYOK agent** (Pi, Droid) as the shared **gemini** pool when the user
  has no own Gemini key. Own key, non-Gemini models, and Droid's Factory-hosted Gemini
  ids stay "user".
- **`usage-limit.ts`** — uses `providerForRun` for the provider and gates purely on the
  resolved pool, so Pi/Droid Gemini turns count against the Gemini daily budget.

The **runtime** already worked: `getUserCredentials` falls back to `process.env`, and
Droid maps `gemini*` models to `${GEMINI_API_KEY}` — so no send-path change was needed.

## Result
Logged out, green dots now appear on: **Claude Code, Gemini, OpenCode, Kilo, Pi, Droid**
(depending on which shared pools the server has configured).
