### PR TITLE
fix: keep chat action slot stable after runs

### DIFF
--- a/packages/web/components/chat/ChatInput.test.tsx
+++ b/packages/web/components/chat/ChatInput.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest"
+import { ChatActionSlot } from "./ChatInput"
+
+interface ActionSlotElementProps {
+  "data-testid": string
+  className: string
+  children: {
+    props: Record<string, unknown>
+  } | null
+}
+
+function getActionSlot(overrides: Partial<Parameters<typeof ChatActionSlot>[0]> = {}) {
+  return ChatActionSlot({
+    isRunning: false,
+    canQueue: false,
+    canSend: false,
+    isMobile: false,
+    showBranchAffordance: false,
+    onSend: vi.fn(),
+    onStop: vi.fn(),
+    ...overrides,
+  })
+}
+
+describe("ChatActionSlot", () => {
+  it.each([
+    { layout: "desktop", isMobile: false },
+    { layout: "mobile", isMobile: true },
+  ])(
+    "keeps a fixed action wrapper mounted in the $layout layout",
+    ({ isMobile }) => {
+      const running = getActionSlot({ isRunning: true, isMobile })
+      const idle = getActionSlot({ isMobile })
+      const runningProps = running.props as ActionSlotElementProps
+      const idleProps = idle.props as ActionSlotElementProps
+
+      expect(running.type).toBe("div")
+      expect(idle.type).toBe("div")
+      expect(runningProps["data-testid"]).toBe("chat-action-slot")
+      expect(idleProps["data-testid"]).toBe("chat-action-slot")
+      expect(runningProps.className).toBe(idleProps.className)
+      expect(idleProps.children).toBeNull()
+    }
+  )
+
+  it.each([
+    {
+      name: "queue",
+      state: { isRunning: true, canQueue: true },
+      label: "Queue message",
+    },
+    {
+      name: "stop",
+      state: { isRunning: true, canQueue: false },
+      label: "Stop agent",
+    },
+    {
+      name: "send",
+      state: { isRunning: false, canSend: true },
+      label: "Send message",
+    },
+  ])("renders the $name action for its composer state", ({ state, label }) => {
+    const element = getActionSlot(state)
+    const props = element.props as ActionSlotElementProps
+
+    expect(props.children?.props["aria-label"]).toBe(label)
+  })
+})

--- a/packages/web/components/chat/ChatInput.tsx
+++ b/packages/web/components/chat/ChatInput.tsx
@@ -86,6 +86,88 @@ interface ChatInputProps {
   isMobile: boolean
 }
 
