### PR TITLE
fix(web): hide chat usage/delete/archive commands for draft chats

### DIFF
--- a/packages/web/lib/chat-state.test.ts
+++ b/packages/web/lib/chat-state.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest"
+import { nanoid } from "nanoid"
+import { DRAFT_CHAT_ID_PREFIX, isDraftChatId } from "./chat-state"
+
+describe("isDraftChatId", () => {
+  it("recognises an id built with the draft prefix", () => {
+    expect(isDraftChatId(`${DRAFT_CHAT_ID_PREFIX}${nanoid()}`)).toBe(true)
+  })
+
+  it("rejects a persisted chat id", () => {
+    expect(isDraftChatId("cmg1x2y3z0000abcdefghijkl")).toBe(false)
+  })
+
+  it("rejects an id that only contains the prefix", () => {
+    expect(isDraftChatId("chat-draft-123")).toBe(false)
+  })
+
+  it("treats a missing id as not a draft", () => {
+    expect(isDraftChatId(null)).toBe(false)
+    expect(isDraftChatId(undefined)).toBe(false)
+  })
+})

--- a/packages/web/lib/chat-state.ts
+++ b/packages/web/lib/chat-state.ts
@@ -12,6 +12,18 @@ import type { Chat, ChatStatus, QueuedMessage } from "@/lib/types"
 import type { PreviewState } from "@/lib/storage"
 
 /**
+ * Prefix for the client-only id a chat carries before it is written to the
+ * database. A draft chat exists in the browser only, so no server route can
+ * resolve its id — callers must check `isDraftChatId` before hitting the API.
+ */
+export const DRAFT_CHAT_ID_PREFIX = "draft-"
+
+/** True for a chat that lives only in the browser (no database row yet). */
+export function isDraftChatId(chatId: string | null | undefined): boolean {
+  return chatId?.startsWith(DRAFT_CHAT_ID_PREFIX) ?? false
+}
+
+/**
  * Client-only chat fields that are layered on top of the server's chat records.
  * Keyed by chat id.
  */

--- a/packages/web/lib/hooks/useChatWithSync.ts
+++ b/packages/web/lib/hooks/useChatWithSync.ts
@@ -32,6 +32,7 @@ import { useMessageDispatch } from "./useMessageDispatch"
 import {
   mergeLocalState,
   computeUnseenTransitions,
+  isDraftChatId as isDraftChatIdPure,
 } from "@/lib/chat-state"
 
 // =============================================================================
