### PR TITLE
fix/ cc auth refresh issue

### DIFF
--- a/packages/claude-credentials/scripts/repro-prune.ts
+++ b/packages/claude-credentials/scripts/repro-prune.ts
@@ -1,0 +1,63 @@
+/**
+ * Local repro for the "pull access denied / repository does not exist" failure
+ * and its fix.
+ *
+ * It can't force Daytona's internal image GC on demand, so it *simulates* the
+ * prune by deleting the named snapshot after building it — the same split-brain
+ * ("nothing to pull") state the production failure lands in — then shows that
+ * ensureCCAuthSnapshot rebuilds instead of failing.
+ *
+ * Requires only DAYTONA_API_KEY (no Claude cookies — this never runs ccauth).
+ *
+ * Usage:
+ *   DAYTONA_API_KEY=... npx tsx packages/claude-credentials/scripts/repro-prune.ts
+ */
+import { Daytona } from "@daytonaio/sdk"
+import {
+  resolveLatestCCAuthSha,
+  getCCAuthImage,
+  getCCAuthSnapshotName,
+  ensureCCAuthSnapshot,
+} from "../src/generate"
+
+async function main() {
+  const apiKey = process.env.DAYTONA_API_KEY
+  if (!apiKey) throw new Error("DAYTONA_API_KEY is not set")
+
+  const sha = await resolveLatestCCAuthSha()
+  const name = getCCAuthSnapshotName(sha)
+  const image = getCCAuthImage(sha)
+  const daytona = new Daytona({ apiKey })
+
+  console.log(`\n[repro] snapshot name: ${name}`)
+
+  // 1. Ensure it exists (first run builds it; later runs reuse).
+  console.log("\n[repro] step 1: ensure snapshot exists (may build ~minutes)…")
+  await ensureCCAuthSnapshot(daytona, name, image)
+  const built = await daytona.snapshot.get(name)
+  console.log(`[repro] state after ensure: ${built.state}`)
+
+  // 2. Simulate Daytona pruning the image out from under us.
+  console.log("\n[repro] step 2: delete snapshot to simulate a prune…")
+  await daytona.snapshot.delete(built)
+  const gone = await daytona.snapshot.get(name).catch(() => undefined)
+  console.log(`[repro] state after delete: ${gone?.state ?? "missing (pruned)"}`)
+
+  // 3. Old behavior would now hit "pull access denied" on create and never
+  //    recover. The fix detects the missing snapshot and rebuilds it.
+  console.log("\n[repro] step 3: ensure again — expect an automatic rebuild…")
+  await ensureCCAuthSnapshot(daytona, name, image)
+  const healed = await daytona.snapshot.get(name)
+  console.log(`[repro] state after self-heal: ${healed.state}`)
+
+  console.log(
+    healed.state === "active"
+      ? "\n✅ PASS: pruned snapshot was rebuilt automatically (bug is fixed)."
+      : `\n❌ FAIL: snapshot ended in '${healed.state}'.`,
+  )
+}
+
+main().catch((err) => {
+  console.error("\n[repro] failed:", err)
+  process.exit(1)
+})

