### PR TITLE
Fix/ownership

### DIFF
--- a/packages/web/app/api/git/push/route.ts
+++ b/packages/web/app/api/git/push/route.ts
@@ -1,7 +1,7 @@
 import { Daytona } from "@daytonaio/sdk"
 import { createSandboxGit } from "@background-agents/sandbox-git"
 import { PATHS } from "@/lib/constants"
-import { requireGitHubAuth, isGitHubAuthError, requireAuth, isAuthError, internalError, badRequest } from "@/lib/db/api-helpers"
+import { requireGitHubAuth, isGitHubAuthError, requireAuth, isAuthError, internalError, badRequest, verifySandboxOwnership, forbidden } from "@/lib/db/api-helpers"
 import { getUserPushOptions } from "@/lib/git/push-options"
 
 export async function POST(req: Request) {
@@ -13,23 +13,27 @@ export async function POST(req: Request) {
     return badRequest("Missing required fields: sandboxId, repoName, branch")
   }
 
-  // 2. Get GitHub token from request body first (for API access)
-  // Fall back to DB token (for browser access)
+  // 2. Require a session and verify sandbox ownership before operating on it.
+  // A body-supplied githubToken must NOT bypass this — otherwise any caller with
+  // some GitHub token could run git operations inside another user's sandbox.
+  const auth = await requireAuth()
+  if (isAuthError(auth)) {
+    return Response.json({ error: "Unauthorized - sign in to push" }, { status: 401 })
+  }
+  const userId = auth.userId
+
+  if (!(await verifySandboxOwnership(userId, sandboxId))) {
+    return forbidden()
+  }
+
+  // GitHub token: honor a body-provided token (API access), else the DB token.
   let githubToken = body.githubToken
-  let userId: string | undefined
   if (!githubToken) {
     const ghAuth = await requireGitHubAuth()
     if (isGitHubAuthError(ghAuth)) {
-      return Response.json({ error: "Unauthorized - provide githubToken in body or sign in" }, { status: 401 })
+      return Response.json({ error: "Unauthorized - provide githubToken in body or link GitHub" }, { status: 401 })
     }
     githubToken = ghAuth.token
-    userId = ghAuth.userId
-  } else {
-    // If token provided in body, still try to get userId for settings
-    const auth = await requireAuth()
-    if (!isAuthError(auth)) {
-      userId = auth.userId
-    }
   }
 
   // 3. Get Daytona API key

--- a/packages/web/app/api/git/setup-remote/route.ts
+++ b/packages/web/app/api/git/setup-remote/route.ts
@@ -1,7 +1,7 @@
 import { Daytona } from "@daytonaio/sdk"
 import { createSandboxGit } from "@background-agents/sandbox-git"
 import { PATHS } from "@/lib/constants"
-import { requireGitHubAuth, isGitHubAuthError, internalError, badRequest } from "@/lib/db/api-helpers"
+import { requireGitHubAuth, isGitHubAuthError, internalError, badRequest, verifySandboxOwnership, forbidden } from "@/lib/db/api-helpers"
 import { getUserPushOptions } from "@/lib/git/push-options"
 
 /**
@@ -27,6 +27,13 @@ export async function POST(req: Request) {
   }
   const githubToken = ghAuth.token
   const userId = ghAuth.userId
+
+  // Ownership gate: signing in isn't enough — the caller must own this sandbox,
+  // otherwise they could point another user's sandbox at their own repo and push
+  // that user's working tree to it.
+  if (!(await verifySandboxOwnership(userId, sandboxId))) {
+    return forbidden()
+  }
 
   // 3. Get Daytona API key
   const daytonaApiKey = process.env.DAYTONA_API_KEY

--- a/packages/web/app/api/github/squash/route.ts
+++ b/packages/web/app/api/github/squash/route.ts
@@ -3,7 +3,7 @@ import { Daytona } from "@daytonaio/sdk"
 import { createSandboxGit } from "@background-agents/sandbox-git"
 import { PATHS } from "@/lib/constants"
 import { createGitOperationMessage } from "@/lib/db/git-messages"
-import { requireGitHubAuth, isGitHubAuthError } from "@/lib/db/api-helpers"
+import { requireGitHubAuth, isGitHubAuthError, verifySandboxOwnership, forbidden } from "@/lib/db/api-helpers"
 
 // Squash operation timeout - 60 seconds
 export const maxDuration = 60
@@ -34,12 +34,20 @@ export async function POST(req: Request) {
   const ghAuth = await requireGitHubAuth()
   if (isGitHubAuthError(ghAuth)) return ghAuth
   const githubToken = ghAuth.token
+  const userId = ghAuth.userId
 
   const body: SquashRequestBody = await req.json()
   const { owner, repo, head, base, sandboxId, chatId } = body
 
   if (!owner || !repo || !head || !base || !sandboxId) {
     return Response.json({ error: "Missing required fields: owner, repo, head, base, sandboxId" }, { status: 400 })
+  }
+
+  // Ownership gate: the sandbox-sync step runs `git checkout` + `git reset --hard`
+  // inside sandboxId, so a caller who doesn't own it could wipe another user's
+  // uncommitted work.
+  if (!(await verifySandboxOwnership(userId, sandboxId))) {
+    return forbidden()
   }
 
   const daytonaApiKey = process.env.DAYTONA_API_KEY

--- a/packages/web/app/api/sandbox/delete/route.ts
+++ b/packages/web/app/api/sandbox/delete/route.ts
@@ -1,5 +1,5 @@
 import { Daytona } from "@daytonaio/sdk"
-import { badRequest } from "@/lib/db/api-helpers"
+import { badRequest, requireSandboxOwner } from "@/lib/db/api-helpers"
 
 export async function POST(req: Request) {
   const body = await req.json()
@@ -8,6 +8,9 @@ export async function POST(req: Request) {
   if (!sandboxId) {
     return badRequest("Missing sandboxId")
   }
+
+  const owner = await requireSandboxOwner(sandboxId)
+  if (owner instanceof Response) return owner
 
   const daytonaApiKey = process.env.DAYTONA_API_KEY
   if (!daytonaApiKey) {

--- a/packages/web/app/api/sandbox/download/route.ts
+++ b/packages/web/app/api/sandbox/download/route.ts
@@ -2,7 +2,7 @@ import { Daytona } from "@daytonaio/sdk"
 import { PATHS } from "@background-agents/common"
 import { ensureSandboxStarted } from "@/lib/sandbox"
 import { getSandboxOrExpired } from "@/lib/sandbox-lifecycle"
-import { internalError, badRequest } from "@/lib/db/api-helpers"
+import { internalError, badRequest, requireSandboxOwner } from "@/lib/db/api-helpers"
 
 export const maxDuration = 60
 
@@ -18,6 +18,9 @@ export async function POST(req: Request) {
   if (!sandboxId) {
     return badRequest("Missing sandboxId")
   }
+
+  const owner = await requireSandboxOwner(sandboxId)
+  if (owner instanceof Response) return owner
 
   const daytonaApiKey = process.env.DAYTONA_API_KEY
   if (!daytonaApiKey) {

--- a/packages/web/app/api/sandbox/files/route.ts
+++ b/packages/web/app/api/sandbox/files/route.ts
@@ -4,7 +4,7 @@ import { getSandboxOrExpired, passiveReadGate } from "@/lib/sandbox-lifecycle"
 import { escapeShell } from "@background-agents/sdk"
 import { PATHS } from "@background-agents/common"
 import { IMAGE_MIME_TYPES } from "@/lib/file-preview/types"
-import { internalError, badRequest, notFound } from "@/lib/db/api-helpers"
+import { internalError, badRequest, notFound, requireSandboxOwner } from "@/lib/db/api-helpers"
 
 export const maxDuration = 30
 
@@ -50,6 +50,9 @@ export async function POST(req: Request) {
   if (!sandboxId || !action) {
     return badRequest("Missing required fields")
   }
+
+  const owner = await requireSandboxOwner(sandboxId)
+  if (owner instanceof Response) return owner
 
   const daytonaApiKey = process.env.DAYTONA_API_KEY
   if (!daytonaApiKey) {

--- a/packages/web/app/api/sandbox/git/route.ts
+++ b/packages/web/app/api/sandbox/git/route.ts
@@ -3,7 +3,7 @@ import { createSandboxGit } from "@background-agents/sandbox-git"
 import { ensureSandboxStarted } from "@/lib/sandbox"
 import { PATHS } from "@/lib/constants"
 import { clearPushFailureMessages, createGitOperationMessage } from "@/lib/db/git-messages"
-import { requireGitHubAuth, isGitHubAuthError } from "@/lib/db/api-helpers"
+import { requireGitHubAuth, isGitHubAuthError, verifySandboxOwnership, forbidden } from "@/lib/db/api-helpers"
 import {
   getConflictedFiles,
   pushViaTemporaryBranch,
@@ -74,6 +74,13 @@ export async function POST(req: Request) {
 
   if (!sandboxId || !repoPath || !action) {
     return Response.json({ error: "Missing required fields: sandboxId, repoPath, action" }, { status: 400 })
+  }
+
+  // requireGitHubAuth only proves the caller is signed in; it does not tie them
+  // to this sandbox. Verify ownership so a logged-in user can't run git actions
+  // against another user's sandbox/repo.
+  if (!(await verifySandboxOwnership(userId, sandboxId))) {
+    return forbidden()
   }
 
   const daytonaApiKey = process.env.DAYTONA_API_KEY

--- a/packages/web/app/api/sandbox/ssh/route.ts
+++ b/packages/web/app/api/sandbox/ssh/route.ts
@@ -1,7 +1,7 @@
 import { Daytona } from "@daytonaio/sdk"
 import { ensureSandboxStarted } from "@/lib/sandbox"
 import { getSandboxOrExpired } from "@/lib/sandbox-lifecycle"
-import { internalError, badRequest } from "@/lib/db/api-helpers"
+import { internalError, badRequest, requireSandboxOwner } from "@/lib/db/api-helpers"
 
 export const maxDuration = 30
 
@@ -17,6 +17,9 @@ export async function POST(req: Request) {
   if (!body) return badRequest("Invalid JSON body")
   const { sandboxId } = body
   if (!sandboxId) return badRequest("Missing sandboxId")
+
+  const owner = await requireSandboxOwner(sandboxId)
+  if (owner instanceof Response) return owner
 
   const daytonaApiKey = process.env.DAYTONA_API_KEY
   if (!daytonaApiKey) {

--- a/packages/web/app/api/sandbox/state/route.ts
+++ b/packages/web/app/api/sandbox/state/route.ts
@@ -1,7 +1,7 @@
 import { Daytona } from "@daytonaio/sdk"
 import { ensureSandboxStarted } from "@/lib/sandbox"
 import { getSandboxOrExpired, passiveReadGate } from "@/lib/sandbox-lifecycle"
-import { badRequest, serverConfigError } from "@/lib/db/api-helpers"
+import { badRequest, serverConfigError, requireSandboxOwner } from "@/lib/db/api-helpers"
 
 export const maxDuration = 30
 
@@ -22,6 +22,9 @@ export async function POST(req: Request) {
   } | null
 
   if (!body?.sandboxId) return badRequest("Missing sandboxId")
+
+  const owner = await requireSandboxOwner(body.sandboxId)
+  if (owner instanceof Response) return owner
 
   const daytonaApiKey = process.env.DAYTONA_API_KEY
   if (!daytonaApiKey) return serverConfigError("DAYTONA_API_KEY")

--- a/packages/web/app/api/sandbox/terminal/route.ts
+++ b/packages/web/app/api/sandbox/terminal/route.ts
@@ -2,7 +2,7 @@ import { Daytona } from "@daytonaio/sdk"
 import { setupTerminal, stopTerminal, getTerminalStatus } from "@background-agents/sandbox-terminal"
 import { ensureSandboxStarted } from "@/lib/sandbox"
 import { getSandboxOrExpired } from "@/lib/sandbox-lifecycle"
-import { internalError, badRequest } from "@/lib/db/api-helpers"
+import { internalError, badRequest, requireSandboxOwner } from "@/lib/db/api-helpers"
 
 export const maxDuration = 60
 
@@ -24,6 +24,9 @@ export async function POST(req: Request) {
 
   const { sandboxId, action = "setup" } = body
   if (!sandboxId) return badRequest("Missing sandboxId")
+
+  const owner = await requireSandboxOwner(sandboxId)
+  if (owner instanceof Response) return owner
 
   const daytonaApiKey = process.env.DAYTONA_API_KEY
   if (!daytonaApiKey) {

--- a/packages/web/lib/db/api-helpers.ts
+++ b/packages/web/lib/db/api-helpers.ts
@@ -42,6 +42,14 @@ export function notFound(message: string = "Not found") {
 }
 
 /**
+ * Returns a 403 Forbidden response. Used when the caller is authenticated but
+ * does not own the resource they're addressing.
+ */
+export function forbidden(message: string = "Forbidden") {
+  return Response.json({ error: message }, { status: 403 })
+}
+
+/**
  * Returns a 500 Server Configuration Error response
  * Use when a required environment variable is missing
  */
@@ -167,6 +175,53 @@ export async function requireChatStreamAccess(
       previewUrlPattern: chat.previewUrlPattern,
     },
   }
