### PR TITLE
fix: show all scheduled agent form errors at once

### DIFF
--- a/packages/web/components/scheduled-jobs/ScheduleFields.tsx
+++ b/packages/web/components/scheduled-jobs/ScheduleFields.tsx
@@ -9,6 +9,7 @@ import {
   inferIntervalMode,
   type IntervalUnit,
 } from "./form-config"
+import { cn } from "@/lib/utils"
 
 interface ScheduleFieldsProps {
   isCustomInterval: boolean
@@ -26,6 +27,8 @@ interface ScheduleFieldsProps {
   setCustomIntervalUnit: (v: IntervalUnit) => void
   setRunAtDay: (v: number) => void
   setRunAtHourLocal: (v: number) => void
+  error?: string
+  onIntervalChange: () => void
 }
 
 export function ScheduleFields({
@@ -43,7 +46,15 @@ export function ScheduleFields({
   setCustomIntervalUnit,
   setRunAtDay,
   setRunAtHourLocal,
+  error,
+  onIntervalChange,
 }: ScheduleFieldsProps) {
+  const intervalError = error ?? (
+    isCustomInterval && effectiveIntervalMinutes < 10
+      ? "Interval must be at least 10 minutes"
+      : undefined
+  )
+
   return (
     <div className="space-y-1">
       <div className="flex flex-wrap items-center gap-2 text-sm">
@@ -51,6 +62,7 @@ export function ScheduleFields({
         <select
           value={isCustomInterval ? CUSTOM_INTERVAL : intervalMinutes}
           onChange={(e) => {
+            onIntervalChange()
             const val = parseInt(e.target.value, 10)
             if (val === CUSTOM_INTERVAL) {
               // Seed custom inputs from the current preset so the
@@ -78,19 +90,31 @@ export function ScheduleFields({
         {isCustomInterval && (
           <>
             <input
+              id="scheduled-job-interval"
+              name="interval"
               type="number"
               min={customIntervalUnit === "minutes" ? 10 : 1}
               step={1}
               value={customIntervalValue}
               onChange={(e) => {
+                onIntervalChange()
                 const n = parseInt(e.target.value, 10)
                 setCustomIntervalValue(Number.isFinite(n) ? Math.max(1, n) : 1)
               }}
-              className="w-16 rounded-md border border-border bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              aria-label="Custom interval"
+              aria-invalid={!!intervalError}
+              aria-describedby={intervalError ? "scheduled-job-interval-error" : undefined}
+              className={cn(
+                "w-16 rounded-md border bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring",
+                intervalError ? "border-destructive" : "border-border"
+              )}
             />
             <select
               value={customIntervalUnit}
-              onChange={(e) => setCustomIntervalUnit(e.target.value as IntervalUnit)}
+              onChange={(e) => {
+                onIntervalChange()
+                setCustomIntervalUnit(e.target.value as IntervalUnit)
+              }}
               className="rounded-md border border-border bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
             >
               {INTERVAL_UNITS.map((u) => (
@@ -140,9 +164,9 @@ export function ScheduleFields({
         )}
       </div>
 
-      {isCustomInterval && effectiveIntervalMinutes < 10 && (
-        <p className="text-xs text-destructive">
-          Interval must be at least 10 minutes.
+      {intervalError && (
+        <p id="scheduled-job-interval-error" className="text-xs text-destructive">
+          {intervalError}
         </p>
       )}
     </div>

--- a/packages/web/components/scheduled-jobs/ScheduledJobForm.tsx
+++ b/packages/web/components/scheduled-jobs/ScheduledJobForm.tsx
@@ -52,6 +52,7 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
     continueFromLastRun,
     loading,
     error,
+    fieldErrors,
     materializedJobId,
     showAgentDropdown,
     showModelDropdown,
@@ -88,7 +89,10 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
     handleRotateToken,
     handleAgentChange,
     handleModelChange,
+    clearFieldError,
   } = useScheduledJobForm({ open, job, onClose, onSuccess })
+
+  const fieldErrorMessages = Object.values(fieldErrors)
 
   return (
     <Dialog.Root open={open} onOpenChange={(isOpen) => !isOpen && handleClose()}>
@@ -119,21 +123,49 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
           {/* Form */}
           <form id="scheduled-job-form" onSubmit={handleSubmit} className="p-4 space-y-4 overflow-y-auto flex-1">
             {error && (
-              <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              <div role="alert" className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
                 {error}
+              </div>
+            )}
+
+            {fieldErrorMessages.length > 0 && (
+              <div role="alert" className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                <p className="font-medium">Please fix the following fields:</p>
+                <ul className="mt-1 list-disc pl-5">
+                  {fieldErrorMessages.map((message) => (
+                    <li key={message}>{message}</li>
+                  ))}
+                </ul>
               </div>
             )}
 
             {/* Name */}
             <div>
-              <label className="block text-sm font-medium mb-1">Name</label>
+              <label htmlFor="scheduled-job-name" className="block text-sm font-medium mb-1">Name</label>
               <input
+                id="scheduled-job-name"
+                name="name"
                 type="text"
                 value={name}
-                onChange={(e) => setName(e.target.value)}
+                onChange={(e) => {
+                  const value = e.target.value
+                  setName(value)
+                  if (value.trim()) clearFieldError("name")
+                }}
                 placeholder="e.g., Dependency Updates"
-                className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                aria-required="true"
+                aria-invalid={!!fieldErrors.name}
+                aria-describedby={fieldErrors.name ? "scheduled-job-name-error" : undefined}
+                className={cn(
+                  "w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring",
+                  fieldErrors.name ? "border-destructive" : "border-border"
+                )}
               />
+              {fieldErrors.name && (
+                <p id="scheduled-job-name-error" className="mt-1 text-xs text-destructive">
+                  {fieldErrors.name}
+                </p>
+              )}
             </div>
 
             {/* Trigger Type - Segmented Control. Always editable — PATCH
@@ -146,7 +178,10 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
                   <button
                     key={t.value}
                     type="button"
-                    onClick={() => setTriggerType(t.value)}
+                    onClick={() => {
+                      setTriggerType(t.value)
+                      if (t.value === "incoming") clearFieldError("interval")
+                    }}
                     className={cn(
                       "px-3 py-1 text-sm rounded-md transition-colors cursor-pointer",
                       triggerType === t.value
@@ -177,6 +212,8 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
                 setCustomIntervalUnit={setCustomIntervalUnit}
                 setRunAtDay={setRunAtDay}
                 setRunAtHourLocal={setRunAtHourLocal}
+                error={fieldErrors.interval}
+                onIntervalChange={() => clearFieldError("interval")}
               />
             )}
 
@@ -231,19 +268,29 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
 
             {/* Prompt Field - styled like ChatInput */}
             <div>
-              <label className="block text-sm font-medium mb-1">Prompt</label>
+              <label htmlFor="scheduled-job-prompt" className="block text-sm font-medium mb-1">Prompt</label>
               <div className={cn(
-                "relative flex flex-col border shadow-sm bg-card border-border",
+                "relative flex flex-col border shadow-sm bg-card",
+                fieldErrors.prompt ? "border-destructive" : "border-border",
                 isMobile ? "rounded-xl" : "rounded-2xl",
                 "focus-within:border-primary/50 focus-within:ring-1 focus-within:ring-primary/20"
               )}>
                 {/* Textarea */}
                 <div className={cn(isMobile ? "px-3 py-2" : "px-4 py-3")}>
                   <textarea
+                    id="scheduled-job-prompt"
+                    name="prompt"
                     value={prompt}
-                    onChange={(e) => setPrompt(e.target.value)}
+                    onChange={(e) => {
+                      const value = e.target.value
+                      setPrompt(value)
+                      if (value.trim()) clearFieldError("prompt")
+                    }}
                     placeholder="What should the agent do?"
                     rows={4}
+                    aria-required="true"
+                    aria-invalid={!!fieldErrors.prompt}
+                    aria-describedby={fieldErrors.prompt ? "scheduled-job-prompt-error" : undefined}
                     className="w-full bg-transparent text-sm text-foreground placeholder:text-muted-foreground/50 focus:outline-none resize-none"
                   />
                 </div>
@@ -389,6 +436,11 @@ export function ScheduledJobForm({ open, job, onClose, onSuccess, isMobile = fal
                   </div>
                 </div>
               </div>
+              {fieldErrors.prompt && (
+                <p id="scheduled-job-prompt-error" className="mt-1 text-xs text-destructive">
+                  {fieldErrors.prompt}
+                </p>
+              )}
             </div>
 
             {/* Options Section — hidden when neither option applies (e.g. an

--- a/packages/web/lib/hooks/useScheduledJobForm.ts
+++ b/packages/web/lib/hooks/useScheduledJobForm.ts
@@ -12,6 +12,12 @@ import {
   localHourToUtc,
   type IntervalUnit,
 } from "@/components/scheduled-jobs/form-config"
+import {
+  getFirstInvalidScheduledJobField,
+  validateScheduledJobForm,
+  type ScheduledJobFormErrors,
+  type ScheduledJobFormField,
+} from "@/lib/scheduled-jobs/form-validation"
 
 interface UseScheduledJobFormArgs {
   open: boolean
@@ -52,6 +58,7 @@ export function useScheduledJobForm({ open, job, onClose, onSuccess }: UseSchedu
 
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [fieldErrors, setFieldErrors] = useState<ScheduledJobFormErrors>({})
 
   // In create mode, the form may "materialize" the job into the DB the first
   // time the user clicks the MCP picker, so MCP server connections have a real
@@ -117,6 +124,7 @@ export function useScheduledJobForm({ open, job, onClose, onSuccess }: UseSchedu
       setAutoPR(job?.autoPR ?? true)
       setContinueFromLastRun(job?.continueFromLastRun ?? false)
       setError(null)
+      setFieldErrors({})
       setMaterializedJobId(null)
       setIncomingToken(job?.incomingToken ?? null)
       setRotating(false)
@@ -151,23 +159,7 @@ export function useScheduledJobForm({ open, job, onClose, onSuccess }: UseSchedu
     return () => document.removeEventListener('click', handleClickOutside)
   }, [])
 
-  /**
-   * Build the request body for create/update from current form state.
-   * Returns `null` and sets the visible error if required fields are missing.
-   */
-  function buildPayload(): Record<string, unknown> | null {
-    if (!name.trim()) {
-      setError("Name is required")
-      return null
-    }
-    if (!prompt.trim()) {
-      setError("Prompt is required")
-      return null
-    }
-    if (triggerType === "interval" && effectiveIntervalMinutes < 10) {
-      setError("Interval must be at least 10 minutes")
-      return null
-    }
+  function buildPayload(): Record<string, unknown> {
     const runAtHourUtc = localHourToUtc(runAtHourLocal)
     return {
       name: name.trim(),
@@ -258,12 +250,29 @@ export function useScheduledJobForm({ open, job, onClose, onSuccess }: UseSchedu
   }
 
   // Handle form submit
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
     setError(null)
 
+    const validationErrors = validateScheduledJobForm({
+      name,
+      prompt,
+      triggerType,
+      intervalMinutes: effectiveIntervalMinutes,
+    })
+    setFieldErrors(validationErrors)
+
+    const firstInvalidField = getFirstInvalidScheduledJobField(validationErrors)
+    if (firstInvalidField) {
+      const form = e.currentTarget
+      requestAnimationFrame(() => {
+        const field = form.elements.namedItem(firstInvalidField)
+        if (field instanceof HTMLElement) field.focus()
+      })
+      return
+    }
+
     const payload = buildPayload()
-    if (!payload) return
 
     setLoading(true)
 
@@ -386,6 +395,15 @@ export function useScheduledJobForm({ open, job, onClose, onSuccess }: UseSchedu
     setShowModelDropdown(false)
   }
 
+  const clearFieldError = (field: ScheduledJobFormField) => {
+    setFieldErrors((current) => {
+      if (!current[field]) return current
+      const next = { ...current }
+      delete next[field]
+      return next
+    })
+  }
+
   return {
     // identity / mode
     isEditing,
@@ -409,6 +427,7 @@ export function useScheduledJobForm({ open, job, onClose, onSuccess }: UseSchedu
     continueFromLastRun,
     loading,
     error,
+    fieldErrors,
     materializedJobId,
     showAgentDropdown,
     showModelDropdown,
@@ -449,5 +468,6 @@ export function useScheduledJobForm({ open, job, onClose, onSuccess }: UseSchedu
     handleRotateToken,
     handleAgentChange,
     handleModelChange,
+    clearFieldError,
   }
 }

--- a/packages/web/lib/scheduled-jobs/form-validation.test.ts
+++ b/packages/web/lib/scheduled-jobs/form-validation.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest"
+import {
+  getFirstInvalidScheduledJobField,
+  validateScheduledJobForm,
+} from "./form-validation"
+
+describe("validateScheduledJobForm", () => {
+  it("reports every missing required field in one pass", () => {
+    expect(validateScheduledJobForm({
+      name: "   ",
+      prompt: "",
+      triggerType: "interval",
+      intervalMinutes: 60,
+    })).toEqual({
+      name: "Name is required",
+      prompt: "Prompt is required",
+    })
+  })
+
+  it("accepts trimmed values and a valid interval", () => {
+    expect(validateScheduledJobForm({
+      name: " Dependency updates ",
+      prompt: " Update dependencies ",
+      triggerType: "interval",
+      intervalMinutes: 60,
+    })).toEqual({})
+  })
+
+  it("rejects interval schedules shorter than ten minutes", () => {
+    expect(validateScheduledJobForm({
+      name: "Dependency updates",
+      prompt: "Update dependencies",
+      triggerType: "interval",
+      intervalMinutes: 9,
+    })).toEqual({
+      interval: "Interval must be at least 10 minutes",
+    })
+  })
+
+  it("does not apply interval validation to webhook triggers", () => {
+    expect(validateScheduledJobForm({
+      name: "Dependency updates",
+      prompt: "Update dependencies",
+      triggerType: "incoming",
+      intervalMinutes: 1,
+    })).toEqual({})
+  })
+})
+
+describe("getFirstInvalidScheduledJobField", () => {
+  it("uses visual form order when multiple fields are invalid", () => {
+    expect(getFirstInvalidScheduledJobField({
+      prompt: "Prompt is required",
+      name: "Name is required",
+    })).toBe("name")
+
+    expect(getFirstInvalidScheduledJobField({
+      prompt: "Prompt is required",
+      interval: "Interval must be at least 10 minutes",
+    })).toBe("interval")
+  })
+
+  it("returns null when the form is valid", () => {
+    expect(getFirstInvalidScheduledJobField({})).toBeNull()
+  })
+})

--- a/packages/web/lib/scheduled-jobs/form-validation.ts
+++ b/packages/web/lib/scheduled-jobs/form-validation.ts
@@ -1,0 +1,45 @@
+export type ScheduledJobFormField = "name" | "prompt" | "interval"
+
+export type ScheduledJobFormErrors = Partial<Record<ScheduledJobFormField, string>>
+
+interface ScheduledJobFormValues {
+  name: string
+  prompt: string
+  triggerType: "interval" | "incoming"
+  intervalMinutes: number
+}
+
+const SCHEDULED_JOB_FIELD_ORDER: ScheduledJobFormField[] = [
+  "name",
+  "interval",
+  "prompt",
+]
+
+export function validateScheduledJobForm({
+  name,
+  prompt,
+  triggerType,
+  intervalMinutes,
+}: ScheduledJobFormValues): ScheduledJobFormErrors {
+  const errors: ScheduledJobFormErrors = {}
+
+  if (!name.trim()) {
+    errors.name = "Name is required"
+  }
+
+  if (triggerType === "interval" && intervalMinutes < 10) {
+    errors.interval = "Interval must be at least 10 minutes"
+  }
+
+  if (!prompt.trim()) {
+    errors.prompt = "Prompt is required"
+  }
+
+  return errors
+}
+
+export function getFirstInvalidScheduledJobField(
+  errors: ScheduledJobFormErrors
+): ScheduledJobFormField | null {
+  return SCHEDULED_JOB_FIELD_ORDER.find((field) => errors[field]) ?? null
+}


### PR DESCRIPTION
## Summary

- validate Name, Prompt, and custom interval constraints in one pass instead of returning after the first failure
- show an announced error summary plus field-level messages and destructive states
- associate labels and errors with their controls through stable ids and ARIA attributes
- focus the first invalid control in visual form order after submit
- clear stale field errors as the corresponding value is corrected
- keep server/API failures in the existing global error path

## User-facing behavior

| Before | After |
| --- | --- |
| First submit with Name and Prompt empty shows only "Name is required" | The same submit shows both missing fields immediately |
| Prompt is only discovered after entering Name and submitting again | Name and Prompt are highlighted during the first validation pass |
| The banner is not announced and is not associated with a field | The summary uses an alert, controls expose aria-invalid, and error text is connected with aria-describedby |
| Keyboard users remain at the submit action | Focus moves to the first invalid control |

## Root cause

The client-side buildPayload function performed three sequential checks and returned null immediately after the first invalid value. The form therefore could not retain more than one validation failure at a time.

This change moves validation into a small pure helper that returns all field errors. Payload construction and API request behavior are otherwise unchanged.

## Verification

- [x] Regression test was added before the implementation and failed because the validation module did not yet exist
- [x] Focused validation suite: 6 tests passed
- [x] Full web unit suite: 16 files / 156 tests passed
- [x] Isolated TypeScript check covering all changed files passed
- [x] git diff --check passed
- [ ] Full npm run typecheck is blocked on this macOS checkout by the pre-existing Sidebar.tsx / sidebar.tsx case-collision on main; the changed-file TypeScript check has no errors
- [ ] Local dev/E2E was not run because DAYTONA_API_KEY, GITHUB_CLIENT_ID, and GITHUB_CLIENT_SECRET are not exported in this environment

Commands:

    npx vitest run --config packages/web/vitest.config.ts packages/web/lib/scheduled-jobs/form-validation.test.ts
    cd packages/web && npx vitest run --config vitest.config.ts
    npx tsc --noEmit -p packages/web/tsconfig.scheduled-job-validation.json

The final command used a temporary, untracked config that included only the five changed files and their imports; it was removed after the check.

## Evidence

Reconfirmed against https://backgrounder.dev on 2026-08-01:

1. Open Scheduled Agents > New Job.
2. Leave both Name and Prompt empty.
3. Select Create.
4. The hosted build displays only "Name is required".
5. Enter a Name and submit again; only then is "Prompt is required" revealed.

### Before — hosted reproduction

<img width="625" alt="New Scheduled Agent form showing only Name is required while both Name and Prompt are empty" src="https://github.com/user-attachments/assets/e1da0382-9d0b-432b-bd3a-5e2dcbde0a76" />

Both required fields are empty in this capture, but the first submit reports only the Name error. The image is a privacy-safe crop of the hosted form; browser tabs and account details are excluded.

### After — this PR

The regression test asserts that the same validation pass returns both Name and Prompt errors. The updated form renders those errors together, links each message to its control, and focuses the first invalid field.

## Risks / Notes

- Client-side form state and accessibility markup only
- No API, database, request payload, scheduling, or agent execution changes
- Create and edit modes share this form hook and receive the same validation behavior
- The submit button remains enabled so users can trigger accessible validation feedback

Closes #385