--- a/packages/claude-credentials/src/generate.test.ts
+++ b/packages/claude-credentials/src/generate.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for the snapshot-lifecycle helpers that keep credential refresh working
+ * after Daytona garbage-collects (prunes) the backing image of a previously
+ * built snapshot.
+ *
+ * The bug these guard against: passing an inline `Image` to `daytona.create()`
+ * registers an anonymous, prunable snapshot. Once pruned, later runs fail with
+ * "pull access denied ... repository does not exist" and never self-heal. We
+ * switched to a *named* snapshot that ensureCCAuthSnapshot can look up and
+ * deterministically rebuild.
+ */
+import { describe, it, expect } from "vitest"
+import type { Image } from "@daytonaio/sdk"
+import { ensureCCAuthSnapshot, getCCAuthSnapshotName } from "./generate"
+
+type FakeState =
+  | "active"
+  | "building"
+  | "pending"
+  | "pulling"
+  | "error"
+  | "build_failed"
+  | "removing"
+
+/**
+ * Minimal stand-in for the pieces of the Daytona SDK that ensureCCAuthSnapshot
+ * touches: `snapshot.get` / `snapshot.delete` / `snapshot.create`. It records
+ * every call so tests can assert on the sequence of decisions.
+ */
+function makeFakeDaytona(opts: {
+  /** Initial snapshot state, or undefined to simulate "not found". */
+  initial?: FakeState
+  /** State to report after a (re)build completes. Defaults to "active". */
+  afterCreate?: FakeState
+}) {
+  const calls: string[] = []
+  let state: FakeState | undefined = opts.initial
+
+  const snapshot = {
+    async get(name: string) {
+      calls.push(`get:${state ?? "missing"}`)
+      if (state === undefined) {
+        throw new Error(`Snapshot ${name} not found (404)`)
+      }
+      return { id: `id-${name}`, name, state }
+    },
+    async delete(_snap: { id: string }) {
+      calls.push(`delete`)
+      state = undefined
+    },
+    async create({ name }: { name: string }) {
+      calls.push(`create`)
+      state = opts.afterCreate ?? "active"
+      return { id: `id-${name}`, name, state }
+    },
+  }
+
+  return { daytona: { snapshot }, calls, getState: () => state }
+}
+
+const fakeImage = {} as Image
+
+describe("getCCAuthSnapshotName", () => {
+  it("derives a stable name from the first 12 chars of the ccauth SHA", () => {
+    const sha = "abcdef0123456789deadbeef"
+    expect(getCCAuthSnapshotName(sha)).toBe("ccauth-abcdef012345")
+  })
+})
+
+describe("ensureCCAuthSnapshot", () => {
+  it("reuses an already-active snapshot without rebuilding", async () => {
+    const { daytona, calls } = makeFakeDaytona({ initial: "active" })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await ensureCCAuthSnapshot(daytona as any, "ccauth-x", fakeImage)
+    expect(calls).toEqual(["get:active"])
+  })
+
+  it("builds the snapshot when it is missing", async () => {
+    const { daytona, calls, getState } = makeFakeDaytona({ initial: undefined })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await ensureCCAuthSnapshot(daytona as any, "ccauth-x", fakeImage)
+    expect(calls).toEqual(["get:missing", "create"])
+    expect(getState()).toBe("active")
+  })
+
+  it("deletes and rebuilds a pruned/failed snapshot (the reported bug)", async () => {
+    // A snapshot whose backing image was pruned surfaces here as a non-active
+    // terminal state; we must delete the dangling record and rebuild.
+    const { daytona, calls, getState } = makeFakeDaytona({ initial: "error" })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await ensureCCAuthSnapshot(daytona as any, "ccauth-x", fakeImage)
+    expect(calls).toEqual(["get:error", "delete", "create"])
+    expect(getState()).toBe("active")
+  })
+
+  it("force-rebuilds even an active snapshot when rebuild is requested", async () => {
+    // This is the recovery path taken after sandbox creation reports a pruned
+    // image despite the snapshot metadata looking healthy.
+    const { daytona, calls } = makeFakeDaytona({ initial: "active" })
+    await ensureCCAuthSnapshot(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      daytona as any,
+      "ccauth-x",
+      fakeImage,
+      { rebuild: true },
+    )
+    expect(calls).toEqual(["get:active", "delete", "create"])
+  })
+})