+}
+
+/**
+ * Verifies that `sandboxId` belongs to `userId`. A Daytona sandbox is owned by
+ * the caller when either a chat they own or a scheduled-job run they own (via
+ * its parent job) references it. Pure DB check — no session lookup — so routes
+ * that already resolved the user (e.g. via requireGitHubAuth) can reuse it.
+ */
+export async function verifySandboxOwnership(
+  userId: string,
+  sandboxId: string
+): Promise<boolean> {
+  const [chat, run] = await Promise.all([
+    prisma.chat.findFirst({
+      where: { sandboxId, userId },
+      select: { id: true },
+    }),
+    prisma.scheduledJobRun.findFirst({
+      where: { sandboxId, job: { userId } },
+      select: { id: true },
+    }),
+  ])
+  return Boolean(chat || run)
+}
+
+/**
+ * Auth + ownership gate for the /api/sandbox/* routes. Verifies the caller is
+ * signed in and owns the sandbox they're addressing, closing the IDOR where any
+ * caller with a sandboxId could read/delete/exec against another user's sandbox.
+ *
+ * Returns the userId on success, or an error Response (401 unauth / 403 not the
+ * owner) that the route should return directly. The 403 deliberately does not
+ * distinguish "not yours" from "does not exist" so sandbox ids aren't probeable.
+ *
+ * Usage:
+ *   const owner = await requireSandboxOwner(sandboxId)
+ *   if (owner instanceof Response) return owner
+ */
+export async function requireSandboxOwner(
+  sandboxId: string
+): Promise<AuthResult | Response> {
+  const auth = await requireAuth()
+  if (isAuthError(auth)) return auth
+  if (!(await verifySandboxOwnership(auth.userId, sandboxId))) {
+    return forbidden()
+  }
+  return auth
 }
 
 // =============================================================================


