### PR TITLE
Preserve MCP servers in Codex config.toml across setup

### DIFF
--- a/packages/agent-configuration/src/mcp/index.ts
+++ b/packages/agent-configuration/src/mcp/index.ts
@@ -79,6 +79,13 @@ function generateClaudeConfig(servers: AgentMcpServer[]): McpConfigFile {
 /**
  * Codex: ~/.codex/config.toml — `[mcp_servers.<name>]` (underscore, not dot).
  * Presence of `url` selects Streamable-HTTP; no `type` field exists.
+ *
+ * This file is shared with Codex's provider/routing config: setupMcpForAgent
+ * runs first and writes only these `[mcp_servers.*]` sections, then the SDK's
+ * codexSetup runs and rewrites the provider config while carrying these sections
+ * over (see extractTomlSections in @background-agents/sdk). That ordering is what
+ * lets this whole-file write coexist with the provider config — don't reorder
+ * the two setups without preserving sections on both sides.
  */
 function generateCodexConfig(servers: AgentMcpServer[]): McpConfigFile {
   const lines: string[] = []

--- a/packages/sdk/src/agents/codex/index.ts
+++ b/packages/sdk/src/agents/codex/index.ts
@@ -14,15 +14,49 @@ import { escapeShell, quote } from "../../utils/shell"
 import { parseCodexLine } from "./parser"
 import { CODEX_TOOL_MAPPINGS } from "./tools"
 import { buildCodexConfigToml } from "./config"
+import { extractTomlSections, combineCodexConfig } from "./toml-merge"
 
 /**
- * Codex agent-specific setup. Two mutually exclusive paths:
+ * Write ~/.codex/config.toml with the given provider config, carrying over any
+ * `[mcp_servers.*]` sections already present in the file. setupMcpForAgent
+ * writes those sections *before* this setup runs and shares this same file, so a
+ * naive overwrite (or `rm -f`) would silently drop every connected MCP server.
+ * When both the provider config and the preserved sections are empty the file is
+ * removed instead of writing an empty one.
+ */
+async function writeCodexConfig(
+  sandbox: CodeAgentSandbox,
+  providerToml: string
+): Promise<void> {
+  if (!sandbox.executeCommand) return
+
+  const read = await sandbox.executeCommand(
+    `cat ~/.codex/config.toml 2>/dev/null || true`,
+    10
+  )
+  const preservedMcp = extractTomlSections(read?.output ?? "", ["mcp_servers"])
+  const content = combineCodexConfig(providerToml, preservedMcp)
+
+  if (!content) {
+    await sandbox.executeCommand(`rm -f ~/.codex/config.toml`, 10)
+    return
+  }
+  // printf '%s' avoids backslash interpretation; quote() handles embedded quotes.
+  await sandbox.executeCommand(
+    `mkdir -p ~/.codex && printf '%s' ${quote(content)} > ~/.codex/config.toml`,
+    30
+  )
+}
+
+/**
+ * Codex agent-specific setup. Two mutually exclusive paths, both of which
+ * preserve any MCP servers already written to config.toml (see writeCodexConfig):
  *
  * 1. Custom endpoint — when CUSTOM_CODEX_BASE_URL is set (the user configured a
  *    custom OpenAI-compatible endpoint), write ~/.codex/config.toml routing all
  *    requests through that provider. Auth lives in the headers blob, so there is
  *    no `codex login` step.
- * 2. Standard OpenAI — remove any custom config.toml left over from a previous
+ * 2. Standard OpenAI — drop any custom provider config left over from a previous
  *    custom run in this sandbox (so a custom→standard switch stops routing to the
  *    old endpoint), then log in with the stored OPENAI_API_KEY.
  */
@@ -39,18 +73,15 @@ async function codexSetup(
       headers: env.CUSTOM_CODEX_HEADERS || undefined,
       authHeaderEnv: env.CUSTOM_CODEX_AUTHORIZATION ? "CUSTOM_CODEX_AUTHORIZATION" : undefined,
     })
-    // printf '%s' avoids backslash interpretation; quote() handles embedded quotes.
-    await sandbox.executeCommand(
-      `mkdir -p ~/.codex && printf '%s' ${quote(toml)} > ~/.codex/config.toml`,
-      30
-    )
+    await writeCodexConfig(sandbox, toml)
     return
   }
 