+interface ChatActionSlotProps {
+  isRunning: boolean
+  canQueue: boolean
+  canSend: boolean
+  isMobile: boolean
+  showBranchAffordance: boolean
+  onSend: (e?: React.MouseEvent) => void
+  onStop: () => void
+}
+
+/**
+ * Keeps the far-right composer action in a stable, fixed-size slot.
+ *
+ * The wrapper intentionally remains mounted while idle. Otherwise, when a run
+ * finishes, the adjacent microphone control shifts into the Stop button's old
+ * hit target and can receive a click that was intended to stop the agent.
+ */
+export function ChatActionSlot({
+  isRunning,
+  canQueue,
+  canSend,
+  isMobile,
+  showBranchAffordance,
+  onSend,
+  onStop,
+}: ChatActionSlotProps) {
+  return (
+    <div
+      data-testid="chat-action-slot"
+      className={cn(
+        "shrink-0 flex items-center justify-center",
+        isMobile ? "h-9 w-9" : "h-7 w-7"
+      )}
+    >
+      {isRunning && canQueue ? (
+        <button
+          type="button"
+          onClick={onSend}
+          title="Queue message (sent after current response)"
+          aria-label="Queue message"
+          className={cn(
+            "flex items-center justify-center rounded-md bg-primary text-primary-foreground hover:bg-primary/90 active:bg-primary/80 transition-colors cursor-pointer",
+            isMobile ? "h-9 w-9" : "h-7 w-7"
+          )}
+        >
+          <ArrowUp className={cn(isMobile ? "h-4 w-4" : "h-3.5 w-3.5")} />
+        </button>
+      ) : isRunning ? (
+        <button
+          type="button"
+          onClick={onStop}
+          title="Stop agent"
+          aria-label="Stop agent"
+          className={cn(
+            "flex items-center justify-center rounded-md bg-red-500 text-white hover:bg-red-600 active:bg-red-700 transition-colors cursor-pointer",
+            isMobile ? "h-9 w-9" : "h-7 w-7"
+          )}
+        >
+          <Square className={cn(isMobile ? "h-3.5 w-3.5" : "h-3 w-3", "fill-current")} />
+        </button>
+      ) : canSend ? (
+        <button
+          type="button"
+          onClick={onSend}
+          title={showBranchAffordance ? "Send to a new branch" : undefined}
+          aria-label={showBranchAffordance ? "Send to a new branch" : "Send message"}
+          className={cn(
+            "flex items-center justify-center rounded-md bg-primary text-primary-foreground hover:bg-primary/90 active:bg-primary/80 transition-colors cursor-pointer",
+            isMobile ? "h-9 w-9" : "h-7 w-7"
+          )}
+        >
+          {showBranchAffordance ? (
+            <GitBranch className={cn(isMobile ? "h-4 w-4" : "h-3.5 w-3.5")} />
+          ) : (
+            <ArrowUp className={cn(isMobile ? "h-4 w-4" : "h-3.5 w-3.5")} />
+          )}
+        </button>
+      ) : null}
+    </div>
+  )
+}
+
 export function ChatInput({
   chat,
   input,
@@ -349,11 +431,10 @@ export function ChatInput({
             />
           </div>
 
-          {/* Voice dictation (speech-to-text) — sits on the left of the send
-              button. When the input is empty (no send button) it's the only
-              control on the right; once the send button appears it moves to
-              its left. Bottom-aligned with the send button as the textarea
-              grows. Only shown when supported. */}
+          {/* Voice dictation (speech-to-text) — stays on the left of the fixed
+              action slot so run-state changes cannot move it under a pending
+              click. Bottom-aligned as the textarea grows. Only shown when
+              supported. */}
           {speech.isSupported && (
             <button
               type="button"
@@ -388,54 +469,17 @@ export function ChatInput({
             </button>
           )}
 
-          {/* Send / stop / queue button — only occupies space when there's an
-              action to show, so the mic stays flush-right when the input is
-              empty. Rendered on the far right. */}
-          {(isRunning || canSend) && (
-            <div className={cn(
-              "shrink-0 flex items-center justify-center",
-              isMobile ? "h-9 w-9" : "h-7 w-7"
-            )}>
-              {isRunning && canQueue ? (
-                <button
-                  onClick={handleSendWithSpeechStop}
-                  title="Queue message (sent after current response)"
-                  className={cn(
-                    "flex items-center justify-center rounded-md bg-primary text-primary-foreground hover:bg-primary/90 active:bg-primary/80 transition-colors cursor-pointer",
-                    isMobile ? "h-9 w-9" : "h-7 w-7"
-                  )}
-                >
-                  <ArrowUp className={cn(isMobile ? "h-4 w-4" : "h-3.5 w-3.5")} />
-                </button>
-              ) : isRunning ? (
-                <button
-                  onClick={onStop}
-                  className={cn(
-                    "flex items-center justify-center rounded-md bg-red-500 text-white hover:bg-red-600 active:bg-red-700 transition-colors cursor-pointer",
-                    isMobile ? "h-9 w-9" : "h-7 w-7"
-                  )}
-                >
-                  <Square className={cn(isMobile ? "h-3.5 w-3.5" : "h-3 w-3", "fill-current")} />
-                </button>
-              ) : canSend ? (
-                <button
-                  onClick={handleSendWithSpeechStop}
-                  title={showBranchAffordance ? "Send to a new branch" : undefined}
-                  aria-label={showBranchAffordance ? "Send to a new branch" : "Send message"}
-                  className={cn(
-                    "flex items-center justify-center rounded-md bg-primary text-primary-foreground hover:bg-primary/90 active:bg-primary/80 transition-colors cursor-pointer",
-                    isMobile ? "h-9 w-9" : "h-7 w-7"
-                  )}
-                >
-                  {showBranchAffordance ? (
-                    <GitBranch className={cn(isMobile ? "h-4 w-4" : "h-3.5 w-3.5")} />
-                  ) : (
-                    <ArrowUp className={cn(isMobile ? "h-4 w-4" : "h-3.5 w-3.5")} />
-                  )}
-                </button>
-              ) : null}
-            </div>
-          )}
+          {/* Send / stop / queue button — the slot remains mounted while idle
+              so the adjacent microphone never replaces its hit target. */}
+          <ChatActionSlot
+            isRunning={isRunning}
+            canQueue={canQueue}
+            canSend={canSend}
+            isMobile={isMobile}
+            showBranchAffordance={showBranchAffordance}
+            onSend={handleSendWithSpeechStop}
+            onStop={onStop}
+          />
         </div>
 
         {/* File upload error message */}


### PR DESCRIPTION
## Summary

- keep the far-right chat action wrapper mounted at a fixed size when no action is available
- prevent the microphone control from sliding into the former Stop hit target when a run finishes
- preserve the existing queue, Stop, send, and branch-send state priority in a focused `ChatActionSlot` component
- add accessible labels and explicit button types for the extracted actions
- cover desktop/mobile slot stability and queue/Stop/send selection with regression tests

## User-visible evidence

The issue was reproduced directly on `backgrounder.dev`: an `Agent finished` notification appeared while the same intended Stop click opened the browser microphone permission prompt.

```text
Before
running: [ microphone ][ Stop ]
idle:                 [ microphone ]  <- moves into the old Stop target

After
running: [ microphone ][ Stop ]
idle:    [ microphone ][ reserved empty action slot ]
```

The raw audit screenshot is not attached because it contains private browser tabs and account information. The reproduction details are documented in #383.

## Verification

- [x] `npm install`
- [x] `npm run prisma:generate`
- [x] `npx vitest run --config packages/web/vitest.config.ts packages/web/components/chat/ChatInput.test.tsx --reporter verbose` — 5 tests passed
- [x] targeted `tsc --noEmit` using the web project settings for `ChatInput.tsx`, its test, and the required NextAuth augmentation
- [ ] browser E2E — not run because `DAYTONA_API_KEY`, `GITHUB_CLIENT_ID`, and `GITHUB_CLIENT_SECRET` are not exported locally
- [ ] repository-wide `npm run typecheck` — all earlier workspaces passed, then the unchanged web baseline failed on macOS because `components/Sidebar.tsx` conflicts by case with the `components/sidebar/` directory

## Risks / Notes

- The idle composer now intentionally reserves one empty action slot: `28px` on desktop and `36px` on mobile. This small spacing change is what keeps the microphone out of the old Stop target.
- A root-level Vitest run also collects existing Playwright and Daytona integration suites and fails without their required runtime setup; the focused regression suite passes.

Closes #383
