### PR TITLE
fix(sandbox-git): parse dotted and unborn branch names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20399,7 +20399,8 @@
       "devDependencies": {
         "@types/node": "^20.10.0",
         "tsup": "^8.0.0",
-        "typescript": "^5.3.0"
+        "typescript": "^5.3.0",
+        "vitest": "^1.0.0"
       },
       "peerDependencies": {
         "@daytonaio/sdk": ">=0.8.0"

--- a/packages/sandbox-git/package.json
+++ b/packages/sandbox-git/package.json
@@ -26,6 +26,8 @@
     "build": "tsup src/index.ts --format esm,cjs --dts --clean --sourcemap",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "prepare": "npm run build"
   },
   "peerDependencies": {
@@ -39,7 +41,8 @@
   "devDependencies": {
     "@types/node": "^20.10.0",
     "tsup": "^8.0.0",
-    "typescript": "^5.3.0"
+    "typescript": "^5.3.0",
+    "vitest": "^1.0.0"
   },
   "keywords": [
     "daytona",

--- a/packages/sandbox-git/src/parsers.ts
+++ b/packages/sandbox-git/src/parsers.ts
@@ -20,9 +20,11 @@ export function parseGitStatus(
 ): GitStatus {
   const lines = porcelainOutput.trim().split("\n").filter(Boolean)
 
-  // Parse branch line: ## branch...origin/branch or ## branch
+  // Parse branch line: ## branch[...origin/branch] or ## No commits yet on branch
   const branchLine = lines[0] || "## main"
-  const branchMatch = branchLine.match(/^## ([^.\s]+)/)
+  const branchMatch = branchLine.match(
+    /^## (?:No commits yet on )?(\S+?)(?=\.\.\.|\s|$)/
+  )
   const currentBranch = branchMatch?.[1] || "main"
 
   // Check if branch is published (has tracking info)

--- a/packages/sandbox-git/tests/parsers.test.ts
+++ b/packages/sandbox-git/tests/parsers.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Pure unit tests for Git status parsing. These use porcelain output directly,
+ * so they do not require a sandbox or Daytona credentials.
+ */
+import { describe, expect, it } from "vitest"
+import { parseGitStatus } from "../src/parsers.js"
+
+describe("parseGitStatus", () => {
+  it("parses a local branch", () => {
+    const status = parseGitStatus("## feature/login", "")
+
+    expect(status.currentBranch).toBe("feature/login")
+    expect(status.isPublished).toBe(false)
+  })
+
+  it("preserves periods in a local branch name", () => {
+    const status = parseGitStatus("## release/v1.2.3", "")
+
+    expect(status.currentBranch).toBe("release/v1.2.3")
+    expect(status.isPublished).toBe(false)
+  })
+
+  it("separates a dotted branch name from its upstream", () => {
+    const status = parseGitStatus(
+      "## release/v1.2.3...origin/release/v1.2.3 [ahead 1, behind 2]",
+      "2\t1"
+    )
+
+    expect(status.currentBranch).toBe("release/v1.2.3")
+    expect(status.isPublished).toBe(true)
+    expect(status.ahead).toBe(1)
+    expect(status.behind).toBe(2)
+  })
+
+  it("parses an unborn dotted branch", () => {
+    const status = parseGitStatus("## No commits yet on release/v1.2.3", "")
+
+    expect(status.currentBranch).toBe("release/v1.2.3")
+    expect(status.isPublished).toBe(false)
+  })
+
+  it("keeps the existing detached HEAD representation", () => {
+    const status = parseGitStatus("## HEAD (no branch)", "")
+
+    expect(status.currentBranch).toBe("HEAD")
+    expect(status.isPublished).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- preserve periods in valid branch names parsed from `git status --porcelain -b`
- recognize Git's `No commits yet on <branch>` header for unborn repositories
- add pure parser regression coverage and a standard Vitest command for `sandbox-git`

## User impact
`git.status()` currently truncates dotted branches at the first period. For example, `release/v1.2.3` is reported as `release/v1`.

The web merge route compares this parsed value with the target branch to decide whether a merge targets the active checkout. When that condition applies, a truncated value can produce a misleading "switch to branch" conflict message or skip the post-merge pull into the active sandbox. Consumers of the published `sandbox-git` package also receive an incorrect `currentBranch` value directly.

Unborn repositories are affected by the same header parsing path: `No commits yet on release/v1.2.3` was previously reported as branch `No`.

## Verification
- [x] `npm test -w @background-agents/sandbox-git` (5 tests)
- [x] `npm run typecheck -w @background-agents/sandbox-git`
- [x] `npm run build -w @background-agents/sandbox-git`
- [x] reproduced against real Git status output for local, tracking, detached, and unborn repositories
- [x] `git diff --check`

## Risks / Notes
- No Daytona credentials or sandbox are required; the tests use Git porcelain fixtures.
- The app-generated `agent/*` branches do not normally contain periods, so the web impact is conditional; dotted release/version branches and package consumers remain valid affected cases.
- A full workspace typecheck reaches `@background-agents/web` but is currently blocked by the existing `Sidebar.tsx` / `sidebar.tsx` filename-casing collision, unrelated to this change.
- No issue is linked because issue creation is restricted in this repository; searches found no existing issue or open PR for this parser bug.
