### PR TITLE
fix: make shared-pool limit upsells plan-aware

### DIFF
--- a/packages/web/app/api/chats/[chatId]/messages/_lib/resolve-credentials.ts
+++ b/packages/web/app/api/chats/[chatId]/messages/_lib/resolve-credentials.ts
@@ -35,9 +35,9 @@ export async function resolveSendCredentials(
 
   let credentials = await getUserCredentials(userId)
 
-  // Enforce the per-provider daily token budget on shared pools (free users
-  // only). Returns allowed=true for own-key runs, Pro users, and agents without
-  // a shared pool — so this is safe to call unconditionally.
+  // Enforce the per-provider daily budget on shared pools. Free and Pro are
+  // capped; Unlimited, own-key runs, and agents without a shared pool are
+  // allowed — so this is safe to call unconditionally.
   const usageCheck = await checkSharedPoolUsage(userId, payload.agent as Agent, payload.model)
   if (!usageCheck.allowed) {
     logActivityAsync(userId, "daily_limit_reached", {
@@ -51,6 +51,7 @@ export async function resolveSendCredentials(
       {
         error: "DAILY_LIMIT_EXCEEDED",
         message: usageCheck.error,
+        plan: usageCheck.plan,
         provider: usageCheck.provider,
         unit: usageCheck.unit,
         used: usageCheck.used,

--- a/packages/web/components/AppModals.tsx
+++ b/packages/web/components/AppModals.tsx
@@ -23,6 +23,7 @@ import { SkillSearchView } from "@/components/skills/SkillSearchView"
 import type { SlashCommandType } from "@/components/SlashCommandMenu"
 import { useModals, useGit, useChat } from "@/lib/contexts"
 import { isRealRepo } from "@/lib/types"
+import type { LimitReachedState } from "@/lib/stores/chat-sync-store"
 
 // =============================================================================
 // AppModals — renders the application's modal/dialog "farm".
@@ -66,7 +67,7 @@ interface AppModalsProps {
   onDeleteChat: (chatId: string) => void
 
   // Daily limit reached dialog
-  limitReachedState: { show: boolean; resetAt?: Date; provider?: string; unit?: "tokens" | "cost" | "messages"; used?: number | null; limit?: number | null }
+  limitReachedState: LimitReachedState
   onDismissLimitReached: () => void
   onContinueWithOpenCode: () => void
 }
@@ -253,6 +254,7 @@ export function AppModals({
         unit={limitReachedState.unit}
         used={limitReachedState.used}
         limit={limitReachedState.limit}
+        plan={limitReachedState.plan}
         onContinueWithOpenCode={onContinueWithOpenCode}
         onAddApiKey={() => {
           onDismissLimitReached()
@@ -264,9 +266,13 @@ export function AppModals({
                 : "anthropic"
           modals.openSettings(key)
         }}
-        onUpgradeToPro={() => {
+        onUpgradePlan={(targetPlan) => {
           onDismissLimitReached()
-          window.open("mailto:james@jamesmurdza.com?subject=Upgrade%20to%20Pro", "_blank")
+          const planLabel = targetPlan === "pro" ? "Pro" : "Unlimited"
+          window.open(
+            `mailto:james@jamesmurdza.com?subject=${encodeURIComponent(`Upgrade to ${planLabel}`)}`,
+            "_blank"
+          )
         }}
         resetAt={limitReachedState.resetAt}
         isMobile={isMobile}

--- a/packages/web/components/modals/LimitReachedDialog.tsx
+++ b/packages/web/components/modals/LimitReachedDialog.tsx
@@ -7,13 +7,18 @@ import { ModalHeader, focusChatPrompt } from "@/components/ui/modal-header"
 import { Crown, Key, Zap } from "lucide-react"
 import { AgentIcon } from "@/components/icons/agent-icons"
 import { fmtBudgetAmount } from "@/lib/format"
+import {
+  getLimitUpgradeCopy,
+  type LimitUpgradeTarget,
+} from "@/lib/usage-limit-copy"
+import type { Plan } from "@/lib/server/usage-budgets"
 
 interface LimitReachedDialogProps {
   open: boolean
   onClose: () => void
   onContinueWithOpenCode: () => void
   onAddApiKey: () => void
-  onUpgradeToPro: () => void
+  onUpgradePlan: (targetPlan: LimitUpgradeTarget) => void
   /** Shared-pool provider that hit its limit (claude | gemini | opencode). */
   provider?: string
   /** Unit the budget is measured in; falls back to the provider's default. */
@@ -21,6 +26,8 @@ interface LimitReachedDialogProps {
   /** Amount used / daily budget for that provider, in `unit`. */
   used?: number | null
   limit?: number | null
+  /** Current subscription tier; defaults to Free for older responses. */
+  plan?: Plan
   resetAt?: Date
   isMobile?: boolean
 }
@@ -45,11 +52,12 @@ export function LimitReachedDialog({
   onClose,
   onContinueWithOpenCode,
   onAddApiKey,
-  onUpgradeToPro,
+  onUpgradePlan,
   provider,
   unit: unitProp,
   used,
   limit,
+  plan,
   resetAt,
   isMobile = false,
 }: LimitReachedDialogProps) {
@@ -59,6 +67,7 @@ export function LimitReachedDialog({
   const primaryButtonRef = useRef<HTMLButtonElement>(null)
   // Prefer the server-provided unit; fall back to the provider's default.
   const unit = unitProp ?? unitForProvider(provider)
+  const upgradeCopy = getLimitUpgradeCopy(plan)
 
   // Focus the primary button when modal opens
   useEffect(() => {
@@ -80,10 +89,11 @@ export function LimitReachedDialog({
     onClose()
   }, [onAddApiKey, onClose])
 
-  const handleUpgradeToPro = useCallback(() => {
-    onUpgradeToPro()
+  const handleUpgradePlan = useCallback(() => {
+    if (!upgradeCopy) return
+    onUpgradePlan(upgradeCopy.targetPlan)
     onClose()
-  }, [onUpgradeToPro, onClose])
+  }, [upgradeCopy, onUpgradePlan, onClose])
 
   // Format reset time
   const resetTimeString = resetAt
@@ -183,29 +193,31 @@ export function LimitReachedDialog({
                 </div>
               </button>
 
-              {/* Option 3: Upgrade to Pro */}
-              <button
-                onClick={handleUpgradeToPro}
-                className={cn(
-                  "w-full flex items-center gap-3 rounded-lg border border-amber-500/30 hover:bg-amber-500/5 transition-colors p-3 text-left cursor-pointer",
-                  "focus:outline-none focus:ring-2 focus:ring-amber-500/50"
-                )}
-              >
-                <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-amber-500/10">
-                  <Crown className="h-5 w-5 text-amber-500" />
-                </div>
-                <div className="flex-1 min-w-0">
-                  <div className="text-sm font-medium text-foreground">
-                    Upgrade to Pro
+              {/* Option 3: plan-aware upgrade (hidden for Unlimited). */}
+              {upgradeCopy && (
+                <button
+                  onClick={handleUpgradePlan}
+                  className={cn(
+                    "w-full flex items-center gap-3 rounded-lg border border-amber-500/30 hover:bg-amber-500/5 transition-colors p-3 text-left cursor-pointer",
+                    "focus:outline-none focus:ring-2 focus:ring-amber-500/50"
+                  )}
+                >
+                  <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-amber-500/10">
+                    <Crown className="h-5 w-5 text-amber-500" />
                   </div>
-                  <div className="text-xs text-muted-foreground">
-                    Higher daily limits on all shared pools and priority support
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm font-medium text-foreground">
+                      {upgradeCopy.title}
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      {upgradeCopy.description}
+                    </div>
                   </div>
-                </div>
-                <div className="shrink-0 text-xs font-medium text-amber-600 dark:text-amber-400 px-2 py-0.5 rounded bg-amber-500/10">
-                  Pro
-                </div>
-              </button>
+                  <div className="shrink-0 text-xs font-medium text-amber-600 dark:text-amber-400 px-2 py-0.5 rounded bg-amber-500/10">
+                    {upgradeCopy.targetPlan === "pro" ? "Pro" : "Unlimited"}
+                  </div>
+                </button>
+              )}
             </div>
 
             {/* Dismiss */}

--- a/packages/web/lib/chat-messages.test.ts
+++ b/packages/web/lib/chat-messages.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { sendMessageToApi } from "./chat-messages"
+
+describe("sendMessageToApi", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("preserves the subscription plan from a daily-limit response", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      Response.json({
+        error: "DAILY_LIMIT_EXCEEDED",
+        plan: "pro",
+        provider: "gemini",
+        unit: "messages",
+        used: 200,
+        limit: 200,
+        resetAt: "2026-08-02T00:00:00.000Z",
+      }, { status: 429 })
+    ))
+
+    const result = await sendMessageToApi("chat-1", {
+      message: "Continue",
+      agent: "gemini",
+      model: "gemini-2.5-flash",
+      userMessageId: "user-1",
+      assistantMessageId: "assistant-1",
+    })
+
+    expect(result).toMatchObject({
+      ok: false,
+      isDailyLimit: true,
+      plan: "pro",
+      provider: "gemini",
+      limit: 200,
+    })
+  })
+})

--- a/packages/web/lib/chat-messages.ts
+++ b/packages/web/lib/chat-messages.ts
@@ -9,6 +9,8 @@
 import type { Chat, Message, CredentialFlags } from "@/lib/types"
 import { sharedClaudePoolEligible } from "@/lib/types"
 import type { SettingsData } from "@/lib/query"
+import type { Plan } from "@/lib/server/usage-budgets"
+import { isPlan } from "@/lib/usage-limit-copy"
 import { generateBranchName } from "@/lib/utils"
 
 // =============================================================================
@@ -40,6 +42,8 @@ export type SendMessageResult =
       error: string
       isDailyLimit: boolean
       resetAt?: string
+      /** Subscription plan used to select the correct limit upsell. */
+      plan?: Plan
       /** Shared-pool provider that hit its limit (claude | gemini | opencode). */
       provider?: string
       /** Unit the budget is measured in (tokens | cost | messages). */
@@ -113,6 +117,7 @@ export async function sendMessageToApi(
       error: err.error || `Failed to send message (HTTP ${response.status})`,
       isDailyLimit: err.error === "DAILY_LIMIT_EXCEEDED",
       resetAt: err.resetAt,
+      plan: isPlan(err.plan) ? err.plan : undefined,
       provider: err.provider,
       unit: err.unit,
       used: err.used,

--- a/packages/web/lib/db/usage-limit.ts
+++ b/packages/web/lib/db/usage-limit.ts
@@ -17,6 +17,7 @@ import { prisma } from "./prisma"
 import { sumSharedUsage, countSharedMessages } from "./token-usage"
 import { providerForRun, resolvePool } from "@/lib/server/shared-pool"
 import { decryptUserCredentials } from "./api-helpers"
+import { formatUsageLimitMessage } from "@/lib/usage-limit-copy"
 import {
   getProviderBudget,
   getNextUtcDayReset,
@@ -35,7 +36,7 @@ export interface UsageLimitResult {
   unit: BudgetUnit
   /** Amount used in the current period, in `unit` (tokens / USD / messages). */
   used: number
-  /** Daily budget in `unit` (free users), or null when unlimited (pro/own key). */
+  /** Daily budget in `unit` (Free/Pro), or null for Unlimited/own-key runs. */
   limit: number | null
   remaining: number | null
   resetAt: Date
@@ -106,7 +107,9 @@ export async function checkSharedPoolUsage(
     used,
     limit: budget.limit,
     remaining,
-    error: allowed ? undefined : limitMessage(provider, budget.unit, budget.limit),
+    error: allowed
+      ? undefined
+      : formatUsageLimitMessage({ plan, provider, unit: budget.unit, limit: budget.limit }),
   }
 }
 
@@ -122,18 +125,4 @@ async function getSharedUsage(
   }
   const { limitedTokens, costUsd } = await sumSharedUsage({ userId, provider, since })
   return unit === "cost" ? costUsd : limitedTokens
-}
-
-/** Human-readable limit message, phrased per unit. */
-function limitMessage(provider: ProviderName, unit: BudgetUnit, limit: number): string {
-  const allowance =
-    unit === "tokens"
-      ? `${limit.toLocaleString()} tokens`
-      : unit === "cost"
-        ? `$${limit.toFixed(2)}`
-        : `${limit.toLocaleString()} messages`
-  return (
-    `Daily ${provider} limit reached (${allowance}). ` +
-    `Upgrade to Pro for unlimited usage, or add your own ${provider} key.`
-  )
 }

--- a/packages/web/lib/hooks/useMessageDispatch.ts
+++ b/packages/web/lib/hooks/useMessageDispatch.ts
@@ -221,6 +221,7 @@ export function useMessageDispatch({
             setLimitReachedState({
               show: true,
               pendingMessage: { chatId, content, files, planMode },
+              plan: result.plan,
               provider: result.provider,
               unit: result.unit,
               used: result.used,

--- a/packages/web/lib/stores/chat-sync-store.ts
+++ b/packages/web/lib/stores/chat-sync-store.ts
@@ -17,6 +17,7 @@
 import { create } from "zustand"
 import { nanoid } from "nanoid"
 import type { Chat } from "@/lib/types"
+import type { Plan } from "@/lib/server/usage-budgets"
 import {
   loadLocalState,
   setCurrentChatId as persistCurrentChatId,
@@ -46,6 +47,8 @@ export interface LimitReachedState {
   }
   /** Shared-pool provider that hit its limit (claude | gemini | opencode). */
   provider?: string
+  /** Subscription tier used to select a non-redundant upgrade path. */
+  plan?: Plan
   /** Unit the budget is measured in (tokens | cost | messages). */
   unit?: "tokens" | "cost" | "messages"
   /** Amount used / daily budget for that provider, in `unit`. */

--- a/packages/web/lib/usage-limit-copy.test.ts
+++ b/packages/web/lib/usage-limit-copy.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest"
+import {
+  formatUsageLimitMessage,
+  getLimitUpgradeCopy,
+} from "./usage-limit-copy"
+
+describe("formatUsageLimitMessage", () => {
+  it("describes Pro as a higher limit for free users", () => {
+    expect(formatUsageLimitMessage({
+      plan: "free",
+      provider: "claude",
+      unit: "tokens",
+      limit: 100_000,
+    })).toBe(
+      "Daily Claude limit reached (100,000 tokens). " +
+      "Upgrade to Pro for higher daily limits, upgrade to Unlimited for unlimited usage, " +
+      "or add your own Claude key."
+    )
+  })
+
+  it("only offers Unlimited or BYOK after a Pro user reaches the limit", () => {
+    expect(formatUsageLimitMessage({
+      plan: "pro",
+      provider: "gemini",
+      unit: "messages",
+      limit: 200,
+    })).toBe(
+      "Daily Gemini limit reached (200 messages). " +
+      "Upgrade to Unlimited for unlimited usage, or add your own Gemini key."
+    )
+  })
+
+  it("formats cost allowances without promising a plan upgrade to Unlimited users", () => {
+    expect(formatUsageLimitMessage({
+      plan: "unlimited",
+      provider: "opencode",
+      unit: "cost",
+      limit: 1,
+    })).toBe(
+      "Daily OpenCode limit reached ($1.00). Add your own OpenCode key to continue."
+    )
+  })
+})
+
+describe("getLimitUpgradeCopy", () => {
+  it("offers Pro with accurate benefits to free users", () => {
+    expect(getLimitUpgradeCopy("free")).toEqual({
+      targetPlan: "pro",
+      title: "Upgrade to Pro",
+      description: "Higher daily limits on all shared pools and priority support",
+    })
+  })
+
+  it("defaults older responses without a plan to the Free upsell", () => {
+    expect(getLimitUpgradeCopy(undefined)?.targetPlan).toBe("pro")
+  })
+
+  it("offers Unlimited instead of Pro to existing Pro users", () => {
+    expect(getLimitUpgradeCopy("pro")).toEqual({
+      targetPlan: "unlimited",
+      title: "Upgrade to Unlimited",
+      description: "Unlimited usage on all shared pools and priority support",
+    })
+  })
+
+  it("does not offer a redundant upgrade to Unlimited users", () => {
+    expect(getLimitUpgradeCopy("unlimited")).toBeNull()
+  })
+})

--- a/packages/web/lib/usage-limit-copy.ts
+++ b/packages/web/lib/usage-limit-copy.ts
@@ -1,0 +1,69 @@
+import type { ProviderName } from "@background-agents/common"
+import type { BudgetUnit, Plan } from "@/lib/server/usage-budgets"
+
+export type LimitUpgradeTarget = "pro" | "unlimited"
+
+export interface LimitUpgradeCopy {
+  targetPlan: LimitUpgradeTarget
+  title: string
+  description: string
+}
+
+const FREE_UPGRADE_COPY: LimitUpgradeCopy = {
+  targetPlan: "pro",
+  title: "Upgrade to Pro",
+  description: "Higher daily limits on all shared pools and priority support",
+}
+
+const PRO_UPGRADE_COPY: LimitUpgradeCopy = {
+  targetPlan: "unlimited",
+  title: "Upgrade to Unlimited",
+  description: "Unlimited usage on all shared pools and priority support",
+}
+
+const PROVIDER_LABELS: Partial<Record<ProviderName, string>> = {
+  claude: "Claude",
+  gemini: "Gemini",
+  opencode: "OpenCode",
+}
+
+export function isPlan(value: unknown): value is Plan {
+  return value === "free" || value === "pro" || value === "unlimited"
+}
+
+export function getLimitUpgradeCopy(plan: Plan | undefined): LimitUpgradeCopy | null {
+  if (plan === "unlimited") return null
+  if (plan === "pro") return PRO_UPGRADE_COPY
+  return FREE_UPGRADE_COPY
+}
+
+export function formatUsageLimitMessage({
+  plan,
+  provider,
+  unit,
+  limit,
+}: {
+  plan: Plan
+  provider: ProviderName
+  unit: BudgetUnit
+  limit: number
+}): string {
+  const providerLabel = PROVIDER_LABELS[provider]
+    ?? provider.charAt(0).toUpperCase() + provider.slice(1)
+  const allowance =
+    unit === "tokens"
+      ? `${limit.toLocaleString("en-US")} tokens`
+      : unit === "cost"
+        ? `$${limit.toFixed(2)}`
+        : `${limit.toLocaleString("en-US")} messages`
+
+  const nextStep =
+    plan === "free"
+      ? "Upgrade to Pro for higher daily limits, upgrade to Unlimited for unlimited usage, " +
+        `or add your own ${providerLabel} key.`
+      : plan === "pro"
+        ? `Upgrade to Unlimited for unlimited usage, or add your own ${providerLabel} key.`
+        : `Add your own ${providerLabel} key to continue.`
+
+  return `Daily ${providerLabel} limit reached (${allowance}). ${nextStep}`
+}


### PR DESCRIPTION
## Summary

- make shared-pool limit messages aware of the user's Free, Pro, or Unlimited plan
- preserve plan in the DAILY_LIMIT_EXCEEDED response, API client result, and dialog state
- describe Pro accurately as higher daily limits for Free users
- offer Unlimited instead of Pro after an existing Pro user reaches the doubled budget
- hide the plan-upgrade action for an inconsistent Unlimited-plan limit state
- direct upgrade emails to the plan actually shown in the dialog
- keep allowance formatting and plan copy in one pure, tested helper

## Root cause

PR #224 changed the plan contract from Pro = uncapped to:

- Free = base daily budget
- Pro = 2× the Free daily budget
- Unlimited = uncapped

The budget implementation and one modal description were updated, but three pieces remained out of sync:

1. the server error still said "Upgrade to Pro for unlimited usage"
2. the 429 response did not include the user's plan
3. the limit dialog always rendered "Upgrade to Pro", including for Pro users

## Evidence

### Source evidence before this change

- Incorrect server copy on main: https://github.com/jamesmurdza/background-agents/blob/76af78114a6245fefc753258c85c9216c7b611f6/packages/web/lib/db/usage-limit.ts#L127-L138
- Implemented Free/Pro/Unlimited budgets: https://github.com/jamesmurdza/background-agents/blob/76af78114a6245fefc753258c85c9216c7b611f6/packages/web/lib/server/usage-budgets.ts#L31-L57
- Plan-tier contract and migration: https://github.com/jamesmurdza/background-agents/pull/224
- Unconditional "Upgrade to Pro" dialog on main: https://github.com/jamesmurdza/background-agents/blob/76af78114a6245fefc753258c85c9216c7b611f6/packages/web/components/modals/LimitReachedDialog.tsx#L186-L206

### Before / after

| State | Before | After |
| --- | --- | --- |
| Free reaches a limit | "Upgrade to Pro for unlimited usage" | Pro is described as higher daily limits; Unlimited/BYOK are identified as uncapped |
| Pro reaches a limit | "Upgrade to Pro" | "Upgrade to Unlimited" |
| 429 API contract | plan omitted | plan preserved through client state |
| Inconsistent Unlimited limit state | "Upgrade to Pro" | plan-upgrade CTA hidden |

Example outputs verified from the new pure helper:

    free: Daily Claude limit reached (100,000 tokens). Upgrade to Pro for higher daily limits, upgrade to Unlimited for unlimited usage, or add your own Claude key.
    pro:  Daily Claude limit reached (200,000 tokens). Upgrade to Unlimited for unlimited usage, or add your own Claude key.

### Regression proof

The tests were run before implementation and failed in two independent places:

- the plan-aware copy module did not exist
- the 429 client result was expected to contain plan: "pro", but plan was missing

After implementation, both regressions pass.

A hosted screenshot is not used for this issue because reproducing the Pro state would require changing an account plan and exhausting a paid shared-pool budget. The immutable source links, plan implementation, exact output, and red/green regression tests provide deterministic evidence without modifying production account state.

## Verification

- [x] Focused regression suite: 2 files / 8 tests passed
- [x] Full web unit suite: 17 files / 157 tests passed
- [x] Isolated TypeScript check covering all changed files and imports passed
- [x] git diff --check passed
- [ ] Full npm run typecheck is blocked on this macOS checkout by the pre-existing Sidebar.tsx / sidebar.tsx case collision on main; no changed-file TypeScript errors remain
- [ ] Local dev/E2E was not run because DAYTONA_API_KEY, GITHUB_CLIENT_ID, and GITHUB_CLIENT_SECRET are not exported in this environment

Commands:

    npx vitest run --config packages/web/vitest.config.ts packages/web/lib/usage-limit-copy.test.ts packages/web/lib/chat-messages.test.ts
    cd packages/web && npx vitest run --config vitest.config.ts
    npx tsc --noEmit -p packages/web/tsconfig.usage-limit-copy.json

The final TypeScript command used a temporary untracked config containing only the changed files and their imports; it was removed after verification.

## Risks / Notes

- No changes to budget amounts, metering, reset windows, database schema, authentication, or authorization
- Missing plan values default to the existing Free upsell for backward compatibility
- Unlimited plans remain uncapped in enforcement; the hidden CTA is only defensive handling for inconsistent client state
- No production usage or account plan was changed during verification

Closes #387