### PR TITLE
feat(claude-credentials): renew credentials from the refresh token (ccauth only as fallback)

### DIFF
--- a/packages/claude-credentials/README.md
+++ b/packages/claude-credentials/README.md
@@ -4,7 +4,7 @@ Claude Code OAuth credential generation via [ccauth](https://github.com/synacktr
 
 ## Overview
 
-This package provides automated generation of Claude Code OAuth credentials from claude.ai session cookies. It runs the ccauth tool inside an ephemeral Daytona sandbox with a persistent volume for Cloudflare Turnstile trust accumulation.
+This package provides automated generation of Claude Code OAuth credentials — either from claude.ai session cookies (a full browser OAuth flow) or from an existing refresh token (a plain HTTP renewal). Both run the ccauth tool inside an ephemeral Daytona sandbox.
 
 ## Installation
 
@@ -17,24 +17,35 @@ npm install @background-agents/claude-credentials
 ```typescript
 import { generateClaudeCredentials } from "@background-agents/claude-credentials"
 
-// Generate credentials from claude.ai cookies
-const cookies = '...' // Your claude.ai session cookies JSON
-const credentials = await generateClaudeCredentials(cookies, {
-  apiKey: process.env.DAYTONA_API_KEY,
-})
+// From claude.ai cookies — full browser OAuth flow (heavy image + Turnstile).
+const cookies = "..." // claude.ai session cookies JSON (Cookie-Editor export)
+const credentials = await generateClaudeCredentials(
+  { cookies },
+  { apiKey: process.env.DAYTONA_API_KEY },
+)
 
-// Use credentials with Claude Code
+// From an existing refresh token — no browser, lightweight image.
+const renewed = await generateClaudeCredentials(
+  { refreshToken: "sk-ant-ort01-..." },
+  { apiKey: process.env.DAYTONA_API_KEY },
+)
+
 // credentials.claudeAiOauth contains accessToken, refreshToken, expiresAt, etc.
 ```
 
 ## How It Works
 
 1. Resolves the latest ccauth commit SHA from GitHub
-2. Creates a Daytona sandbox with the ccauth image (Debian + Chrome + patchright)
-3. Mounts a persistent volume for Turnstile trust signal accumulation
-4. Uploads cookies and runs `ccauth --cookies <path>` with xvfb
-5. Parses and returns the OAuth credentials JSON
-6. Cleans up the ephemeral sandbox
+2. Creates an ephemeral Daytona sandbox with the image for the chosen mode:
+   - `{ cookies }` → heavy image (Debian + Chrome + patchright) with a persistent
+     volume for Cloudflare Turnstile trust, running `ccauth --cookies` under xvfb
+   - `{ refreshToken }` → lightweight image (no browser, no volume), running
+     `ccauth --refresh` (a plain `grant_type=refresh_token` HTTP call)
+3. Parses and returns the OAuth credentials JSON (same shape for both modes)
+4. Cleans up the ephemeral sandbox
+
+The `{ refreshToken }` form throws `RefreshTokenExpiredError` when the refresh
+token is rejected, so callers can fall back to the `{ cookies }` form.
 
 ## Exports
 
@@ -69,10 +80,11 @@ import {
 
 ```typescript
 import {
-  generateClaudeCredentials,        // Main entry point
+  generateClaudeCredentials,        // Main entry point ({ cookies } | { refreshToken })
   resolveLatestCCAuthSha,           // Get latest ccauth commit SHA
-  getCCAuthImage,                   // Build Daytona Image spec
+  getCCAuthImage,                   // Build Daytona Image spec (sha, refreshMode?)
   isClaudeOAuthCredentials,         // Type guard
+  RefreshTokenExpiredError,         // Thrown when the refresh token is expired/revoked
   type GenerateCredentialsOptions,  // Options for generateClaudeCredentials
 } from "@background-agents/claude-credentials"
 ```

--- a/packages/claude-credentials/src/generate.ts
+++ b/packages/claude-credentials/src/generate.ts
@@ -41,15 +41,29 @@ export async function resolveLatestCCAuthSha(): Promise<string> {
 
 /**
  * Builds the Daytona Image spec for running ccauth.
+ *
+ * `refreshMode` returns a lightweight image for `ccauth --refresh` (a plain HTTP
+ * call, no browser): it drops the heavy X/Chrome layers, keeping just git for
+ * the `git+https@sha` pip install — so the snapshot builds in seconds.
  */
-export function getCCAuthImage(sha: string): Image {
-  return Image.debianSlim("3.12")
+export function getCCAuthImage(sha: string, refreshMode = false): Image {
+  const baseImage = Image.debianSlim("3.12")
+  const pipPackages = [`git+https://github.com/${CCAUTH_REPO}.git@${sha}`]
+  if (refreshMode) {
+    return baseImage
+      .runCommands(
+        "apt-get update && apt-get install -y --no-install-recommends git " +
+          "&& rm -rf /var/lib/apt/lists/*",
+      )
+      .pipInstall(pipPackages)
+  }
+  return baseImage
     .runCommands(
       "apt-get update && apt-get install -y --no-install-recommends " +
         "git xvfb xauth x11vnc novnc xfce4 xfce4-terminal dbus-x11 " +
         "&& rm -rf /var/lib/apt/lists/*",
     )
-    .pipInstall([`git+https://github.com/${CCAUTH_REPO}.git@${sha}`])
+    .pipInstall(pipPackages)
     .runCommands("patchright install --with-deps chrome")
     .workdir("/home/daytona")
 }
@@ -71,45 +85,116 @@ export function isClaudeOAuthCredentials(
   )
 }
 
+/**
+ * Thrown when ccauth reports the refresh token itself is expired/revoked (its
+ * error JSON carries `refresh_expired`). Callers should fall back to the full
+ * cookie-based OAuth flow (generateClaudeCredentials).
+ */
+export class RefreshTokenExpiredError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "RefreshTokenExpiredError"
+  }
+}
+
+/**
+ * Parses ccauth's final stdout line. ccauth always emits a single-line JSON:
+ * {"claudeAiOauth": {...}} on success, or {"error": ..., extra} on failure.
+ * Daytona merges stdout+stderr and ccauth prints its JSON last, so we take the
+ * final non-empty line. Throws RefreshTokenExpiredError when the failure carries
+ * `refresh_expired` so callers can fall back to the full OAuth flow.
+ */
+function parseCredentialsOutput(output: string): ClaudeOAuthCredentials {
+  const lastLine = output
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .pop()
+  if (!lastLine) throw new Error("ccauth produced empty output")
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(lastLine)
+  } catch {
+    throw new Error(
+      `ccauth produced non-JSON final line: ${lastLine.slice(0, 4000)}`,
+    )
+  }
+
+  if (isClaudeOAuthCredentials(parsed)) return parsed
+
+  const err = parsed as { error?: unknown; refresh_expired?: unknown }
+  if (err && typeof err.error === "string") {
+    if (err.refresh_expired === true) {
+      throw new RefreshTokenExpiredError(err.error.slice(0, 500))
+    }
+    throw new Error(`ccauth error: ${err.error.slice(0, 4000)}`)
+  }
+
+  throw new Error(
+    `ccauth output missing claudeAiOauth fields: ${JSON.stringify(parsed).slice(0, 4000)}`,
+  )
+}
+
 export interface GenerateCredentialsOptions {
   /** Daytona API key. If not provided, reads from DAYTONA_API_KEY env var. */
   apiKey?: string
 }
 
 /**
- * Provisions an ephemeral Daytona sandbox, runs `ccauth --cookies <path>` against
- * the supplied claude.ai cookies, and returns the parsed credential JSON.
+ * Provisions an ephemeral Daytona sandbox and returns the parsed credential JSON.
  *
- * The persistent patchright profile lives on a Daytona volume named `ccauth-profile`
- * mounted at /home/daytona/.ccauth/patchright-profile so Cloudflare Turnstile trust
- * signals accumulate across cron runs.
+ * - `{ cookies }` runs the full browser OAuth flow (`ccauth --cookies`) in the
+ *   heavy image, mounting the persistent patchright profile volume so Cloudflare
+ *   Turnstile trust accumulates across runs. Use on first run or when the
+ *   refresh token has expired.
+ * - `{ refreshToken }` renews from an existing refresh token (`ccauth --refresh`)
+ *   in the lightweight image — a plain HTTP call, no browser, no volume. This is
+ *   the common path. Throws {@link RefreshTokenExpiredError} when the refresh
+ *   token is rejected, so callers can fall back to the `{ cookies }` form.
  */
