### PR TITLE
Log LLM provider errors to activity log and server logs

### DIFF
--- a/packages/web/app/api/agent/stream/route.ts
+++ b/packages/web/app/api/agent/stream/route.ts
@@ -9,6 +9,7 @@ import {
   type AgentSnapshot,
 } from "@/lib/agent-session"
 import { prisma } from "@/lib/db/prisma"
+import { logLlmProviderError } from "@/lib/db/activity-log"
 import { isAuthError, requireChatStreamAccess } from "@/lib/db/api-helpers"
 import { meterAssistantTurn } from "@/lib/server/token-metering"
 import { autoPushChat, type PushInfo } from "@/lib/git/auto-push"
@@ -183,6 +184,28 @@ export async function GET(req: Request) {
             // exited (the common completed/crashed case).
             if (lastSnap.status === "error") {
               await cancelBackgroundAgent(sandbox, backgroundSessionId, sessionOpts)
+
+              // Record the provider failure so it's visible in aggregate — we
+              // otherwise have no view over which models/providers are failing.
+              try {
+                const chatRow = chatId
+                  ? await prisma.chat.findUnique({
+                      where: { id: chatId },
+                      select: { agent: true, model: true },
+                    })
+                  : null
+                logLlmProviderError({
+                  userId: auth.userId,
+                  agent: chatRow?.agent,
+                  model: chatRow?.model,
+                  chatId: chatId ?? undefined,
+                  source: "stream",
+                  error: lastSnap.error ?? "Unknown error",
+                  errorKind: lastSnap.errorKind,
+                })
+              } catch (err) {
+                console.error("[agent/stream] logLlmProviderError failed:", err)
+              }
             }
 
             await finalizeTurn(sandbox, backgroundSessionId, sessionOpts)

--- a/packages/web/app/api/cron/agent-lifecycle/_lib/monitor.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/_lib/monitor.ts
@@ -22,7 +22,7 @@ export async function monitorAgent(
   daytona: Daytona,
   handlers: {
     onComplete: (snapshot: AgentSnapshot) => Promise<void>
-    onError: (error: string) => Promise<void>
+    onError: (error: string, errorKind?: AgentSnapshot["errorKind"]) => Promise<void>
   }
 ) {
   try {
@@ -43,7 +43,7 @@ export async function monitorAgent(
       await cancelBackgroundAgent(sandbox, backgroundSessionId, {
         repoPath: `${PATHS.SANDBOX_HOME}/project`,
       })
-      await handlers.onError(snapshot.error ?? "Unknown error")
+      await handlers.onError(snapshot.error ?? "Unknown error", snapshot.errorKind)
     }
     // else still running, check again next cycle
   } catch (err) {

--- a/packages/web/app/api/cron/agent-lifecycle/route.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/route.ts
@@ -2,6 +2,7 @@ import { Daytona } from "@daytonaio/sdk"
 import { addMinutes, differenceInMinutes } from "date-fns"
 
 import { prisma } from "@/lib/db/prisma"
+import { logLlmProviderError } from "@/lib/db/activity-log"
 
 import { INTERACTIVE_HARD_TIMEOUT, SCHEDULED_HARD_TIMEOUT } from "./_lib/constants"
 import { monitorAgent, stopAgent } from "./_lib/monitor"
@@ -148,7 +149,16 @@ export async function GET(req: Request) {
             await finalizeInteractiveChat(chat, snapshot, daytona)
             results.completedInteractive++
           },
-          onError: async (error) => {
+          onError: async (error, errorKind) => {
+            logLlmProviderError({
+              userId: chat.userId,
+              agent: chat.agent,
+              model: chat.model,
+              chatId: chat.id,
+              source: "cron-interactive",
+              error,
+              errorKind,
+            })
             await markChatError(chat.id, error)
           },
         })
@@ -187,7 +197,16 @@ export async function GET(req: Request) {
               await finalizeScheduledRun(run, snapshot, daytona)
               results.completedScheduled++
             },
-            onError: async (error) => {
+            onError: async (error, errorKind) => {
+              logLlmProviderError({
+                userId: run.job.userId,
+                agent: run.job.agent,
+                model: run.job.model,
+                jobRunId: run.id,
+                source: "cron-scheduled",
+                error,
+                errorKind,
+              })
               await failScheduledRun(run, error, daytona)
             },
           })

--- a/packages/web/components/admin/ActivityFeed.tsx
+++ b/packages/web/components/admin/ActivityFeed.tsx
@@ -16,6 +16,7 @@ import {
   Bot,
   Cpu,
   Calendar,
+  AlertTriangle,
 } from "lucide-react"
 
 interface Activity {
@@ -65,6 +66,7 @@ const ACTION_CONFIG: Record<
   settings_updated: { icon: Settings, label: "updated settings", color: "text-orange-600" },
   admin_promoted: { icon: ShieldCheck, label: "promoted user to admin", color: "text-green-600" },
   admin_demoted: { icon: ShieldOff, label: "removed admin status", color: "text-red-600" },
+  llm_provider_error: { icon: AlertTriangle, label: "hit an LLM provider error", color: "text-red-600" },
 }
 
 const ACTION_LABELS: Record<string, string> = {
@@ -79,6 +81,7 @@ const ACTION_LABELS: Record<string, string> = {
   sandbox_created: "Sandbox Created",
   sandbox_deleted: "Sandbox Deleted",
   daily_limit_reached: "Daily Limit Reached",
+  llm_provider_error: "LLM Provider Error",
 }
 
 function ActivityItem({ activity }: { activity: Activity }) {
@@ -93,6 +96,9 @@ function ActivityItem({ activity }: { activity: Activity }) {
   const agent = metadata?.agent
   const model = metadata?.model
   const details = metadata?.repo || metadata?.targetUserName || metadata?.chatId
+  // llm_provider_error carries the failure category + the raw error text.
+  const errorCategory = metadata?.category
+  const errorMessage = metadata?.message
 
   return (
     <div className="flex items-start gap-3 py-3">
@@ -111,8 +117,8 @@ function ActivityItem({ activity }: { activity: Activity }) {
             <span className="text-muted-foreground"> - {details}</span>
           )}
         </p>
-        {(agent || model) && (
-          <div className="mt-1 flex gap-2">
+        {(agent || model || errorCategory) && (
+          <div className="mt-1 flex flex-wrap gap-2">
             {agent && (
               <span className="inline-flex items-center gap-1 rounded bg-accent px-2 py-0.5 text-xs font-medium text-accent-foreground">
                 <Bot className="h-3 w-3" />
@@ -125,7 +131,18 @@ function ActivityItem({ activity }: { activity: Activity }) {
                 {model}
               </span>
             )}
+            {errorCategory && (
+              <span className="inline-flex items-center gap-1 rounded bg-red-500/10 px-2 py-0.5 text-xs font-medium text-red-600">
+                <AlertTriangle className="h-3 w-3" />
+                {errorCategory}
+              </span>
+            )}
           </div>
+        )}
+        {errorMessage && (
+          <p className="mt-1 break-words text-xs text-muted-foreground">
+            {errorMessage}
+          </p>
         )}
         <p className="mt-1 text-xs text-muted-foreground">
           {formatDistanceToNow(new Date(activity.createdAt), { addSuffix: true })}

--- a/packages/web/lib/db/activity-log.test.ts
+++ b/packages/web/lib/db/activity-log.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// Mock the prisma singleton so logLlmProviderError can be exercised without a
+// DB. `vi.hoisted` lets the factory (hoisted above imports) see the mock.
+const { activityLog } = vi.hoisted(() => ({
+  activityLog: { create: vi.fn() },
+}))
+vi.mock("@/lib/db/prisma", () => ({ prisma: { activityLog } }))
+
+import { logLlmProviderError } from "./activity-log"
+
+// logActivityAsync is fire-and-forget; flush the microtask queue so the
+// create() call has run before we assert.
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+beforeEach(() => {
+  activityLog.create.mockReset()
+  activityLog.create.mockResolvedValue({})
+})
+
+describe("logLlmProviderError", () => {
+  it("records a provider error and classifies its category", async () => {
+    logLlmProviderError({
+      userId: "u1",
+      agent: "opencode",
+      model: "gpt-5",
+      chatId: "c1",
+      source: "stream",
+      error: "AI_APICallError: insufficient balance (402)",
+    })
+    await flush()
+
+    expect(activityLog.create).toHaveBeenCalledTimes(1)
+    const { data } = activityLog.create.mock.calls[0][0]
+    expect(data.userId).toBe("u1")
+    expect(data.action).toBe("llm_provider_error")
+    expect(data.metadata).toMatchObject({
+      category: "balance",
+      agent: "opencode",
+      model: "gpt-5",
+      chatId: "c1",
+      source: "stream",
+    })
+    expect(data.metadata.message).toContain("insufficient balance")
+  })
+
+  it("skips a bare process crash that carries no provider detail", async () => {
+    logLlmProviderError({
+      userId: "u1",
+      agent: "claude-code",
+      source: "cron-interactive",
+      error: "Process exited without completing",
+      errorKind: "crash",
+    })
+    await flush()
+
+    expect(activityLog.create).not.toHaveBeenCalled()
+  })
+
+  it("still records a crash when its captured detail is a real provider failure", async () => {
+    logLlmProviderError({
+      userId: "u1",
+      agent: "claude-code",
+      source: "cron-interactive",
+      error: "Process exited without completing\n\nInvalid API key: 401 Unauthorized",
+      errorKind: "crash",
+    })
+    await flush()
+
+    expect(activityLog.create).toHaveBeenCalledTimes(1)
+    const { data } = activityLog.create.mock.calls[0][0]
+    expect(data.metadata.category).toBe("auth")
+  })
+})

--- a/packages/web/lib/db/activity-log.ts
+++ b/packages/web/lib/db/activity-log.ts
@@ -1,4 +1,5 @@
 import { Prisma } from "@prisma/client"
+import { classifyAgentError } from "@background-agents/sdk"
 import { prisma } from "./prisma"
 
 /**
@@ -16,6 +17,9 @@ export type ActivityAction =
   | "admin_promoted"
   | "admin_demoted"
   | "daily_limit_reached"
+  // An LLM provider/model call failed for a turn (auth, balance, rate limit,
+  // model unavailable, network, or an otherwise-unclassified model error).
+  | "llm_provider_error"
 
 /**
  * Metadata types for different actions
@@ -28,6 +32,15 @@ export type ActivityMetadata = {
   targetUserId?: string
   ip?: string
   userAgent?: string
+  // llm_provider_error fields:
+  /** Coarse failure category from the SDK classifier. */
+  category?: string
+  /** Where the failure was observed (live stream vs. one of the crons). */
+  source?: string
+  /** The (truncated) user-facing error string. */
+  message?: string
+  /** Scheduled-job run id, when the failure came from a scheduled run. */
+  jobRunId?: string
   [key: string]: unknown
 }
 
@@ -73,4 +86,67 @@ export function logActivityAsync(
   logActivity(userId, action, metadata).catch(() => {
     // Errors already logged in logActivity
   })
+}
+
+/** Cap the error string we persist/print — provider errors can be large JSON. */
+const LLM_ERROR_MSG_MAX = 500
+
+export interface LlmProviderErrorContext {
+  userId: string
+  agent?: string
+  model?: string | null
+  chatId?: string
+  jobRunId?: string
+  /** Where the failure was observed. */
+  source: "stream" | "cron-interactive" | "cron-scheduled"
+  /** The user-facing error string from the agent snapshot. */
+  error: string
+  /**
+   * The snapshot's errorKind, if any. "crash"/"incomplete" are process- or
+   * stream-level failures rather than the provider failing.
+   */
+  errorKind?: "crash" | "incomplete"
+}
+
+/**
+ * Record an LLM provider/model failure for observability.
+ *
+ * Motivation: we previously had NO visibility into provider failures. When a
+ * model started failing (auth, insufficient balance, rate limit, unavailable
+ * model, network) the turn surfaced an error to the one user and vanished —
+ * nothing aggregate to look at. This records each such failure in two places:
+ *
+ *   1. A structured `console.error("[llm-provider-error]", …)` line — immediate,
+ *      greppable visibility in the server/Vercel logs.
+ *   2. An ActivityLog row (action "llm_provider_error") — durable and queryable
+ *      in the admin activity view, filterable by action.
+ *
+ * Bare process crashes / incomplete streams are skipped unless the captured
+ * detail actually classifies as a provider category (e.g. a crash whose
+ * captured stderr is an auth failure), since those are infra failures rather
+ * than the provider itself failing.
+ */
+export function logLlmProviderError(ctx: LlmProviderErrorContext): void {
+  const { category } = classifyAgentError(ctx.error)
+
+  // Filter out non-provider process/stream failures.
+  if (ctx.errorKind && category === "unknown") return
+
+  const message =
+    ctx.error.length > LLM_ERROR_MSG_MAX
+      ? `${ctx.error.slice(0, LLM_ERROR_MSG_MAX)}…`
+      : ctx.error
+
+  const metadata: ActivityMetadata = {
+    category,
+    agent: ctx.agent,
+    model: ctx.model ?? undefined,
+    source: ctx.source,
+    chatId: ctx.chatId,
+    jobRunId: ctx.jobRunId,
+    message,
+  }
+
+  console.error("[llm-provider-error]", JSON.stringify({ userId: ctx.userId, ...metadata }))
+  logActivityAsync(ctx.userId, "llm_provider_error", metadata)
 }


### PR DESCRIPTION
 ## Log LLM provider errors

  Adds visibility into LLM provider/model failures. Previously, when a model started failing (bad API key, no balance, rate limit, unavailable  model, network), the error surfaced to the one user and vanished — no aggregate record.
  ### What it does
  Records every provider failure at the point a turn resolves to an error, in two places:
  - **Server logs** — a structured, greppable `[llm-provider-error]` line for immediate visibility.
  - **`ActivityLog`** — a durable, queryable `llm_provider_error` row (category, agent, model, source, chatId, message).

  Wired into all three server-side paths: live stream, interactive cron, and scheduled-job cron. The SDK's existing `classifyAgentError` tags
  each with a category (auth / balance / rate_limit / model_unavailable / network / unknown). Bare process crashes / incomplete streams are
  skipped unless their captured detail is a real provider failure.

  The admin **Activity** feed renders these entries with a red ⚠ icon, agent/model/category chips, the error text, and a dedicated Action
  filter.

  ### Testing
  - `activity-log.test.ts` — classifies a provider error, skips a bare crash, still records a crash whose detail is an auth failure.
  - Typecheck clean on all touched files.