### PR TITLE
feat(opencode): random 50/50 shared key pool via secondary env var

### DIFF
--- a/packages/web/lib/db/api-helpers.ts
+++ b/packages/web/lib/db/api-helpers.ts
@@ -7,6 +7,7 @@ import {
   normalizeStoredCredentials,
   type Credentials,
 } from "@/lib/credentials"
+import { pickSharedOpencodeKey } from "@/lib/server/opencode-pool"
 
 // =============================================================================
 // Types
@@ -316,10 +317,13 @@ export async function getUserCredentials(userId: string): Promise<Credentials> {
 
   // Fallback: if a credential isn't stored in the DB, check process.env.
   // This lets operators set API keys in .env / .env.local without the UI.
+  // OpenCode's shared key comes from a pool (OPENCODE_API_KEYS) — pick one at
+  // random per resolution so runs spread evenly across the configured keys.
   for (const { id } of CREDENTIAL_KEYS) {
-    if (!creds[id] && process.env[id]) {
-      creds[id] = process.env[id]
-    }
+    if (creds[id]) continue
+    const envVal =
+      id === "OPENCODE_API_KEY" ? pickSharedOpencodeKey() : process.env[id]
+    if (envVal) creds[id] = envVal
   }
 
   return creds

--- a/packages/web/lib/server/credential-flags.ts
+++ b/packages/web/lib/server/credential-flags.ts
@@ -16,6 +16,7 @@ import {
   type Plan,
 } from "@/lib/server/usage-budgets"
 import { flagsFromCredentials, CREDENTIAL_KEYS, type CredentialFlags } from "@/lib/credentials"
+import { hasSharedOpencodeKey } from "@/lib/server/opencode-pool"
 import { sharedClaudePoolEligible } from "@background-agents/common"
 
 export interface EffectiveFlags {
@@ -61,7 +62,7 @@ export async function getSharedPoolFlags(): Promise<CredentialFlags> {
   // Server env keys back the shared OpenCode / Gemini pools. Mark both the
   // presence flag (so hasCredentialsForModel treats the provider as available)
   // and the `_SHARED` origin flag (so the UI knows it isn't a user-owned key).
-  if (process.env.OPENCODE_API_KEY) {
+  if (hasSharedOpencodeKey()) {
     flags.OPENCODE_API_KEY = true
     flags.OPENCODE_API_KEY_SHARED = true
   }
@@ -103,7 +104,7 @@ export async function getEffectiveCredentialFlags(userId: string): Promise<Effec
   // Special-case: mark whether OPENCODE_API_KEY comes from the user's stored
   // credentials (user-owned) or only from the server environment (shared).
   const opencodeFromDb = !!storedCreds.OPENCODE_API_KEY
-  const opencodeFromEnv = !opencodeFromDb && !!process.env.OPENCODE_API_KEY
+  const opencodeFromEnv = !opencodeFromDb && hasSharedOpencodeKey()
   flags.OPENCODE_API_KEY_USER = opencodeFromDb
   flags.OPENCODE_API_KEY_SHARED = opencodeFromEnv
   // Preserve the conventional boolean presence flag for callers that expect it

--- a/packages/web/lib/server/opencode-pool.test.ts
+++ b/packages/web/lib/server/opencode-pool.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for the shared OpenCode key pool.
+ */
+import { describe, it, expect, afterEach, vi } from "vitest"
+import {
+  getSharedOpencodeKeys,
+  hasSharedOpencodeKey,
+  pickSharedOpencodeKey,
+} from "./opencode-pool"
+
+const PRIMARY = "OPENCODE_API_KEY"
+const SECONDARY = "OPENCODE_API_KEY_SECONDARY"
+
+afterEach(() => {
+  delete process.env[PRIMARY]
+  delete process.env[SECONDARY]
+  vi.restoreAllMocks()
+})
+
+describe("getSharedOpencodeKeys", () => {
+  it("returns [] when neither key is configured", () => {
+    expect(getSharedOpencodeKeys()).toEqual([])
+    expect(hasSharedOpencodeKey()).toBe(false)
+  })
+
+  it("returns just the primary when only it is set", () => {
+    process.env[PRIMARY] = "primary"
+    expect(getSharedOpencodeKeys()).toEqual(["primary"])
+    expect(hasSharedOpencodeKey()).toBe(true)
+  })
+
+  it("returns just the secondary when only it is set", () => {
+    process.env[SECONDARY] = "secondary"
+    expect(getSharedOpencodeKeys()).toEqual(["secondary"])
+  })
+
+  it("returns both (primary first) when both are set, trimming whitespace", () => {
+    process.env[PRIMARY] = " primary "
+    process.env[SECONDARY] = " secondary "
+    expect(getSharedOpencodeKeys()).toEqual(["primary", "secondary"])
+  })
+
+  it("drops a blank secondary", () => {
+    process.env[PRIMARY] = "primary"
+    process.env[SECONDARY] = "   "
+    expect(getSharedOpencodeKeys()).toEqual(["primary"])
+  })
+})
+
+describe("pickSharedOpencodeKey", () => {
+  it("returns undefined when nothing is configured", () => {
+    expect(pickSharedOpencodeKey()).toBeUndefined()
+  })
+
+  it("returns the single key when only one is configured", () => {
+    process.env[PRIMARY] = "primary"
+    expect(pickSharedOpencodeKey()).toBe("primary")
+  })
+
+  it("selects by Math.random across both keys", () => {
+    process.env[PRIMARY] = "primary"
+    process.env[SECONDARY] = "secondary"
+    // Math.random in [0, 0.5) → index 0 (primary), [0.5, 1) → index 1 (secondary).
+    vi.spyOn(Math, "random").mockReturnValue(0)
+    expect(pickSharedOpencodeKey()).toBe("primary")
+    vi.spyOn(Math, "random").mockReturnValue(0.75)
+    expect(pickSharedOpencodeKey()).toBe("secondary")
+  })
+
+  it("spreads roughly 50/50 across both keys over many draws", () => {
+    process.env[PRIMARY] = "primary"
+    process.env[SECONDARY] = "secondary"
+    const counts: Record<string, number> = { primary: 0, secondary: 0 }
+    for (let i = 0; i < 4000; i++) counts[pickSharedOpencodeKey()!]++
+    // Each should land well within a generous band around 50%.
+    expect(counts.primary).toBeGreaterThan(1600)
+    expect(counts.secondary).toBeGreaterThan(1600)
+  })
+})

--- a/packages/web/lib/server/opencode-pool.ts
+++ b/packages/web/lib/server/opencode-pool.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared OpenCode key pool (server-only).
+ *
+ * The shared OpenCode pool can be backed by two API keys: the primary
+ * `OPENCODE_API_KEY` and an optional `OPENCODE_API_KEY_SECONDARY`. When both are
+ * set, each shared run picks one uniformly at random (~50/50), which lets an
+ * operator run both keys concurrently instead of manually swapping a single key
+ * on a schedule. With only the primary set, behaviour is unchanged.
+ *
+ * Never imported from client code — reads raw key values from process.env.
+ */
+
+/**
+ * The configured shared-pool keys (primary + optional secondary), in that
+ * order, trimmed with blanks dropped.
+ */
+export function getSharedOpencodeKeys(): string[] {
+  return [process.env.OPENCODE_API_KEY, process.env.OPENCODE_API_KEY_SECONDARY]
+    .map((k) => k?.trim())
+    .filter((k): k is string => !!k)
+}
+
+/** Whether the server has at least one shared OpenCode key configured. */
+export function hasSharedOpencodeKey(): boolean {
+  return getSharedOpencodeKeys().length > 0
+}
+
+/**
+ * Pick one shared OpenCode key uniformly at random, or undefined when none are
+ * configured. Called per shared run so usage spreads evenly across the pool —
+ * with both keys set that's ~50/50.
+ */
+export function pickSharedOpencodeKey(): string | undefined {
+  const keys = getSharedOpencodeKeys()
+  if (keys.length === 0) return undefined
+  return keys[Math.floor(Math.random() * keys.length)]
+}


### PR DESCRIPTION
The shared OpenCode pool can now be backed by two server env keys — OPENCODE_API_KEY and OPENCODE_API_KEY_SECONDARY. When both are set, each shared run picks one uniformly at random (~50/50), so an operator can run both keys concurrently instead of manually swapping a single key every couple of weeks. With only one set, behaviour is unchanged.

- Add lib/server/opencode-pool.ts: getSharedOpencodeKeys / hasSharedOpencodeKey / pickSharedOpencodeKey.
- getUserCredentials injects the shared OpenCode key via pickSharedOpencodeKey (per-run random), user-stored keys still take precedence.
- credential-flags presence checks use hasSharedOpencodeKey so OpenCode still shows available when only the secondary is configured.

Adds unit tests for pool parsing, precedence, and ~50/50 distribution.