-  // Standard path: drop any custom config.toml from an earlier custom run in this
-  // sandbox so it can't override the default provider. In this app config.toml is
-  // only ever written by the custom path above, so removing it is safe.
-  await sandbox.executeCommand(`rm -f ~/.codex/config.toml`, 10)
+  // Standard path: drop any custom provider config from an earlier custom run in
+  // this sandbox so it can't override the default provider, while keeping the
+  // MCP sections. Passing an empty provider config strips model_provider/
+  // model_providers but carries [mcp_servers.*] over.
+  await writeCodexConfig(sandbox, "")
 
   if (!env.OPENAI_API_KEY) return
 

--- a/packages/sdk/src/agents/codex/toml-merge.ts
+++ b/packages/sdk/src/agents/codex/toml-merge.ts
@@ -1,0 +1,68 @@
+/**
+ * TOML section helpers for ~/.codex/config.toml.
+ *
+ * The Codex config file has two independent owners that each do whole-file
+ * writes: the MCP layer (@background-agents/agent-configuration) writes the
+ * `[mcp_servers.*]` sections, while codexSetup writes the provider/routing
+ * config (the top-level `model_provider`/`model` keys and `[model_providers.*]`
+ * sections). setupMcpForAgent runs first, then codexSetup runs last — so
+ * codexSetup must carry the MCP sections across its own rewrite instead of
+ * clobbering them. These helpers do that section-preserving carry-over.
+ */
+
+/**
+ * Extract top-level TOML sections whose dotted header starts with one of the
+ * given prefixes. A "section" is a `[header]` line plus every following line up
+ * to (but not including) the next top-level `[header]`. Blocks are returned in
+ * their original order with inner formatting preserved and trailing whitespace
+ * trimmed; the preamble (top-level key/value lines before the first section) is
+ * never included.
+ *
+ * A prefix matches a header that equals it exactly or that begins with
+ * `prefix + "."` — so `["mcp_servers"]` keeps `[mcp_servers.github]` and its
+ * sub-tables but not `[model_providers.custom]`.
+ *
+ * Assumes the simple config this app generates (string / inline-table values,
+ * no multi-line TOML arrays whose continuation lines could look like a
+ * `[header]`). Both writers emit that shape, so the assumption holds.
+ */
+export function extractTomlSections(content: string, prefixes: string[]): string {
+  const isOwned = (header: string) =>
+    prefixes.some((p) => header === p || header.startsWith(`${p}.`))
+
+  const blocks: string[] = []
+  let current: string[] | null = null
+
+  const flush = () => {
+    if (current) blocks.push(current.join("\n").replace(/\s+$/, ""))
+    current = null
+  }
+
+  for (const line of content.split("\n")) {
+    const match = line.match(/^\s*\[\s*([^[\]]+?)\s*\]\s*$/)
+    if (match) {
+      // New top-level section header — close out the previous block and start a
+      // new one only if this header is owned by a requested prefix.
+      flush()
+      current = isOwned(match[1].trim()) ? [line] : null
+    } else if (current) {
+      current.push(line)
+    }
+    // Lines outside any owned section (incl. the preamble) are dropped.
+  }
+  flush()
+
+  return blocks.join("\n\n")
+}
+
+/**
+ * Combine a provider-config TOML string with preserved foreign sections (e.g.
+ * `[mcp_servers.*]`) into the final config.toml contents. Empty parts are
+ * dropped; the provider config comes first so its top-level preamble keys stay
+ * above every section header (required by TOML). Returns "" when both parts are
+ * empty, signalling the file should be removed rather than written.
+ */
+export function combineCodexConfig(providerToml: string, preserved: string): string {
+  const parts = [providerToml.trim(), preserved.trim()].filter(Boolean)
+  return parts.length > 0 ? `${parts.join("\n\n")}\n` : ""
+}