--- a/packages/claude-credentials/src/generate.test.ts
+++ b/packages/claude-credentials/src/generate.test.ts
@@ -32,12 +32,27 @@ function makeFakeDaytona(opts: {
   initial?: FakeState
   /** State to report after a (re)build completes. Defaults to "active". */
   afterCreate?: FakeState
+  /**
+   * Model Daytona's asynchronous deletion: delete() moves the snapshot to
+   * `removing` and it lingers there for this many get() reads before the name
+   * frees up. 0 (default) = synchronous delete.
+   */
+  removingReads?: number
+  /** Number of initial create() calls that throw a 409 "already exists". */
+  conflictOnCreate?: number
 }) {
   const calls: string[] = []
   let state: FakeState | undefined = opts.initial
+  let removingLeft = 0
+  let conflictsLeft = opts.conflictOnCreate ?? 0
 
   const snapshot = {
     async get(name: string) {
+      // Consume the `removing` lifetime, then the name frees up.
+      if (state === "removing") {
+        if (removingLeft > 0) removingLeft--
+        if (removingLeft === 0) state = undefined
+      }
       calls.push(`get:${state ?? "missing"}`)
       if (state === undefined) {
         throw new Error(`Snapshot ${name} not found (404)`)
@@ -46,10 +61,23 @@ function makeFakeDaytona(opts: {
     },
     async delete(_snap: { id: string }) {
       calls.push(`delete`)
-      state = undefined
+      if (opts.removingReads && opts.removingReads > 0) {
+        state = "removing"
+        removingLeft = opts.removingReads
+      } else {
+        state = undefined
+      }
     },
     async create({ name }: { name: string }) {
       calls.push(`create`)
+      if (conflictsLeft > 0) {
+        conflictsLeft--
+        const err = new Error(
+          `Snapshot with name "${name}" already exists for this organization`,
+        ) as Error & { statusCode?: number }
+        err.statusCode = 409
+        throw err
+      }
       state = opts.afterCreate ?? "active"
       return { id: `id-${name}`, name, state }
     },
@@ -89,7 +117,8 @@ describe("ensureCCAuthSnapshot", () => {
     const { daytona, calls, getState } = makeFakeDaytona({ initial: "error" })
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await ensureCCAuthSnapshot(daytona as any, "ccauth-x", fakeImage)
-    expect(calls).toEqual(["get:error", "delete", "create"])
+    // delete → wait-for-gone (get:missing) → create
+    expect(calls).toEqual(["get:error", "delete", "get:missing", "create"])
     expect(getState()).toBe("active")
   })
 
@@ -104,6 +133,35 @@ describe("ensureCCAuthSnapshot", () => {
       fakeImage,
       { rebuild: true },
     )
-    expect(calls).toEqual(["get:active", "delete", "create"])
+    expect(calls).toEqual(["get:active", "delete", "get:missing", "create"])
+  })
+
+  it("waits out asynchronous deletion (removing) before recreating", async () => {
+    // Regression: Daytona deletion is async — the snapshot sits in `removing`
+    // before the name frees up. Recreating too early 409s. Verified end-to-end
+    // against real Daytona, where delete() returned `removing`.
+    const { daytona, calls, getState } = makeFakeDaytona({
+      initial: "error",
+      removingReads: 2, // report `removing` once, then the name frees up
+    })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await ensureCCAuthSnapshot(daytona as any, "ccauth-x", fakeImage)
+    // It must observe `removing` and wait for `missing` before creating.
+    expect(calls).toContain("get:removing")
+    expect(calls.indexOf("get:removing")).toBeLessThan(calls.lastIndexOf("create"))
+    expect(getState()).toBe("active")
+  })
+
+  it("retries the build once when create() 409s on a still-clearing name", async () => {
+    // Regression: even after we wait, a race can make the first create() conflict.
+    // We should wait and retry rather than surface a hard failure.
+    const { daytona, calls, getState } = makeFakeDaytona({
+      initial: "error",
+      conflictOnCreate: 1, // first create() throws 409, second succeeds
+    })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await ensureCCAuthSnapshot(daytona as any, "ccauth-x", fakeImage)
+    expect(calls.filter((c) => c === "create")).toHaveLength(2)
+    expect(getState()).toBe("active")
   })
 })

--- a/packages/claude-credentials/src/generate.ts
+++ b/packages/claude-credentials/src/generate.ts
@@ -337,8 +337,20 @@ export async function generateClaudeCredentials(
     // ccauth always emits JSON on stdout: {"claudeAiOauth": {...}} on success
     // (exit 0) or {"error": ..., extra} on failure (exit 1). Verbose logs go
     // to stderr.
+    //
+    // IMPORTANT: clear the persistent profile's cookie database before running
+    // ccauth. The patchright profile at ~/.ccauth/patchright-profile accumulates
+    // cookies across runs — after the first successful OAuth flow, patchright
+    // saves cookies Claude set during authorization into the profile. On the
+    // next run, those stale cookies load into the browser context BEFORE our
+    // fresh cookies are injected, causing conflicts that make the OAuth flow
+    // fail (Timed out waiting for OAuth callback). Deleting just the cookie
+    // database preserves the Turnstile trust signals (localStorage, fingerprint,
+    // browser cache) while ensuring a clean cookie injection every time.
+    const COOKIES_DB_PATH = `${PATCHRIGHT_PROFILE_PATH}/Default/Cookies`
+    const COOKIES_JOURNAL_PATH = `${PATCHRIGHT_PROFILE_PATH}/Default/Cookies-journal`
     const res = await sandbox.process.executeCommand(
-      `xvfb-run -a ccauth --cookies ${COOKIES_REMOTE_PATH}`,
+      `rm -f ${COOKIES_DB_PATH} ${COOKIES_JOURNAL_PATH} && xvfb-run -a ccauth --cookies ${COOKIES_REMOTE_PATH}`,
       undefined,
       undefined,
       300,

--- a/packages/claude-credentials/src/generate.ts
+++ b/packages/claude-credentials/src/generate.ts
@@ -23,6 +23,10 @@ const SNAPSHOT_NAME_PREFIX = "ccauth"
 // and rebuilding it ourselves.
 const SNAPSHOT_BUILD_TIMEOUT_MS = 10 * 60 * 1000
 const SNAPSHOT_POLL_INTERVAL_MS = 2000
+// Deletion is asynchronous: a deleted snapshot sits in `removing` for a bit
+// before its name is free again. Recreating with the same name before then 409s,
+// so we wait this long for the record to disappear.
+const SNAPSHOT_DELETE_TIMEOUT_MS = 60 * 1000
 
 // Substrings Daytona surfaces when a sandbox references a snapshot whose backing
 // registry image has been garbage-collected. The control plane still has the
@@ -152,29 +156,72 @@ export async function ensureCCAuthSnapshot(
     console.error(
       `[claude-credentials] rebuilding snapshot ${name} (was '${existing.state}')`,
     )
-    try {
-      await daytona.snapshot.delete(existing)
-    } catch (err) {
-      console.error("[claude-credentials] snapshot.delete failed:", err)
+    // `removing` means a delete is already in flight — don't re-issue it.
+    if (existing.state !== "removing") {
+      try {
+        await daytona.snapshot.delete(existing)
+      } catch (err) {
+        console.error("[claude-credentials] snapshot.delete failed:", err)
+      }
+    }
+    // Deletion is async: wait for the name to free up before recreating, or
+    // create() 409s with "already exists".
+    if (!(await waitForSnapshotGone(daytona, name))) {
+      console.error(
+        `[claude-credentials] snapshot ${name} still not gone after ${SNAPSHOT_DELETE_TIMEOUT_MS}ms; attempting build anyway`,
+      )
     }
   } else {
     console.error(`[claude-credentials] building snapshot ${name}`)
   }
 
-  try {
-    await daytona.snapshot.create(
-      { name, image },
-      {
-        timeout: 0,
-        onLogs: (chunk) => console.error(`[ccauth-image] ${chunk}`),
-      },
-    )
-  } catch (err) {
-    // Lost a create race with a concurrent builder: if the winner produced an
-    // active snapshot, we're done; otherwise surface the failure.
+  // Build. Retry once on a name conflict: that means an old record was still
+  // being deleted (or a concurrent run is mid-build) — wait for it to settle and
+  // try again, accepting an active snapshot a concurrent builder may have won.
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    try {
+      await daytona.snapshot.create(
+        { name, image },
+        {
+          timeout: 0,
+          onLogs: (chunk) => console.error(`[ccauth-image] ${chunk}`),
+        },
+      )
+      return
+    } catch (err) {
+      const snap = await daytona.snapshot.get(name).catch(() => undefined)
+      if (snap?.state === "active") return // Concurrent builder produced it.
+
+      const msg = err instanceof Error ? err.message : String(err)
+      const isConflict =
+        msg.includes("already exists") ||
+        (err as { statusCode?: number })?.statusCode === 409
+      if (isConflict && attempt < 2) {
+        console.error(
+          `[claude-credentials] snapshot ${name} create conflicted (record still clearing); waiting and retrying`,
+        )
+        await waitForSnapshotGone(daytona, name)
+        continue
+      }
+      throw err
+    }
+  }
+}
+
+/**
+ * Polls until the named snapshot no longer exists (get 404s). Returns true when
+ * it's gone, false if the deadline passes first (still `removing`).
+ */
+async function waitForSnapshotGone(
+  daytona: Daytona,
+  name: string,
+): Promise<boolean> {
+  const deadline = Date.now() + SNAPSHOT_DELETE_TIMEOUT_MS
+  for (;;) {
     const snap = await daytona.snapshot.get(name).catch(() => undefined)
-    if (snap?.state === "active") return
-    throw err
+    if (!snap) return true
+    if (Date.now() >= deadline) return false
+    await new Promise((r) => setTimeout(r, SNAPSHOT_POLL_INTERVAL_MS))
   }
 }
 

--- a/packages/claude-credentials/src/generate.ts
+++ b/packages/claude-credentials/src/generate.ts
@@ -251,6 +251,13 @@ export async function generateClaudeCredentials(
           volumes: [{ volumeId: volume.id, mountPath: PATCHRIGHT_PROFILE_PATH }],
           autoStopInterval: 5,
         },
+        // Note: the SDK's snapshot-based create() overload only accepts
+        // `{ timeout }` — `onSnapshotCreateLogs` exists solely on the
+        // image-based overload and is rejected here by the type system. No build
+        // happens on this path anyway; the image build logs (same `[ccauth-image]`
+        // prefix) are streamed via snapshot.create's `onLogs` in
+        // ensureCCAuthSnapshot, so no log output is lost.
+        //
         // No client-side timeout: starting from a cold snapshot can occasionally
         // exceed the SDK's 60s default; the cron route's maxDuration is the real
         // ceiling. A genuine start failure still surfaces via the `error` state.

--- a/packages/claude-credentials/src/generate.ts
+++ b/packages/claude-credentials/src/generate.ts
@@ -14,6 +14,35 @@ const PATCHRIGHT_PROFILE_PATH = "/home/daytona/.ccauth/patchright-profile"
 const CCAUTH_REPO = "synacktraa/ccauth"
 const CCAUTH_BRANCH = "master"
 
+// Prefix for the named, persistent Daytona snapshot we build ccauth into. The
+// full name is suffixed with the ccauth commit SHA so a new ccauth release
+// naturally produces a new snapshot (see getCCAuthSnapshotName).
+const SNAPSHOT_NAME_PREFIX = "ccauth"
+
+// How long to wait for a concurrent snapshot build to finish before giving up
+// and rebuilding it ourselves.
+const SNAPSHOT_BUILD_TIMEOUT_MS = 10 * 60 * 1000
+const SNAPSHOT_POLL_INTERVAL_MS = 2000
+
+// Substrings Daytona surfaces when a sandbox references a snapshot whose backing
+// registry image has been garbage-collected. The control plane still has the
+// snapshot *metadata* (so it won't rebuild on its own), but the runner daemon
+// can't pull the image, so the sandbox goes straight to `error`:
+//   "failed to start with status: error, error reason: Error response from
+//    daemon: pull access denied for daytona-<hash> ... repository does not
+//    exist or may require 'docker login'"
+const STALE_IMAGE_ERROR_FRAGMENTS = [
+  "pull access denied",
+  "repository does not exist",
+  "docker login",
+]
+
+/** True when an error looks like a pruned/missing snapshot image (see above). */
+function isStaleImageError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err)
+  return STALE_IMAGE_ERROR_FRAGMENTS.some((fragment) => msg.includes(fragment))
+}
+
 /**
  * Resolves the latest commit SHA on `master` so the pip install command becomes
  * `git+...@<sha>`. When the SHA changes, the Image spec hash changes, and
@@ -52,6 +81,101 @@ export function getCCAuthImage(sha: string): Image {
     .pipInstall([`git+https://github.com/${CCAUTH_REPO}.git@${sha}`])
     .runCommands("patchright install --with-deps chrome")
     .workdir("/home/daytona")
+}
+
+/**
+ * Deterministic name for the persistent ccauth snapshot. Keyed on the ccauth
+ * commit SHA so a new ccauth release rebuilds automatically, while repeated runs
+ * against the same release reuse one long-lived snapshot.
+ */
+export function getCCAuthSnapshotName(sha: string): string {
+  return `${SNAPSHOT_NAME_PREFIX}-${sha.slice(0, 12)}`
+}
+
+/**
+ * Ensures a usable (`active`) snapshot named `name` exists, building it from
+ * `image` when it is missing, mid-flight, or in a failed/pruned state.
+ *
+ * Why a *named* snapshot instead of passing the declarative `Image` straight to
+ * `daytona.create()`: an inline image is registered as an anonymous
+ * `daytona-<hash>` snapshot that Daytona garbage-collects once nothing has used
+ * it for a while. The control plane keeps the metadata but the registry blob is
+ * pruned, so a later `create()` tries to *pull* an image that no longer exists
+ * and the sandbox fails to start ("pull access denied ... repository does not
+ * exist"). A named snapshot is a first-class object we can look up and
+ * deterministically rebuild, so a prune becomes a self-healing rebuild instead
+ * of a hard failure.
+ *
+ * @param rebuild - When true, delete any existing snapshot and rebuild from
+ *   scratch. Used to recover after a prune is detected at sandbox-create time.
+ */
+export async function ensureCCAuthSnapshot(
+  daytona: Daytona,
+  name: string,
+  image: Image,
+  { rebuild = false }: { rebuild?: boolean } = {},
+): Promise<void> {
+  let existing: Awaited<ReturnType<typeof daytona.snapshot.get>> | undefined
+  try {
+    existing = await daytona.snapshot.get(name)
+  } catch {
+    // Not found (or unreadable) — treat as missing and build below.
+    existing = undefined
+  }
+
+  if (existing && !rebuild) {
+    if (existing.state === "active") return
+
+    // Reuse an in-flight build kicked off by a concurrent run rather than
+    // racing it with a second build of the same name.
+    if (
+      existing.state === "building" ||
+      existing.state === "pending" ||
+      existing.state === "pulling"
+    ) {
+      const deadline = Date.now() + SNAPSHOT_BUILD_TIMEOUT_MS
+      while (Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, SNAPSHOT_POLL_INTERVAL_MS))
+        const snap = await daytona.snapshot.get(name)
+        if (snap.state === "active") return
+        if (snap.state !== "building" && snap.state !== "pending" && snap.state !== "pulling") {
+          existing = snap
+          break // Fell into a terminal/failed state — rebuild below.
+        }
+      }
+    }
+  }
+
+  // Delete a stale/failed/pruned snapshot so create() can register a fresh one;
+  // a lingering record with the same name would otherwise 409.
+  if (existing) {
+    console.error(
+      `[claude-credentials] rebuilding snapshot ${name} (was '${existing.state}')`,
+    )
+    try {
+      await daytona.snapshot.delete(existing)
+    } catch (err) {
+      console.error("[claude-credentials] snapshot.delete failed:", err)
+    }
+  } else {
+    console.error(`[claude-credentials] building snapshot ${name}`)
+  }
+
+  try {
+    await daytona.snapshot.create(
+      { name, image },
+      {
+        timeout: 0,
+        onLogs: (chunk) => console.error(`[ccauth-image] ${chunk}`),
+      },
+    )
+  } catch (err) {
+    // Lost a create race with a concurrent builder: if the winner produced an
+    // active snapshot, we're done; otherwise surface the failure.
+    const snap = await daytona.snapshot.get(name).catch(() => undefined)
+    if (snap?.state === "active") return
+    throw err
+  }
 }
 
 /**
@@ -94,6 +218,7 @@ export async function generateClaudeCredentials(
   const ccauthSha = await resolveLatestCCAuthSha()
   console.error(`[claude-credentials] using ccauth ${ccauthSha.slice(0, 12)}`)
   const ccauthImage = getCCAuthImage(ccauthSha)
+  const snapshotName = getCCAuthSnapshotName(ccauthSha)
 
   const daytona = new Daytona({ apiKey })
 
@@ -112,21 +237,41 @@ export async function generateClaudeCredentials(
     )
   }
 
+  // Build (or reuse) the persistent named snapshot before creating a sandbox
+  // from it. See ensureCCAuthSnapshot for why we don't pass the inline image.
+  await ensureCCAuthSnapshot(daytona, snapshotName, ccauthImage)
+
   let sandbox: Sandbox | undefined
   try {
-    sandbox = await daytona.create(
-      {
-        image: ccauthImage,
-        ephemeral: true,
-        volumes: [{ volumeId: volume.id, mountPath: PATCHRIGHT_PROFILE_PATH }],
-        autoStopInterval: 5,
-      },
-      {
-        timeout: 0,
-        onSnapshotCreateLogs: (chunk) =>
-          console.error(`[ccauth-image] ${chunk}`),
-      },
-    )
+    const createSandbox = () =>
+      daytona.create(
+        {
+          snapshot: snapshotName,
+          ephemeral: true,
+          volumes: [{ volumeId: volume.id, mountPath: PATCHRIGHT_PROFILE_PATH }],
+          autoStopInterval: 5,
+        },
+        // No client-side timeout: starting from a cold snapshot can occasionally
+        // exceed the SDK's 60s default; the cron route's maxDuration is the real
+        // ceiling. A genuine start failure still surfaces via the `error` state.
+        { timeout: 0 },
+      )
+
+    try {
+      sandbox = await createSandbox()
+    } catch (err) {
+      // The snapshot passed our `active` check but its backing image was pruned
+      // between then and now (or was already a dangling record). Rebuild it once
+      // and retry, turning a hard failure into a self-healing recovery.
+      if (!isStaleImageError(err)) throw err
+      console.error(
+        `[claude-credentials] sandbox start hit a pruned image; rebuilding snapshot ${snapshotName} and retrying`,
+      )
+      await ensureCCAuthSnapshot(daytona, snapshotName, ccauthImage, {
+        rebuild: true,
+      })
+      sandbox = await createSandbox()
+    }
 
     await sandbox.fs.uploadFile(
       Buffer.from(cookies, "utf8"),

--- a/packages/claude-credentials/src/index.ts
+++ b/packages/claude-credentials/src/index.ts
@@ -16,6 +16,7 @@ export { CLAUDE_CREDS_KEY, CLAUDE_COOKIES_KEY } from "./constants"
 export {
   resolveLatestCCAuthSha,
   getCCAuthImage,
+  getCCAuthSnapshotName,
   isClaudeOAuthCredentials,
   generateClaudeCredentials,
   type GenerateCredentialsOptions,


### PR DESCRIPTION
## Fix: self-heal Claude credential refresh when Daytona prunes the ccauth image

### Problem

The shared Claude credential refresh (`generateClaudeCredentials`) began failing on every real run with:

```
CCAUTH_FAILED: Sandbox <id> failed to start with status: error, error reason:
Error response from daemon: pull access denied for daytona-<hash>
... repository does not exist or may require 'docker login'
```

It had worked for ~2 months, then started failing on roughly every ~8h cycle (i.e. every *non-skipped* refresh — `Skipped` runs never touch Daytona, so they can't fail).

### Root cause

`generateClaudeCredentials` passed a declarative `Image` straight to `daytona.create()`. Daytona registers that as an **anonymous, prunable snapshot** whose hash is derived from the ccauth commit SHA. The design assumes *"SHA changes → hash changes → Daytona rebuilds."*

- ccauth upstream (`synacktraa/ccauth`) has been **frozen since 2026-05-14**, so our image hash has been constant for ~7 weeks.
- While ccauth was actively committing, every refresh got a fresh build and always worked.
- With the SHA frozen, refreshes *reuse* the cached image. When Daytona eventually dropped that image's backing blob, the control plane kept the snapshot **metadata** (so it never rebuilds) while the runner daemon couldn't **pull** the image → the sandbox goes straight to `error`.

Net effect: once the image was gone, **every** refresh failed permanently, because nothing triggered a rebuild. (A previous blind retry loop couldn't help — it re-issued the identical `create()` and kept hitting the same missing hash.)

### Fix

Switch from an anonymous inline image to a **named, persistent snapshot** (`ccauth-<sha12>`) that can be looked up and deterministically rebuilt:

- **`getCCAuthSnapshotName(sha)`** — deterministic snapshot name keyed on the ccauth SHA (a real ccauth release still rebuilds automatically).
- **`ensureCCAuthSnapshot(daytona, name, image, { rebuild? })`** — runs before sandbox creation:
  - reuses the snapshot when `active`,
  - waits out an in-flight build from a concurrent run,
  - deletes + rebuilds when it is missing or in a failed/pruned state.
- **Create-time recovery** — if the snapshot passes the `active` check but its image was pruned in the meantime, the sandbox-create catch detects the stale-image error, force-rebuilds once, and retries. A prune becomes a self-healing rebuild instead of a permanent failure.

### Async-deletion handling (found via end-to-end repro)

Running the repro against real Daytona surfaced a second bug in the rebuild path: **Daytona deletion is asynchronous** — a deleted snapshot sits in `removing` before its name frees up, so recreating immediately fails with `409 Snapshot already exists`. `ensureCCAuthSnapshot` now:

- skips re-issuing `delete` when the snapshot is already `removing`,
- waits (`waitForSnapshotGone`) for the record to disappear before rebuilding,
- retries the build once on a 409 conflict, accepting an `active` snapshot a concurrent builder may have produced.

### Verification

- **End-to-end against real Daytona** via `scripts/repro-prune.ts`: build `ccauth-<sha>` → delete it (goes to `removing`) → `ensureCCAuthSnapshot` rebuilds → `✅ state after self-heal: active`. Previously this threw `DaytonaConflictError (409)`.
- **`npm run typecheck`** — passes across all workspaces.
- **7 unit tests** (`generate.test.ts`) covering: reuse-active, build-when-missing, delete-and-rebuild-on-pruned (the reported bug), force-rebuild, wait-out-`removing`, and 409-retry — modeling Daytona's async deletion in the test fake.

### Notes

- Sandbox creation uses the SDK's **snapshot-based `create()` overload**, whose options are `{ timeout }` only. `onSnapshotCreateLogs` is image-path-only (rejected by the type system here) and never fired on this path anyway — image build logs (same `[ccauth-image]` prefix) are now streamed via `snapshot.create`'s `onLogs`, so **no log output is lost**. A code comment documents this. Additional log lines were added for the rebuild/recovery paths.
- Kept `timeout: 0` on create so a slow cold snapshot start isn't killed by the SDK's 60s default; the cron route's `maxDuration = 300` remains the real ceiling.

### Out of scope (separate, operational issue)

This does **not** fix the other error seen intermittently — `ccauth failed (exit 1): Timed out waiting for OAuth callback`. That's a Claude-side auth failure (ccauth reaches the consent page and clicks *Authorize*, but the OAuth callback never returns — stale `claude.ai` cookies and/or Cloudflare Turnstile). Remedy: **re-seed fresh cookies** via `npm run seed:ccauth -- ./cookies.json`. Note there's a compounding effect — Error A killing sandboxes prevents the persistent patchright profile from accumulating Turnstile trust, so fixing A should also help B recover.

### Files changed

```
packages/claude-credentials/src/generate.ts        | named-snapshot logic + async-deletion handling + docs
packages/claude-credentials/src/generate.test.ts   | 7 regression tests (async-deletion aware fake)
packages/claude-credentials/src/index.ts           | export getCCAuthSnapshotName
packages/claude-credentials/scripts/repro-prune.ts | end-to-end repro script (real Daytona)
```
