### PR TITLE
fix(opencode): keep config out of the sandbox repo working tree

### DIFF
--- a/packages/agent-configuration/src/mcp/index.ts
+++ b/packages/agent-configuration/src/mcp/index.ts
@@ -117,8 +117,13 @@ function generateGeminiConfig(servers: AgentMcpServer[]): McpConfigFile {
 }
 
 /**
- * OpenCode: <project>/opencode.json — `mcp.<name>` with `type: "remote"`.
- * The `.opencode/` directory is for agents/commands/plugins, not config.
+ * OpenCode: ~/.config/opencode/opencode.json (global) — `mcp.<name>` with
+ * `type: "remote"`. Must NOT go in the project root: OpenCode also reads a
+ * `<project>/opencode.json`, but writing there dirties the repo working tree in
+ * the sandbox (it shows up in `git status` and can get swept into the agent's
+ * commit). OpenCode merges the global config, so servers still load. The
+ * custom-endpoint provider config (opencodeSetup) shares this same file and
+ * preserves the `mcp` section on write.
  */
 function generateOpenCodeConfig(servers: AgentMcpServer[]): McpConfigFile {
   const mcp: Record<string, unknown> = {}
@@ -131,7 +136,7 @@ function generateOpenCodeConfig(servers: AgentMcpServer[]): McpConfigFile {
     }
   }
   return {
-    filePath: "/home/daytona/project/opencode.json",
+    filePath: "/home/daytona/.config/opencode/opencode.json",
     content: JSON.stringify(
       { $schema: "https://opencode.ai/config.json", mcp },
       null,

--- a/packages/sdk/src/agents/opencode/config.ts
+++ b/packages/sdk/src/agents/opencode/config.ts
@@ -29,13 +29,20 @@ export interface OpencodeCustomConfig {
 /** Provider id used for the synthesized custom provider in opencode.json. */
 export const OPENCODE_CUSTOM_PROVIDER_ID = "custom"
 
+/** JSON `$schema` URL used by OpenCode config files. */
+export const OPENCODE_CONFIG_SCHEMA = "https://opencode.ai/config.json"
+
 /**
- * Build a ~/.config/opencode/opencode.json that routes the custom model through
- * an OpenAI-compatible provider (`@ai-sdk/openai-compatible`). The Authorization
+ * Build the `provider` map that routes the custom model through an
+ * OpenAI-compatible provider (`@ai-sdk/openai-compatible`). The Authorization
  * header is supplied as `options.apiKey` via `{env:...}`; any other headers pass
- * through as `options.headers`.
+ * through as `options.headers`. Returned as a `{ [id]: {...} }` object so callers
+ * can merge it into an existing opencode.json without clobbering other keys
+ * (e.g. the `mcp` section).
  */
-export function buildOpencodeConfigJson(cfg: OpencodeCustomConfig): string {
+export function buildOpencodeProvider(
+  cfg: OpencodeCustomConfig
+): Record<string, unknown> {
   const id = OPENCODE_CUSTOM_PROVIDER_ID
 
   const options: Record<string, unknown> = { baseURL: cfg.baseUrl }
@@ -49,16 +56,26 @@ export function buildOpencodeConfigJson(cfg: OpencodeCustomConfig): string {
     options.headers = Object.fromEntries(headerPairs)
   }
 
-  const config = {
-    $schema: "https://opencode.ai/config.json",
-    provider: {
-      [id]: {
-        npm: "@ai-sdk/openai-compatible",
-        name: "Custom",
-        options,
-        models: { [cfg.model]: { name: cfg.model } },
-      },
+  return {
+    [id]: {
+      npm: "@ai-sdk/openai-compatible",
+      name: "Custom",
+      options,
+      models: { [cfg.model]: { name: cfg.model } },
     },
+  }
+}
+
+/**
+ * Build a standalone ~/.config/opencode/opencode.json that routes the custom
+ * model through an OpenAI-compatible provider. Prefer merging
+ * {@link buildOpencodeProvider} into the existing file (see opencodeSetup); this
+ * whole-file form is retained for callers/tests that want the full document.
+ */
+export function buildOpencodeConfigJson(cfg: OpencodeCustomConfig): string {
+  const config = {
+    $schema: OPENCODE_CONFIG_SCHEMA,
+    provider: buildOpencodeProvider(cfg),
   }
 
   return JSON.stringify(config, null, 2) + "\n"

--- a/packages/sdk/src/agents/opencode/index.ts
+++ b/packages/sdk/src/agents/opencode/index.ts
@@ -13,20 +13,108 @@ import type { CodeAgentSandbox } from "../../types/provider"
 import { parseOpencodeLine } from "./parser"
 import { OPENCODE_TOOL_MAPPINGS } from "./tools"
 import { quote } from "../../utils/shell"
-import { buildOpencodeConfigJson } from "./config"
-
-/** Global OpenCode config path (not the project root, to avoid touching the repo). */
-const OPENCODE_CONFIG_PATH = "~/.config/opencode/opencode.json"
+import {
+  buildOpencodeProvider,
+  OPENCODE_CONFIG_SCHEMA,
+} from "./config"
 
 /**
- * OpenCode agent-specific setup. Two mutually exclusive paths:
+ * Global OpenCode config path — NOT the project root. Writing under the repo
+ * checkout would dirty the sandbox working tree (and could get committed by the
+ * agent). The MCP setup (see @background-agents/agent-configuration) writes the
+ * `mcp` section into this same file, so both readers/writers here preserve keys
+ * they don't own.
+ */
+const OPENCODE_CONFIG_DIR = "~/.config/opencode"
+const OPENCODE_CONFIG_PATH = `${OPENCODE_CONFIG_DIR}/opencode.json`
+
+/**
+ * Legacy location that older builds wrote OpenCode config to — the repo checkout
+ * itself. Sandboxes created before the global-path fix still have this file
+ * sitting in the working tree, where it dirties `git status` and can be swept
+ * into the agent's commit. On every session start we relocate it (see
+ * relocateLegacyProjectConfig) so existing sandboxes self-heal.
+ */
+const OPENCODE_LEGACY_PROJECT_CONFIG_PATH = "/home/daytona/project/opencode.json"
+
+/** Read+parse the global opencode.json, or `{}` if absent/unparseable. */
+async function readOpencodeConfig(
+  sandbox: CodeAgentSandbox
+): Promise<Record<string, unknown>> {
+  const res = await sandbox.executeCommand!(
+    `cat ${OPENCODE_CONFIG_PATH} 2>/dev/null || echo '{}'`,
+    10
+  )
+  try {
+    return JSON.parse((res?.output ?? "").trim() || "{}") as Record<string, unknown>
+  } catch {
+    return {}
+  }
+}
+
+/**
+ * Migrate a stale project-root opencode.json (written by older builds) out of
+ * the repo working tree. Folds any keys the global config doesn't already own
+ * into `config` (global wins, since it reflects this run's setupMcpForAgent),
+ * then deletes the project-root file so it stops dirtying the tree. Returns
+ * whether `config` gained anything and therefore needs to be written back.
+ */
+async function relocateLegacyProjectConfig(
+  sandbox: CodeAgentSandbox,
+  config: Record<string, unknown>
+): Promise<boolean> {
+  const res = await sandbox.executeCommand!(
+    `cat ${OPENCODE_LEGACY_PROJECT_CONFIG_PATH} 2>/dev/null || true`,
+    10
+  )
+  const raw = (res?.output ?? "").trim()
+  if (!raw) return false
+
+  // Remove it regardless of what it contains — we never want config in the tree.
+  await sandbox.executeCommand!(`rm -f ${OPENCODE_LEGACY_PROJECT_CONFIG_PATH}`, 10)
+
+  let legacy: Record<string, unknown>
+  try {
+    legacy = JSON.parse(raw) as Record<string, unknown>
+  } catch {
+    return false // junk file: deleted, nothing worth salvaging
+  }
+
+  let changed = false
+  for (const [key, value] of Object.entries(legacy)) {
+    if (config[key] === undefined) {
+      config[key] = value
+      changed = true
+    }
+  }
+  return changed
+}
+
+/** Write the global opencode.json (creating its directory). */
+async function writeOpencodeConfig(
+  sandbox: CodeAgentSandbox,
+  config: Record<string, unknown>
+): Promise<void> {
+  const json = JSON.stringify(config, null, 2) + "\n"
+  await sandbox.executeCommand!(
+    `mkdir -p ${OPENCODE_CONFIG_DIR} && printf '%s' ${quote(json)} > ${OPENCODE_CONFIG_PATH}`,
+    30
+  )
+}
+
+/**
+ * OpenCode agent-specific setup. Runs on every session start (for both fresh and
+ * reused sandboxes), read-modify-writing the global opencode.json so the `mcp`
+ * section written earlier by setupMcpForAgent survives:
  *
- * 1. Custom endpoint — when CUSTOM_OPENCODE_BASE_URL is set, write a global
- *    opencode.json defining a custom OpenAI-compatible provider. Auth lives in
- *    the headers blob (promoted to the provider apiKey).
- * 2. Standard — remove any custom opencode.json left over from a previous custom
- *    run in this sandbox, so a custom→standard switch stops using the old
- *    provider. In this app that file is only ever written by the custom path.
+ * 0. Relocation — move any legacy project-root opencode.json out of the repo
+ *    working tree and into the global config (self-heals older sandboxes).
+ * 1. Custom endpoint — when CUSTOM_OPENCODE_BASE_URL is set, merge a custom
+ *    OpenAI-compatible `provider` into the file. Auth lives in the headers blob
+ *    (promoted to the provider apiKey).
+ * 2. Standard — drop any `provider` left over from a previous custom run in this
+ *    sandbox, so a custom→standard switch stops using the old provider, while
+ *    keeping any MCP config in place.
  */
 async function opencodeSetup(
   sandbox: CodeAgentSandbox,
@@ -34,21 +122,25 @@ async function opencodeSetup(
 ): Promise<void> {
   if (!sandbox.executeCommand) return
 
+  const config = await readOpencodeConfig(sandbox)
+  let dirty = await relocateLegacyProjectConfig(sandbox, config)
+
   if (env.CUSTOM_OPENCODE_BASE_URL) {
-    const json = buildOpencodeConfigJson({
+    config.$schema = config.$schema ?? OPENCODE_CONFIG_SCHEMA
+    config.provider = buildOpencodeProvider({
       baseUrl: env.CUSTOM_OPENCODE_BASE_URL,
       model: env.CUSTOM_OPENCODE_NAME || "",
       headers: env.CUSTOM_OPENCODE_HEADERS || undefined,
       apiKeyEnv: env.CUSTOM_OPENCODE_API_KEY ? "CUSTOM_OPENCODE_API_KEY" : undefined,
     })
-    await sandbox.executeCommand(
-      `mkdir -p ~/.config/opencode && printf '%s' ${quote(json)} > ${OPENCODE_CONFIG_PATH}`,
-      30
-    )
-    return
+    dirty = true
+  } else if (config.provider !== undefined) {
+    // Standard path: strip a leftover custom provider from a previous run.
+    delete config.provider
+    dirty = true
   }
 
-  await sandbox.executeCommand(`rm -f ${OPENCODE_CONFIG_PATH}`, 10)
+  if (dirty) await writeOpencodeConfig(sandbox, config)
 }
 
 /**

--- a/packages/sdk/tests/unit/opencode-setup.test.ts
+++ b/packages/sdk/tests/unit/opencode-setup.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Unit tests for opencodeSetup (opencodeAgent.capabilities.setup).
+ *
+ * Focus: the global opencode.json is read-modify-written so it never lands in
+ * the repo working tree, the `mcp` section written earlier by setupMcpForAgent
+ * survives, and a legacy project-root opencode.json left by older builds is
+ * relocated out of the tree.
+ */
+import { describe, it, expect } from "vitest"
+import type { CodeAgentSandbox } from "../../src/types/provider"
+import { opencodeAgent } from "../../src/agents/opencode"
+
+const GLOBAL_PATH = "~/.config/opencode/opencode.json"
+const PROJECT_PATH = "/home/daytona/project/opencode.json"
+
+/** In-memory sandbox that interprets the handful of shell commands setup emits. */
+function fakeSandbox(initial: Record<string, string> = {}) {
+  const files: Record<string, string> = { ...initial }
+  const removed: string[] = []
+
+  const sandbox: CodeAgentSandbox = {
+    ensureProvider: async () => {},
+    setEnvVars: () => {},
+    async executeCommand(command: string) {
+      const cat = command.match(/^cat (\S+) /)
+      if (cat) {
+        const path = cat[1]
+        if (path in files) return { exitCode: 0, output: files[path] }
+        // Reproduce the shell fallbacks: `|| echo '{}'` vs `|| true`.
+        return { exitCode: 0, output: command.includes("echo '{}'") ? "{}" : "" }
+      }
+      const rm = command.match(/^rm -f (\S+)/)
+      if (rm) {
+        delete files[rm[1]]
+        removed.push(rm[1])
+        return { exitCode: 0, output: "" }
+      }
+      const write = command.match(/printf '%s' '([^']*)' > (\S+)/)
+      if (write) {
+        files[write[2]] = write[1]
+        return { exitCode: 0, output: "" }
+      }
+      return { exitCode: 0, output: "" }
+    },
+  }
+
+  return { sandbox, files, removed }
+}
+
+async function runSetup(
+  fs: ReturnType<typeof fakeSandbox>,
+  env: Record<string, string> = {}
+) {
+  await opencodeAgent.capabilities!.setup!(fs.sandbox, env)
+}
+
+const mcp = (name: string) => ({
+  [name]: { type: "remote", url: `https://${name}`, enabled: true },
+})
+
+describe("opencodeSetup — legacy project-root relocation", () => {
+  it("moves a stale project-root config into the global file and deletes it", async () => {
+    const fs = fakeSandbox({
+      [PROJECT_PATH]: JSON.stringify({
+        $schema: "https://opencode.ai/config.json",
+        mcp: mcp("github"),
+      }),
+    })
+
+    await runSetup(fs)
+
+    expect(fs.removed).toContain(PROJECT_PATH)
+    expect(PROJECT_PATH in fs.files).toBe(false)
+    const global = JSON.parse(fs.files[GLOBAL_PATH])
+    expect(global.mcp).toEqual(mcp("github"))
+  })
+
+  it("does not resurrect stale mcp when the global file already has one", async () => {
+    const fs = fakeSandbox({
+      [GLOBAL_PATH]: JSON.stringify({ mcp: mcp("current") }),
+      [PROJECT_PATH]: JSON.stringify({ mcp: mcp("stale") }),
+    })
+
+    await runSetup(fs)
+
+    expect(fs.removed).toContain(PROJECT_PATH)
+    const global = JSON.parse(fs.files[GLOBAL_PATH])
+    expect(global.mcp).toEqual(mcp("current"))
+  })
+
+  it("deletes a junk project-root file without touching the global config", async () => {
+    const fs = fakeSandbox({ [PROJECT_PATH]: "not json {{{" })
+
+    await runSetup(fs)
+
+    expect(fs.removed).toContain(PROJECT_PATH)
+    expect(GLOBAL_PATH in fs.files).toBe(false)
+  })
+
+  it("is a no-op when there is no project-root file and nothing to strip", async () => {
+    const fs = fakeSandbox()
+
+    await runSetup(fs)
+
+    expect(fs.removed).toHaveLength(0)
+    expect(GLOBAL_PATH in fs.files).toBe(false)
+  })
+})
+
+describe("opencodeSetup — custom endpoint", () => {
+  it("merges a custom provider while preserving the mcp section", async () => {
+    const fs = fakeSandbox({
+      [GLOBAL_PATH]: JSON.stringify({ mcp: mcp("github") }),
+    })
+
+    await runSetup(fs, {
+      CUSTOM_OPENCODE_BASE_URL: "https://gw.example.com/v1",
+      CUSTOM_OPENCODE_NAME: "gpt-4o-mini",
+      CUSTOM_OPENCODE_API_KEY: "tok",
+    })
+
+    const global = JSON.parse(fs.files[GLOBAL_PATH])
+    expect(global.mcp).toEqual(mcp("github"))
+    expect(global.provider.custom.options.baseURL).toBe("https://gw.example.com/v1")
+    expect(global.provider.custom.options.apiKey).toBe("{env:CUSTOM_OPENCODE_API_KEY}")
+    expect(global.$schema).toBe("https://opencode.ai/config.json")
+  })
+})
+
+describe("opencodeSetup — standard path", () => {
+  it("strips a leftover custom provider but keeps mcp", async () => {
+    const fs = fakeSandbox({
+      [GLOBAL_PATH]: JSON.stringify({
+        $schema: "https://opencode.ai/config.json",
+        provider: { custom: { npm: "@ai-sdk/openai-compatible" } },
+        mcp: mcp("github"),
+      }),
+    })
+
+    await runSetup(fs)
+
+    const global = JSON.parse(fs.files[GLOBAL_PATH])
+    expect(global.provider).toBeUndefined()
+    expect(global.mcp).toEqual(mcp("github"))
+  })
+})


### PR DESCRIPTION
OpenCode's MCP config was written to /home/daytona/project/opencode.json — inside the cloned repo — so every run dirtied the sandbox working tree and the file could be swept into the agent's commit. Every other agent writes to a home-dir path.

- MCP config now targets ~/.config/opencode/opencode.json (global). OpenCode merges the global config, so servers still load.
- opencodeSetup relocates any legacy project-root opencode.json into the global file on session start and deletes it, so existing/reused sandboxes self-heal.
- Custom-endpoint provider setup and MCP setup now share the global file with merge-safe read-modify-write, so neither clobbers the other's section.

Adds opencode-setup unit tests covering relocation, mcp preservation, provider merge, and provider strip.