### PR TITLE
Use single comma-separated OPENCODE_API_KEY for shared pool

### DIFF
--- a/packages/web/lib/db/api-helpers.ts
+++ b/packages/web/lib/db/api-helpers.ts
@@ -317,8 +317,8 @@ export async function getUserCredentials(userId: string): Promise<Credentials> {
 
   // Fallback: if a credential isn't stored in the DB, check process.env.
   // This lets operators set API keys in .env / .env.local without the UI.
-  // OpenCode's shared key comes from a pool (OPENCODE_API_KEYS) — pick one at
-  // random per resolution so runs spread evenly across the configured keys.
+  // OpenCode's shared key comes from a pool (comma-separated OPENCODE_API_KEY) —
+  // pick one at random per resolution so runs spread evenly across the keys.
   for (const { id } of CREDENTIAL_KEYS) {
     if (creds[id]) continue
     const envVal =

--- a/packages/web/lib/server/opencode-pool.test.ts
+++ b/packages/web/lib/server/opencode-pool.test.ts
@@ -8,42 +8,39 @@ import {
   pickSharedOpencodeKey,
 } from "./opencode-pool"
 
-const PRIMARY = "OPENCODE_API_KEY"
-const SECONDARY = "OPENCODE_API_KEY_SECONDARY"
+const KEY = "OPENCODE_API_KEY"
 
 afterEach(() => {
-  delete process.env[PRIMARY]
-  delete process.env[SECONDARY]
+  delete process.env[KEY]
   vi.restoreAllMocks()
 })
 
 describe("getSharedOpencodeKeys", () => {
-  it("returns [] when neither key is configured", () => {
+  it("returns [] when the key is not configured", () => {
     expect(getSharedOpencodeKeys()).toEqual([])
     expect(hasSharedOpencodeKey()).toBe(false)
   })
 
-  it("returns just the primary when only it is set", () => {
-    process.env[PRIMARY] = "primary"
+  it("returns a single key when one is set", () => {
+    process.env[KEY] = "primary"
     expect(getSharedOpencodeKeys()).toEqual(["primary"])
     expect(hasSharedOpencodeKey()).toBe(true)
   })
 
-  it("returns just the secondary when only it is set", () => {
-    process.env[SECONDARY] = "secondary"
-    expect(getSharedOpencodeKeys()).toEqual(["secondary"])
+  it("splits comma-separated keys, trimming whitespace", () => {
+    process.env[KEY] = " primary , secondary , third "
+    expect(getSharedOpencodeKeys()).toEqual(["primary", "secondary", "third"])
   })
 
-  it("returns both (primary first) when both are set, trimming whitespace", () => {
-    process.env[PRIMARY] = " primary "
-    process.env[SECONDARY] = " secondary "
+  it("drops blank entries between commas", () => {
+    process.env[KEY] = "primary,,   ,secondary"
     expect(getSharedOpencodeKeys()).toEqual(["primary", "secondary"])
   })
 
-  it("drops a blank secondary", () => {
-    process.env[PRIMARY] = "primary"
-    process.env[SECONDARY] = "   "
-    expect(getSharedOpencodeKeys()).toEqual(["primary"])
+  it("returns [] for an all-blank value", () => {
+    process.env[KEY] = "  , ,  "
+    expect(getSharedOpencodeKeys()).toEqual([])
+    expect(hasSharedOpencodeKey()).toBe(false)
   })
 })
 
@@ -53,27 +50,28 @@ describe("pickSharedOpencodeKey", () => {
   })
 
   it("returns the single key when only one is configured", () => {
-    process.env[PRIMARY] = "primary"
+    process.env[KEY] = "primary"
     expect(pickSharedOpencodeKey()).toBe("primary")
   })
 
-  it("selects by Math.random across both keys", () => {
-    process.env[PRIMARY] = "primary"
-    process.env[SECONDARY] = "secondary"
-    // Math.random in [0, 0.5) → index 0 (primary), [0.5, 1) → index 1 (secondary).
+  it("selects by Math.random across all keys", () => {
+    process.env[KEY] = "a,b,c"
+    // Math.random in [0, 1/3) → index 0, [1/3, 2/3) → index 1, [2/3, 1) → index 2.
     vi.spyOn(Math, "random").mockReturnValue(0)
-    expect(pickSharedOpencodeKey()).toBe("primary")
-    vi.spyOn(Math, "random").mockReturnValue(0.75)
-    expect(pickSharedOpencodeKey()).toBe("secondary")
+    expect(pickSharedOpencodeKey()).toBe("a")
+    vi.spyOn(Math, "random").mockReturnValue(0.5)
+    expect(pickSharedOpencodeKey()).toBe("b")
+    vi.spyOn(Math, "random").mockReturnValue(0.9)
+    expect(pickSharedOpencodeKey()).toBe("c")
   })
 
-  it("spreads roughly 50/50 across both keys over many draws", () => {
-    process.env[PRIMARY] = "primary"
-    process.env[SECONDARY] = "secondary"
-    const counts: Record<string, number> = { primary: 0, secondary: 0 }
-    for (let i = 0; i < 4000; i++) counts[pickSharedOpencodeKey()!]++
-    // Each should land well within a generous band around 50%.
-    expect(counts.primary).toBeGreaterThan(1600)
-    expect(counts.secondary).toBeGreaterThan(1600)
+  it("spreads roughly evenly across all keys over many draws", () => {
+    process.env[KEY] = "a,b,c"
+    const counts: Record<string, number> = { a: 0, b: 0, c: 0 }
+    for (let i = 0; i < 6000; i++) counts[pickSharedOpencodeKey()!]++
+    // Each should land well within a generous band around 1/3 (2000).
+    expect(counts.a).toBeGreaterThan(1600)
+    expect(counts.b).toBeGreaterThan(1600)
+    expect(counts.c).toBeGreaterThan(1600)
   })
 })

--- a/packages/web/lib/server/opencode-pool.ts
+++ b/packages/web/lib/server/opencode-pool.ts
@@ -1,23 +1,24 @@
 /**
  * Shared OpenCode key pool (server-only).
  *
- * The shared OpenCode pool can be backed by two API keys: the primary
- * `OPENCODE_API_KEY` and an optional `OPENCODE_API_KEY_SECONDARY`. When both are
- * set, each shared run picks one uniformly at random (~50/50), which lets an
- * operator run both keys concurrently instead of manually swapping a single key
- * on a schedule. With only the primary set, behaviour is unchanged.
+ * The shared OpenCode pool is backed by `OPENCODE_API_KEY`, which may hold a
+ * single key or several comma-separated keys. When multiple are set, each shared
+ * run picks one uniformly at random (equal chance across all N), which lets an
+ * operator run several keys concurrently instead of manually swapping a single
+ * key on a schedule. With one key, behaviour is unchanged.
  *
  * Never imported from client code — reads raw key values from process.env.
  */
 
 /**
- * The configured shared-pool keys (primary + optional secondary), in that
- * order, trimmed with blanks dropped.
+ * The configured shared-pool keys, parsed from the comma-separated
+ * `OPENCODE_API_KEY`, trimmed with blanks dropped.
  */
 export function getSharedOpencodeKeys(): string[] {
-  return [process.env.OPENCODE_API_KEY, process.env.OPENCODE_API_KEY_SECONDARY]
-    .map((k) => k?.trim())
-    .filter((k): k is string => !!k)
+  return (process.env.OPENCODE_API_KEY ?? "")
+    .split(",")
+    .map((k) => k.trim())
+    .filter((k) => !!k)
 }
 
 /** Whether the server has at least one shared OpenCode key configured. */
@@ -28,7 +29,7 @@ export function hasSharedOpencodeKey(): boolean {
 /**
  * Pick one shared OpenCode key uniformly at random, or undefined when none are
  * configured. Called per shared run so usage spreads evenly across the pool —
- * with both keys set that's ~50/50.
+ * every key has an equal chance.
  */
 export function pickSharedOpencodeKey(): string | undefined {
   const keys = getSharedOpencodeKeys()


### PR DESCRIPTION
 ## Summary

  Replace the two-variable OpenCode shared-key setup (`OPENCODE_API_KEY` +
  `OPENCODE_API_KEY_SECONDARY`) with a single comma-separated `OPENCODE_API_KEY`.  Operators now set `OPENCODE_API_KEY=key1,key2,key3` and each shared run picks one
  key at random with equal probability across all N.
  ## Changes

  - **`opencode-pool.ts`** — `getSharedOpencodeKeys()` splits `OPENCODE_API_KEY` on
    commas, trims, and drops blanks. Random pick logic unchanged, so every key gets
    an equal chance. Removed `OPENCODE_API_KEY_SECONDARY`.
  - **`opencode-pool.test.ts`** — updated for the comma-separated form (splitting,
    trimming, blank-dropping, uniform N-way spread).
  - **`api-helpers.ts`** — fixed stale `OPENCODE_API_KEYS` comment.

  ## Notes

  - A single key works exactly as before — no config change needed for existing setups.
  - All 9 unit tests pass.