### PR TITLE
fix(web): stop repository picker loading loop

### DIFF
--- a/packages/web/components/chat/RepoCombobox.tsx
+++ b/packages/web/components/chat/RepoCombobox.tsx
@@ -1,9 +1,25 @@
 "use client"
 
-import { useState, useEffect, useMemo } from "react"
-import { Github, Lock, Globe, ChevronDown, Loader2, Plus } from "lucide-react"
+import {
+  useState,
+  useEffect,
+  useMemo,
+  useCallback,
+  useRef,
+} from "react"
+import { useSession } from "next-auth/react"
+import {
+  Github,
+  Lock,
+  Globe,
+  ChevronDown,
+  Loader2,
+  Plus,
+  RefreshCw,
+} from "lucide-react"
 import { cn } from "@/lib/utils"
 import { fetchAllRepos } from "@/lib/github"
+import { signInWithGitHub } from "@/lib/auth-utils"
 import type { GitHubRepo } from "@/lib/types"
 import {
   Popover,
@@ -46,22 +62,26 @@ export function RepoCombobox({
   showLabel = false,
   createOnly = false,
 }: RepoComboboxProps) {
+  const { status } = useSession()
   const [open, setOpen] = useState(false)
   const [repos, setRepos] = useState<GitHubRepo[]>([])
   const [loading, setLoading] = useState(false)
   const [loadingMore, setLoadingMore] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [search, setSearch] = useState("")
+  const loadingRef = useRef(false)
 
-  // Fetch repos when popover opens - with progressive loading
-  useEffect(() => {
-    if (open && repos.length === 0 && !loading) {
-      setLoading(true)
-      setLoadingMore(false)
-      setError(null)
+  const loadRepos = useCallback(async () => {
+    if (status !== "authenticated" || loadingRef.current) return
 
-      let isFirstPage = true
-      fetchAllRepos((repos, isComplete) => {
+    loadingRef.current = true
+    setLoading(true)
+    setLoadingMore(false)
+    setError(null)
+
+    let isFirstPage = true
+    try {
+      await fetchAllRepos((repos, isComplete) => {
         setRepos(repos)
         if (isFirstPage) {
           setLoading(false)
@@ -73,18 +93,32 @@ export function RepoCombobox({
         if (isComplete) {
           setLoadingMore(false)
         }
-      }).catch((err) => {
-        setError(err.message)
-        setLoading(false)
-        setLoadingMore(false)
       })
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load repositories"
+      )
+    } finally {
+      loadingRef.current = false
+      setLoading(false)
+      setLoadingMore(false)
     }
-  }, [open, repos.length, loading])
+  }, [status])
+
+  // Fetch once when an authenticated user opens an empty picker. Keep errors
+  // visible until the user retries instead of immediately starting the same
+  // failing request again.
+  useEffect(() => {
+    if (open && status === "authenticated" && repos.length === 0 && !error) {
+      void loadRepos()
+    }
+  }, [open, status, repos.length, error, loadRepos])
 
   // Reset search when popover closes
   useEffect(() => {
     if (!open) {
       setSearch("")
+      setError(null)
     }
   }, [open])
 
@@ -163,23 +197,53 @@ export function RepoCombobox({
         sideOffset={8}
       >
         <Command shouldFilter={false} value={search ? undefined : (value || undefined)}>
-          <CommandInput
-            placeholder="Search repositories..."
-            value={search}
-            onValueChange={setSearch}
-          />
+          {status === "authenticated" && (
+            <CommandInput
+              placeholder="Search repositories..."
+              value={search}
+              onValueChange={setSearch}
+            />
+          )}
           <CommandList>
-            {loading && (
+            {status === "loading" && (
               <div className="flex items-center justify-center py-6">
                 <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
               </div>
             )}
-            {error && (
-              <div className="py-6 text-center text-sm text-destructive">
-                {error}
+            {status === "unauthenticated" && (
+              <div className="flex flex-col items-center gap-3 px-4 py-6 text-center">
+                <p className="text-sm text-muted-foreground">
+                  Sign in with GitHub to load your repositories.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => signInWithGitHub()}
+                  className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90 transition-colors"
+                >
+                  <Github className="h-4 w-4" />
+                  Sign in with GitHub
+                </button>
               </div>
             )}
-            {!loading && !error && (
+            {status === "authenticated" && loading && (
+              <div className="flex items-center justify-center py-6">
+                <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+              </div>
+            )}
+            {status === "authenticated" && error && (
+              <div className="flex flex-col items-center gap-3 px-4 py-6 text-center">
+                <p className="text-sm text-destructive">{error}</p>
+                <button
+                  type="button"
+                  onClick={() => void loadRepos()}
+                  className="inline-flex items-center gap-2 rounded-md border border-border px-3 py-1.5 text-sm text-foreground hover:bg-accent transition-colors"
+                >
+                  <RefreshCw className="h-4 w-4" />
+                  Retry
+                </button>
+              </div>
+            )}
+            {status === "authenticated" && !loading && !error && (
               <>
                 {onRequestCreate && !search && (
                   <>

--- a/packages/web/e2e/repo-picker.spec.ts
+++ b/packages/web/e2e/repo-picker.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from "@playwright/test"
+import { setupTestAuth } from "./helpers"
+
+test("signed-out repository picker explains that GitHub sign-in is required", async ({
+  page,
+}) => {
+  const repoRequests: string[] = []
+  page.on("request", (request) => {
+    if (request.url().includes("/api/github/repos")) {
+      repoRequests.push(request.url())
+    }
+  })
+
+  await page.goto("/")
+
+  await page.getByRole("button", { name: "Repository" }).click()
+
+  const picker = page.getByRole("dialog")
+  await expect(
+    picker.getByText("Sign in with GitHub to load your repositories.")
+  ).toBeVisible()
+  await expect(
+    picker.getByRole("button", { name: "Sign in with GitHub" })
+  ).toBeVisible()
+  expect(repoRequests).toEqual([])
+})
+
+test("repository picker surfaces fetch errors and supports an explicit retry", async ({
+  page,
+  context,
+}) => {
+  await setupTestAuth(page, context)
+
+  let serviceRecovered = false
+  await page.route("**/api/github/repos?*", async (route) => {
+    if (serviceRecovered) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ repos: [], page: 1, hasMore: false }),
+      })
+      return
+    }
+
+    await route.fulfill({
+      status: 503,
+      contentType: "application/json",
+      body: JSON.stringify({ error: "GitHub is temporarily unavailable" }),
+    })
+  })
+
+  await page.goto("/")
+  await page.getByRole("button", { name: "Repository" }).click()
+
+  const picker = page.getByRole("dialog")
+  await expect(
+    picker.getByText("GitHub is temporarily unavailable")
+  ).toBeVisible()
+
+  serviceRecovered = true
+  await picker.getByRole("button", { name: "Retry" }).click()
+
+  await expect(picker.getByText("No repositories found")).toBeVisible()
+})


### PR DESCRIPTION
## Summary

- gate repository loading on the resolved NextAuth session
- show signed-out users a clear GitHub sign-in explanation and action
- keep authenticated fetch failures visible instead of immediately hiding them behind another spinner
- add an explicit retry action and prevent overlapping repository requests
- cover the signed-out and recoverable API-error journeys with Playwright

## Problem and user impact

Opening the repository picker could leave it on an indefinite spinner. Signed-out users were not told that GitHub authentication was required, while authenticated users could not see the GitHub/API error preventing their repositories from loading.

The failure path also generated repeated requests while the picker remained open, leaving users without an actionable recovery path.

## Root cause

`RepoCombobox` fetched whenever the picker was open, its local repository list was empty, and `loading` was false. The request catch handler set `loading` back to false, which was an effect dependency, so the effect immediately cleared the error and started the same request again.

The picker also called the authenticated repository endpoint without first checking the NextAuth session state.

## Verification

- [x] `npm install`
- [x] `npm run prisma:generate`
- [x] `npm run test:e2e -w @background-agents/web -- --list` (both new scenarios discovered)
- [x] parsed the changed component and Playwright spec with esbuild
- [x] `git diff --check`
- [ ] full E2E execution was not run because the required `packages/web/.env.test` test database configuration and exported `DAYTONA_API_KEY` are not present locally
- [ ] web workspace typecheck remains blocked by the existing `Sidebar.tsx` / `sidebar.tsx` filename-casing collision; none of the reported errors point to the changed files

## Visual evidence

The existing screenshot and recording in #318 show the same indefinite repository-loader symptom. I also reproduced the signed-out variant on the hosted app: the popover remained on the spinner after seven seconds and never surfaced its 401 response.

## Risks / Notes

- The change is isolated to repository-picker loading and empty/error states.
- Successful authenticated repository pagination is preserved.
- GitHub OAuth scopes and server-side repository access are unchanged.
- Related signed-out states in Scheduled Agents and Usage were identified separately and intentionally kept out of this PR.

Closes #318