+export function generateClaudeCredentials(
+  input: { cookies: string },
+  options?: GenerateCredentialsOptions,
+): Promise<ClaudeOAuthCredentials>
+export function generateClaudeCredentials(
+  input: { refreshToken: string },
+  options?: GenerateCredentialsOptions,
+): Promise<ClaudeOAuthCredentials>
 export async function generateClaudeCredentials(
-  cookies: string,
+  input: { cookies: string } | { refreshToken: string },
   options: GenerateCredentialsOptions = {},
 ): Promise<ClaudeOAuthCredentials> {
   const apiKey = options.apiKey ?? process.env.DAYTONA_API_KEY
   if (!apiKey) throw new Error("DAYTONA_API_KEY is not set")
 
+  const refreshMode = "refreshToken" in input
   const ccauthSha = await resolveLatestCCAuthSha()
-  console.error(`[claude-credentials] using ccauth ${ccauthSha.slice(0, 12)}`)
-  const ccauthImage = getCCAuthImage(ccauthSha)
+  console.error(
+    `[claude-credentials] using ccauth (${refreshMode ? "refresh" : "cookie-based"} flow) ${ccauthSha.slice(0, 12)}`,
+  )
+  const ccauthImage = getCCAuthImage(ccauthSha, refreshMode)
 
   const daytona = new Daytona({ apiKey })
 
-  // volume.get(..., true) creates on first run, but the volume comes back in
-  // `pending_create` state; mounting it before it's `ready` 400s. Poll until
-  // ready before sandbox creation.
-  let volume = await daytona.volume.get(VOLUME_NAME, true)
-  const volumeDeadline = Date.now() + VOLUME_READY_TIMEOUT_MS
-  while (volume.state !== "ready" && Date.now() < volumeDeadline) {
-    await new Promise((r) => setTimeout(r, VOLUME_POLL_INTERVAL_MS))
-    volume = await daytona.volume.get(VOLUME_NAME, false)
-  }
-  if (volume.state !== "ready") {
-    throw new Error(
-      `Volume '${VOLUME_NAME}' not ready after ${VOLUME_READY_TIMEOUT_MS}ms (state: ${volume.state})`,
-    )
+  // Cookie mode mounts a persistent patchright profile volume so Cloudflare
+  // Turnstile trust accumulates across runs; refresh mode needs no browser
+  // profile. volume.get(..., true) creates on first run but comes back in
+  // `pending_create` state; mounting before it's `ready` 400s, so poll first.
+  let volumes: { volumeId: string; mountPath: string }[] | undefined
+  if (!refreshMode) {
+    let volume = await daytona.volume.get(VOLUME_NAME, true)
+    const volumeDeadline = Date.now() + VOLUME_READY_TIMEOUT_MS
+    while (volume.state !== "ready" && Date.now() < volumeDeadline) {
+      await new Promise((r) => setTimeout(r, VOLUME_POLL_INTERVAL_MS))
+      volume = await daytona.volume.get(VOLUME_NAME, false)
+    }
+    if (volume.state !== "ready") {
+      throw new Error(
+        `Volume '${VOLUME_NAME}' not ready after ${VOLUME_READY_TIMEOUT_MS}ms (state: ${volume.state})`,
+      )
+    }
+    volumes = [{ volumeId: volume.id, mountPath: PATCHRIGHT_PROFILE_PATH }]
   }
 
   let sandbox: Sandbox | undefined
@@ -118,69 +203,44 @@ export async function generateClaudeCredentials(
       {
         image: ccauthImage,
         ephemeral: true,
-        volumes: [{ volumeId: volume.id, mountPath: PATCHRIGHT_PROFILE_PATH }],
+        volumes,
         autoStopInterval: 5,
       },
       {
         timeout: 0,
         onSnapshotCreateLogs: (chunk) =>
-          console.error(`[ccauth-image] ${chunk}`),
+          console.error(`[ccauth-snapshot] ${chunk}`),
       },
     )
 
-    await sandbox.fs.uploadFile(
-      Buffer.from(cookies, "utf8"),
-      COOKIES_REMOTE_PATH,
-    )
+    if (!refreshMode) {
+      await sandbox.fs.uploadFile(
+        Buffer.from(input.cookies, "utf8"),
+        COOKIES_REMOTE_PATH,
+      )
+    }
 
-    // ccauth runs Chrome headed (Turnstile flags headless). xvfb-run spins up a
-    // throwaway X display, sets DISPLAY for ccauth, and tears it down on exit.
     // ccauth always emits JSON on stdout: {"claudeAiOauth": {...}} on success
-    // (exit 0) or {"error": ..., extra} on failure (exit 1). Verbose logs go
-    // to stderr.
-    const res = await sandbox.process.executeCommand(
-      `xvfb-run -a ccauth --cookies ${COOKIES_REMOTE_PATH}`,
-      undefined,
-      undefined,
-      300,
-    )
+    // (exit 0) or {"error": ..., extra} on failure (exit 1); verbose logs go to
+    // stderr. Cookie mode runs Chrome headed under xvfb-run (Turnstile flags
+    // headless); refresh mode is a plain HTTP call with the token passed via env
+    // (not argv) so it stays out of the command string.
+    const res =
+      refreshMode
+        ? await sandbox.process.executeCommand(
+            `ccauth --refresh "$CCAUTH_REFRESH_TOKEN"`,
+            undefined,
+            { CCAUTH_REFRESH_TOKEN: input.refreshToken },
+            120,
+          )
+        : await sandbox.process.executeCommand(
+            `xvfb-run -a ccauth --cookies $COOKIES_PATH`,
+            undefined,
+            { COOKIES_PATH: COOKIES_REMOTE_PATH },
+            300,
+          )
 
-    const output = res.result ?? ""
-
-    if (res.exitCode !== 0) {
-      throw new Error(
-        `ccauth failed (exit ${res.exitCode}): ${output.slice(0, 4000) || "(no output)"}`,
-      )
-    }
-
-    // Daytona's executeCommand merges stdout and stderr into `result`. ccauth
-    // emits its single-line JSON last (after stderr-bound progress logs), so
-    // pick the final non-empty line and parse that.
-    const lastLine = output
-      .split("\n")
-      .map((l) => l.trim())
-      .filter(Boolean)
-      .pop()
-    if (!lastLine) {
-      throw new Error(`ccauth produced empty output`)
-    }
-
-    let parsed: unknown
-    try {
-      parsed = JSON.parse(lastLine)
-    } catch {
-      throw new Error(
-        `ccauth produced non-JSON final line: ${lastLine.slice(0, 4000)}`,
-      )
-    }
-
-    if (!isClaudeOAuthCredentials(parsed)) {
-      throw new Error(
-        `ccauth output missing claudeAiOauth fields: ${JSON.stringify(parsed).slice(0, 4000)}`,
-      )
-    }
-
-    return parsed
+    return parseCredentialsOutput(res.result ?? "")
   } finally {
     if (sandbox) {
       try {

--- a/packages/claude-credentials/src/index.ts
+++ b/packages/claude-credentials/src/index.ts
@@ -18,5 +18,6 @@ export {
   getCCAuthImage,
   isClaudeOAuthCredentials,
   generateClaudeCredentials,
+  RefreshTokenExpiredError,
   type GenerateCredentialsOptions,
 } from "./generate"

--- a/packages/web/lib/server/refresh-claude-credentials.ts
+++ b/packages/web/lib/server/refresh-claude-credentials.ts
@@ -14,7 +14,10 @@
 import "server-only"
 import {
   generateClaudeCredentials,
+  RefreshTokenExpiredError,
+  isClaudeOAuthCredentials,
   CLAUDE_COOKIES_KEY,
+  type ClaudeOAuthCredentials,
 } from "@background-agents/claude-credentials"
 import {
   readCredentials,
@@ -33,7 +36,7 @@ export type RefreshResult =
   | { status: "refreshed"; expiresAt: number }
   | {
       status: "error"
-      code: "COOKIES_UNAVAILABLE" | "CCAUTH_FAILED"
+      code: "COOKIES_UNAVAILABLE" | "CCAUTH_FAILED" | "REFRESH_FAILED"
       message: string
     }
 
@@ -84,30 +87,57 @@ export async function refreshCredentials(
 }
 
 async function runRefresh(force: boolean): Promise<RefreshResult> {
-  if (!force) {
-    const existing = await readCredentials()
-    if (existing) {
-      try {
-        const parsed = JSON.parse(existing) as {
-          claudeAiOauth?: { expiresAt?: number }
+  const existing = await readCredentials()
+
+  let current: ClaudeOAuthCredentials | null = null
+  if (existing) {
+    try {
+      const parsed = JSON.parse(existing)
+      if (isClaudeOAuthCredentials(parsed)) {
+        current = parsed
+        if (!force && current.claudeAiOauth.expiresAt - Date.now() > SKIP_THRESHOLD_MS) {
+          return { status: "skipped", expiresAt: current.claudeAiOauth.expiresAt }
         }
-        const expiresAt = parsed.claudeAiOauth?.expiresAt
-        if (
-          typeof expiresAt === "number" &&
-          expiresAt - Date.now() > SKIP_THRESHOLD_MS
-        ) {
-          return { status: "skipped", expiresAt }
-        }
-      } catch (err) {
-        // Malformed row — fall through and overwrite.
+      }
+    } catch (err) {
+      // Malformed row — fall through and overwrite.
+      console.warn(
+        "[refresh-claude-credentials] Existing creds row unparseable:",
+        err,
+      )
+    }
+  }
+
+  // Preferred path: renew from the refresh token — a plain grant_type=refresh_token
+  // call in a lightweight sandbox, no browser/Cloudflare. Only when the refresh
+  // token itself is expired do we fall through to the full cookie-based flow.
+  const refreshToken = current?.claudeAiOauth.refreshToken
+  if (refreshToken) {
+    try {
+      const creds = await generateClaudeCredentials({ refreshToken })
+      await writeCredentials(JSON.stringify(creds))
+      return { status: "refreshed", expiresAt: creds.claudeAiOauth.expiresAt }
+    } catch (err) {
+      if (err instanceof RefreshTokenExpiredError) {
         console.warn(
-          "[refresh-claude-credentials] Existing creds row unparseable:",
-          err,
+          "[refresh-claude-credentials] refresh token expired; falling back to ccauth:",
+          err.message,
         )
+        // fall through to the cookie flow below
+      } else {
+        // Transient refresh failure — don't spin up the heavy ccauth browser
+        // flow; let the next run retry the cheap refresh.
+        console.error("[refresh-claude-credentials] token refresh failed:", err)
+        return {
+          status: "error",
+          code: "REFRESH_FAILED",
+          message: err instanceof Error ? err.message : String(err),
+        }
       }
     }
   }
 
+  // Fallback: full cookie-based OAuth flow (first run, or refresh token expired).
   const cookies = await getCookies()
   if (!cookies) {
     return {
@@ -119,7 +149,7 @@ async function runRefresh(force: boolean): Promise<RefreshResult> {
 
   let creds
   try {
-    creds = await generateClaudeCredentials(cookies)
+    creds = await generateClaudeCredentials({ cookies })
   } catch (err) {
     console.error("[refresh-claude-credentials] ccauth failed:", err)
     return {

--- a/packages/web/scripts/run-ccauth.ts
+++ b/packages/web/scripts/run-ccauth.ts
@@ -1,13 +1,19 @@
 /**
- * Run ccauth in a Daytona sandbox against a local cookies file.
+ * Run ccauth in a Daytona sandbox to mint Claude credentials.
+ *
+ * Exactly one input is required:
+ *   --cookies-path <path>    claude.ai cookies JSON → cookie-based (browser) flow
+ *   --refresh-token <token>  existing refresh token → refresh flow (no browser)
  *
  * Modes:
- *   default       generate creds, print JSON to stdout (no DB)
- *   --seed        also upsert cookies + creds rows into the CcAuthInfo table
+ *   default   generate creds, print JSON to stdout (no DB)
+ *   --seed    also upsert the resulting creds row (and, in cookie mode, the
+ *             cookies row) into the CcAuthInfo table
  *
  * Usage:
- *   npm run test:ccauth -- ./cookies.json
- *   npm run seed:ccauth -- ./cookies.json
+ *   npm run test:ccauth -- --cookies-path ./cookies.json
+ *   npm run test:ccauth -- --refresh-token sk-ant-ort01-...
+ *   npm run seed:ccauth -- --cookies-path ./cookies.json
  *
  * Required env (loaded via tsx --env-file=.env.local):
  *   DAYTONA_API_KEY
@@ -16,17 +22,38 @@
 
 import { readFileSync } from "node:fs"
 import { resolve } from "node:path"
-import { generateClaudeCredentials, CLAUDE_CREDS_KEY, CLAUDE_COOKIES_KEY } from "@background-agents/claude-credentials"
+import {
+  generateClaudeCredentials,
+  CLAUDE_CREDS_KEY,
+  CLAUDE_COOKIES_KEY,
+} from "@background-agents/claude-credentials"
+
+const USAGE =
+  "usage: tsx scripts/run-ccauth.ts (--cookies-path <path> | --refresh-token <token>) [--seed]"
+
+/** Reads `--flag value` or `--flag=value`; ignores a following token that is itself a flag. */
+function getFlag(args: string[], name: string): string | undefined {
+  const eq = args.find((a) => a.startsWith(`${name}=`))
+  if (eq) return eq.slice(name.length + 1)
+  const i = args.indexOf(name)
+  if (i !== -1 && i + 1 < args.length && !args[i + 1].startsWith("--")) {
+    return args[i + 1]
+  }
+  return undefined
+}
 
 async function main() {
   const args = process.argv.slice(2)
   const seed = args.includes("--seed")
-  const cookiesPath = args.find((a) => !a.startsWith("--"))
+  const cookiesPath = getFlag(args, "--cookies-path")
+  const refreshToken = getFlag(args, "--refresh-token")
 
-  if (!cookiesPath) {
-    console.error(
-      "usage: tsx scripts/run-ccauth.ts <path-to-cookies.json> [--seed]",
-    )
+  if (!cookiesPath && !refreshToken) {
+    console.error(`At least one of --cookies-path or --refresh-token is required.\n${USAGE}`)
+    process.exit(1)
+  }
+  if (cookiesPath && refreshToken) {
+    console.error(`Provide only one of --cookies-path or --refresh-token.\n${USAGE}`)
     process.exit(1)
   }
   if (!process.env.DAYTONA_API_KEY) {
@@ -40,8 +67,12 @@ async function main() {
     process.exit(1)
   }
 
-  const cookies = readFileSync(resolve(cookiesPath), "utf8")
-  JSON.parse(cookies) // sanity check before sending into a sandbox
+  // Cookie mode: read + sanity-check the cookies file before sending it into a sandbox.
+  let cookies: string | undefined
+  if (cookiesPath) {
+    cookies = readFileSync(resolve(cookiesPath), "utf8")
+    JSON.parse(cookies)
+  }
 
   // Lazy: only import (and connect to) Prisma in --seed mode so test mode
   // doesn't require DATABASE_URL.
@@ -56,16 +87,19 @@ async function main() {
     })
   }
 
-  if (seed) {
+  // Seed the cookies row up front — cookie mode only; refresh mode has no cookies.
+  if (seed && cookies) {
     console.error(`→ Upserting cookies row (${CLAUDE_COOKIES_KEY})`)
     await upsert(CLAUDE_COOKIES_KEY, cookies)
   }
 
   console.error(
-    "→ Running ccauth in Daytona (first run can take a few minutes)",
+    `→ Running ccauth in Daytona (${cookiesPath ? "cookie-based" : "refresh"} flow; first run can take a few minutes)`,
   )
   const t0 = Date.now()
-  const creds = await generateClaudeCredentials(cookies)
+  const creds = cookiesPath
+    ? await generateClaudeCredentials({ cookies: cookies! })
+    : await generateClaudeCredentials({ refreshToken: refreshToken! })
   const elapsed = ((Date.now() - t0) / 1000).toFixed(1)
 
   if (seed) {


### PR DESCRIPTION
## Context

The shared Claude credential pool is kept fresh by an hourly cron. Until now, **every** renewal ran the full ccauth *browser* flow: spin up a Daytona sandbox with headed Chrome, replay claude.ai cookies, click "Authorize" past Cloudflare Turnstile, and complete the OAuth handshake.

That path is heavy and fragile. From Daytona's datacenter IP it frequently hits Cloudflare "Just a moment…" challenges (and occasional Daytona snapshot/pull issues), so renewals fail and the pool goes stale — which is what's been showing up as recurring errors in the refresh history.

But we already have a long-lived OAuth **refresh token**. Standard OAuth lets us mint a new access token from it with a single HTTP call — no browser, no Cloudflare. We just weren't using it: we re-ran the whole browser flow every 8 hours instead.

## What this PR does

Makes the **refresh token the primary renewal path**, and demotes the browser flow to a rare fallback. Per run, the cron now decides:

1. **Skip** — the access token still has > 2h of life.
2. **Refresh** — mint a new access token via `ccauth --refresh` (a plain `grant_type=refresh_token` call in a lightweight sandbox — no browser, no volume).
3. **Cookie flow (fallback)** — only on first run, or when the refresh token itself has expired.

So the fragile browser/Cloudflare path runs only in the rare cases it's actually needed; routine 8-hour renewals are now a cheap HTTP call.

## Changes

| File | Change |
|------|--------|
| `claude-credentials/src/generate.ts` | `generateClaudeCredentials` overloaded to take `{ cookies }` or `{ refreshToken }`; refresh mode runs `ccauth --refresh` in a lightweight image (git-only, no Chrome/xvfb); adds `RefreshTokenExpiredError`. Also removes the stale patchright-profile volume mount (a symlink made it ineffective) from the cookie path |
| `claude-credentials/src/index.ts` | Export `RefreshTokenExpiredError` |
| `claude-credentials/README.md` | Document the refresh mode + overloaded API |
| `web/lib/server/refresh-claude-credentials.ts` | The decision logic above; transient refresh errors return `REFRESH_FAILED` and retry next tick rather than escalating to the browser flow |
| `web/scripts/run-ccauth.ts` | `--cookies-path` / `--refresh-token` flags (exactly one required) so the seed/test script can drive either flow |

## Notes

- **Depends on ccauth's `--refresh`** (already on ccauth `master`). The package pip-installs ccauth at the latest `master` SHA, so it's picked up automatically.
- Refresh tokens **rotate** on every call — the new one is persisted with the rest of the credentials each run.
- Also drops the stale patchright-profile volume mount from the cookie path — a symlink made the mount ineffective, so it was just an extra volume create/poll round-trip per run.