@@ -137,7 +138,7 @@ export function useChatWithSync() {
 
   // Helper to check if a chat ID is a draft
   const isDraftChatId = useCallback((chatId: string | null): boolean => {
-    return chatId?.startsWith("draft-") ?? false
+    return isDraftChatIdPure(chatId)
   }, [])
 
   // Materialize a draft chat into a real database chat

--- a/packages/web/lib/hooks/usePaletteProps.ts
+++ b/packages/web/lib/hooks/usePaletteProps.ts
@@ -11,6 +11,7 @@ import type { useModals, useSidebar } from "@/lib/contexts"
 import type { usePreview } from "@/lib/hooks/usePreview"
 import { useGitHubUserQuery } from "@/lib/query"
 import { getChatRepos } from "@/components/sidebar"
+import { isDraftChatId } from "@/lib/chat-state"
 
 /** All props the PaletteProvider takes, minus `children` (supplied by JSX). */
 export type PaletteProps = Omit<React.ComponentProps<typeof PaletteProvider>, "children">
@@ -110,6 +111,11 @@ export function usePaletteProps({
   const sandboxId = currentChat?.sandboxId ?? null
   const hasRepo = isRealRepo(currentChat?.repo)
 
+  // Commands that address a chat row on the server (usage, delete, archive) are
+  // only offered once the chat has been written to the database. A draft chat
+  // lives in the browser only, so those requests would 404.
+  const savedChatId = isDraftChatId(displayCurrentChatId) ? null : displayCurrentChatId
+
   // Find or create a uniquely-numbered terminal id for this sandbox. We scan
   // existing terminal preview items, pull the trailing `-<n>` suffix from each,
   // and pick the next integer above the highest one we've seen.
@@ -165,8 +171,8 @@ export function usePaletteProps({
     onCreateRepo: currentChat?.repo === NEW_REPOSITORY ? handleCreateRepo : undefined,
     showGitCommands: hasRepo,
     onOpenInGitHub: githubBranchUrl ? handleOpenInGitHub : undefined,
-    onOpenChatUsage: displayCurrentChatId
-      ? () => modals.openChatUsage(displayCurrentChatId)
+    onOpenChatUsage: savedChatId
+      ? () => modals.openChatUsage(savedChatId)
       : undefined,
     onOpenSettings: modals.openSettingsSection,
     onToggleSidebar: !isMobile ? () => sidebar.toggleCollapse() : undefined,
@@ -177,12 +183,12 @@ export function usePaletteProps({
           signOut()
         }
       : undefined,
-    onDeleteChat: displayCurrentChatId
-      ? () => modals.setDeleteConfirmChatId(displayCurrentChatId)
+    onDeleteChat: savedChatId
+      ? () => modals.setDeleteConfirmChatId(savedChatId)
       : undefined,
     onArchiveChat:
-      displayCurrentChatId && !currentChat?.archived
-        ? () => handleArchiveChat(displayCurrentChatId)
+      savedChatId && !currentChat?.archived
+        ? () => handleArchiveChat(savedChatId)
         : undefined,
     onOpenInVSCode: sandboxId ? handleOpenInVSCode : undefined,
     onOpenTerminal: sandboxId ? openNewTerminal : undefined,

--- a/packages/web/lib/stores/chat-sync-store.ts
+++ b/packages/web/lib/stores/chat-sync-store.ts
@@ -34,6 +34,7 @@ import {
   migrateLocalChatState,
   upsertDraft,
   computeNextPreviewState,
+  DRAFT_CHAT_ID_PREFIX,
   type LocalChatState,
 } from "@/lib/chat-state"
 
@@ -163,7 +164,7 @@ export const useChatSyncStore = create<ChatSyncStore>((set, get) => ({
   },
 
   enterDraftMode: (repo, baseBranch, agent, model) => {
-    const draftId = `draft-${nanoid()}`
+    const draftId = `${DRAFT_CHAT_ID_PREFIX}${nanoid()}`
     const config: DraftChatConfig = { id: draftId, repo, baseBranch, agent, model }
     set({ draftChatConfig: config, currentChatId: draftId })
     setDraftChatConfig(config)


### PR DESCRIPTION
## What this changes

The command palette offered "Chat usage", "Delete chat", and "Archive chat" for
draft chats. A draft chat has no row in the database, so its id is a
browser-only string like `draft-V1StGXR8`, and every one of those three commands
sends that id to a server route that can only resolve a real chat id. Picking any
of them returned a 404.

The palette now offers the three commands only after the chat has been written to
the database. `usePaletteProps` computes a `savedChatId` that is null while the
chat is a draft, and the three handlers read from it, so they stay undefined and
the commands don't appear.

## How the draft check is shared

The check for a draft id was written inline in two places, as
`chatId?.startsWith("draft-")` in `useChatWithSync` and as the literal
`` `draft-${nanoid()}` `` in `chat-sync-store`. The prefix is now
`DRAFT_CHAT_ID_PREFIX` in `lib/chat-state.ts`, alongside an `isDraftChatId`
helper, and all three call sites use them. The store builds new draft ids from
the same constant, so the prefix it writes and the prefix the palette checks
can't drift apart.

`lib/chat-state.ts` was the right home for it because it already holds the pure
client-side chat state helpers, and it has no React or store dependencies, so the
palette hook, the sync hook, and the store can all import from it.

## Screenshots

On `main` the palette lists usage, delete, and archive while the chat is still a
draft. After this change, the palette omits them, and they come back once the
first message is sent and the chat is saved.

| | |
|---|---|
| Before, chat token usage | <img width="1469" height="668" alt="404 for token usage" src="https://github.com/user-attachments/assets/f4458754-24e7-4cfd-85de-ea9eb2f7f503" /> |
| Before, Command view | <img width="1469" height="668" alt="Command view" src="https://github.com/user-attachments/assets/02963fe8-ae00-49ac-a02f-fac05e2b06ca" /> |
| After, Signed out | <img width="1469" height="522" alt="Signed out" src="https://github.com/user-attachments/assets/e769a14b-a999-4207-bf5e-805d757f93df" /> |
| After, Signed in, before any chat is started | <img width="1469" height="668" alt="signed in, no chat" src="https://github.com/user-attachments/assets/ede6d0b1-1ce4-4b85-a67d-23e5d3c37993" /> |
| After, Signed in, after the first message is sent | <img width="1469" height="668" alt="signed in, after first message" src="https://github.com/user-attachments/assets/3f3ca81e-5f6a-492c-977a-f40d07864b63" /> |




## Tests

`packages/web/lib/chat-state.test.ts` covers `isDraftChatId` against an id built
from the prefix, a persisted chat id, an id that contains "draft-" somewhere
other than the start, and a null or undefined id.