### PR DESCRIPTION
 ## Fix sandbox IDOR: enforce ownership on all sandbox routes

  ### Problem
  The `/api/sandbox/*` routes (and `git/push`, `git/setup-remote`, `github/squash`)
  resolved a sandbox by `sandboxId` from the request body without checking that the
  caller owned it. Six routes had no auth at all. Any user (in some cases
  unauthenticated) could read files, download the project, open SSH/terminal,
  delete, or run git operations against **another user's sandbox** — enabling
  working-tree exfiltration, RCE, and data loss.

  ### Fix
  Added `verifySandboxOwnership(userId, sandboxId)` / `requireSandboxOwner()`
  helpers (a sandbox is owned if a chat or scheduled-job run the caller owns
  references it) and gated every affected route:

  - `sandbox/{delete,download,files,ssh,state,terminal,git}` — now require an
    authenticated owner (401 unauth / 403 not owner)
  - `git/setup-remote`, `github/squash` — ownership check before touching the sandbox
  - `git/push` — now always requires a session (closes the body-`githubToken`
    auth bypass) plus the ownership check

  403s don't distinguish "not yours" from "doesn't exist", so sandbox ids stay
  unprobeable.

  ### Verification
  Tested end-to-end against a running instance with minted sessions:
  - unauthenticated → **401**
  - authenticated non-owner → **403**
  - authenticated owner → **200** (sandbox resolves normally)
  - `git/push` body-token bypass → **401**

  Typecheck clean.