--- a/packages/sdk/tests/unit/codex-toml-merge.test.ts
+++ b/packages/sdk/tests/unit/codex-toml-merge.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Unit tests for the Codex config.toml section-preserving merge.
+ *
+ * The MCP layer and codexSetup both write ~/.codex/config.toml; these helpers
+ * let codexSetup rewrite the provider config without dropping the MCP servers
+ * written before it. See toml-merge.ts.
+ */
+import { describe, it, expect } from "vitest"
+import {
+  extractTomlSections,
+  combineCodexConfig,
+} from "../../src/agents/codex/toml-merge"
+import { buildCodexConfigToml } from "../../src/agents/codex/config"
+
+const MCP_SECTION = [
+  `[mcp_servers.github]`,
+  `url = "https://api.example.com/mcp"`,
+  `http_headers = { Authorization = "Bearer tok-1" }`,
+  `enabled = true`,
+  `startup_timeout_sec = 30`,
+].join("\n")
+
+describe("extractTomlSections", () => {
+  it("keeps only sections matching a prefix and drops the preamble", () => {
+    const content = [
+      `model_provider = "custom"`,
+      `model = "gpt-5.5"`,
+      ``,
+      `[model_providers.custom]`,
+      `base_url = "https://gw.example.com/v1"`,
+      ``,
+      MCP_SECTION,
+    ].join("\n")
+
+    const kept = extractTomlSections(content, ["mcp_servers"])
+    expect(kept).toContain(`[mcp_servers.github]`)
+    expect(kept).toContain(`http_headers = { Authorization = "Bearer tok-1" }`)
+    // Preamble and foreign sections are gone.
+    expect(kept).not.toContain("model_provider")
+    expect(kept).not.toContain("[model_providers.custom]")
+    expect(kept).not.toContain("base_url")
+  })
+
+  it("keeps sub-tables of a matched section but not sibling sections", () => {
+    const content = [
+      `[mcp_servers.github]`,
+      `url = "https://a/mcp"`,
+      ``,
+      `[mcp_servers.github.extra]`,
+      `foo = "bar"`,
+      ``,
+      `[model_providers.custom]`,
+      `base_url = "https://b/v1"`,
+    ].join("\n")
+
+    const kept = extractTomlSections(content, ["mcp_servers"])
+    expect(kept).toContain(`[mcp_servers.github]`)
+    expect(kept).toContain(`[mcp_servers.github.extra]`)
+    expect(kept).toContain(`foo = "bar"`)
+    expect(kept).not.toContain(`[model_providers.custom]`)
+  })
+
+  it("preserves the order of multiple matched sections", () => {
+    const content = [
+      `[mcp_servers.alpha]`,
+      `url = "https://alpha/mcp"`,
+      ``,
+      `[mcp_servers.beta]`,
+      `url = "https://beta/mcp"`,
+    ].join("\n")
+
+    const kept = extractTomlSections(content, ["mcp_servers"])
+    expect(kept.indexOf("alpha")).toBeLessThan(kept.indexOf("beta"))
+  })
+
+  it("returns empty string when nothing matches or content is empty", () => {
+    expect(extractTomlSections("", ["mcp_servers"])).toBe("")
+    expect(
+      extractTomlSections(`[model_providers.custom]\nbase_url = "x"`, [
+        "mcp_servers",
+      ])
+    ).toBe("")
+  })
+})
+
+describe("combineCodexConfig", () => {
+  it("puts the provider config (with preamble) before preserved sections", () => {
+    const provider = buildCodexConfigToml({
+      baseUrl: "https://gw.example.com/v1",
+      model: "gpt-5.5",
+      headers: "Authorization: Bearer tok",
+      authHeaderEnv: "CUSTOM_CODEX_AUTHORIZATION",
+    })
+    const merged = combineCodexConfig(provider, MCP_SECTION)
+
+    // Top-level preamble keys must sit above every section header.
+    expect(merged.indexOf("model_provider")).toBeLessThan(
+      merged.indexOf("[model_providers.custom]")
+    )
+    expect(merged.indexOf("[model_providers.custom]")).toBeLessThan(
+      merged.indexOf("[mcp_servers.github]")
+    )
+    expect(merged.endsWith("\n")).toBe(true)
+  })
+
+  it("returns just the preserved sections when there is no provider config", () => {
+    const merged = combineCodexConfig("", MCP_SECTION)
+    expect(merged).toContain("[mcp_servers.github]")
+    expect(merged).not.toContain("model_provider")
+    expect(merged.trim().startsWith("[mcp_servers.github]")).toBe(true)
+  })
+
+  it("returns empty string (→ remove the file) when both parts are empty", () => {
+    expect(combineCodexConfig("", "")).toBe("")
+    expect(combineCodexConfig("   ", "\n\n")).toBe("")
+  })
+
+  it("round-trips: extract from a merged file yields the original MCP section", () => {
+    const provider = buildCodexConfigToml({
+      baseUrl: "https://gw.example.com/v1",
+    })
+    const merged = combineCodexConfig(provider, MCP_SECTION)
+    const kept = extractTomlSections(merged, ["mcp_servers"])
+    expect(kept).toBe(MCP_SECTION)
+  })
+})


### PR DESCRIPTION
~/.codex/config.toml has two owners that both do whole-file writes: setupMcpForAgent writes the [mcp_servers.*] sections, then codexSetup runs last and rewrote the provider config. The standard path rm -f'd the file and the custom-endpoint path overwrote it, so every connected MCP server was silently dropped on each run.

codexSetup now reads the existing config, extracts the [mcp_servers.*] sections, and carries them across its rewrite via new pure helpers (extractTomlSections / combineCodexConfig). Both paths route through writeCodexConfig, which removes the file only when nothing remains.