### PR TITLE
Feat/claude cost pool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ __v0_jsx-dev-runtime.ts
 
 # macOS screenshots dropped into the repo root (uploaded in chat, not project files)
 Screenshot*.png
+
+# Backfill snapshots (originals dumped before a repricing run)
+packages/web/scripts/*.backup.*.json

--- a/packages/web/app/admin/page.tsx
+++ b/packages/web/app/admin/page.tsx
@@ -70,19 +70,32 @@ const USAGE_PROVIDERS: { key: UsageProvider; label: string }[] = [
 
 // Tokens vs cost for the usage section. Independent of a provider's budget unit
 // — OpenCode is budgeted in USD, but its token volume is still worth seeing.
-//
-// Cost is offered for OpenCode only. It's the one provider billed per token, so
-// its dollar figure is money we actually spend. Claude runs on a flat
-// subscription through the rotating credential and Gemini on a shared key, so a
-// per-token cost there is a notional API-equivalent price rather than spend —
-// showing it would invite adding up numbers that don't correspond to a bill.
 const USAGE_METRICS: { key: UsageMetric; label: string }[] = [
   { key: "tokens", label: "Tokens" },
   { key: "cost", label: "Cost" },
 ]
 
-/** Providers billed per token, where a cost figure reflects real spend. */
-const METERED_PROVIDERS: ReadonlySet<UsageProvider> = new Set<UsageProvider>(["opencode"])
+/**
+ * Providers whose usage is worth looking at in dollars.
+ *
+ * OpenCode because it's billed per token, so the figure is money we spend.
+ * Claude because its shared pool is *budgeted* in dollars — the admin view has
+ * to show the same measure the limiter enforces, or there's no way to see why
+ * someone hit their cap. Gemini stays out: it's capped by message count, so a
+ * dollar figure there answers no question anyone is asking.
+ */
+const COST_PROVIDERS: ReadonlySet<UsageProvider> = new Set<UsageProvider>([
+  "opencode",
+  "claude",
+])
+
+/**
+ * Of those, the ones where a dollar is an actual bill. Claude runs on a flat
+ * subscription, so its cost is API-equivalent value — real for comparing users
+ * and models against each other, but not a number that shows up on an invoice.
+ * Labelled as such rather than hidden, so nobody totals it as spend.
+ */
+const BILLED_PROVIDERS: ReadonlySet<UsageProvider> = new Set<UsageProvider>(["opencode"])
 
 type SectionKey = "overview" | "users" | "activity" | "credentials"
 
@@ -137,12 +150,16 @@ export default function AdminDashboard() {
   // Overview's pool filter or its "all" range.
   const [usageProvider, setUsageProvider] = useState<UsageProvider>("opencode")
   const [usageMetric, setUsageMetric] = useState<UsageMetric>("tokens")
-  // Cost only means something for a metered provider. Rather than resetting the
-  // stored preference when switching to Claude/Gemini, derive the effective
-  // metric — so returning to OpenCode lands you back on Cost if that's where you
-  // were, and the view can never be left showing a figure with no toggle to escape.
-  const costSupported = METERED_PROVIDERS.has(usageProvider)
+  // Cost only means something for a provider whose usage is denominated in it.
+  // Rather than resetting the stored preference when switching to Gemini, derive
+  // the effective metric — so returning to OpenCode or Claude lands you back on
+  // Cost if that's where you were, and the view can never be left showing a
+  // figure with no toggle to escape.
+  const costSupported = COST_PROVIDERS.has(usageProvider)
   const effectiveUsageMetric: UsageMetric = costSupported ? usageMetric : "tokens"
+  // Dollars that aren't an invoice line need saying so, once, next to the number.
+  const costIsNotional =
+    effectiveUsageMetric === "cost" && !BILLED_PROVIDERS.has(usageProvider)
   // The distribution view is day-bucketed, so it has no "all" range. Follow the
   // global range where it can and fall back to 30d for "all".
   const usageRange: UsageRange = globalTimeRange === "all" ? "30d" : globalTimeRange
@@ -515,11 +532,13 @@ export default function AdminDashboard() {
                   <p className="text-xs text-muted-foreground">
                     Where our credential spend goes
                     {globalTimeRange === "all" && " · last 30 days"}
+                    {costIsNotional &&
+                      " · API-equivalent value on a flat subscription, not a bill"}
                   </p>
                 </div>
                 <div className="flex flex-wrap items-center gap-2 sm:gap-3">
-                  {/* Hidden entirely for subscription-backed providers — see
-                      METERED_PROVIDERS. With one option left there's nothing to
+                  {/* Hidden for providers with no meaningful cost view — see
+                      COST_PROVIDERS. With one option left there's nothing to
                       toggle, so the control disappears rather than showing a
                       single dead button. */}
                   {costSupported && (

--- a/packages/web/app/api/user/settings/route.ts
+++ b/packages/web/app/api/user/settings/route.ts
@@ -22,6 +22,7 @@ import {
   validateEndpoints,
 } from "@/lib/server/custom-endpoints"
 import type { Settings } from "@/lib/types"
+import type { BudgetUnit } from "@/lib/server/usage-budgets"
 import { DEFAULT_SETTINGS } from "@/lib/storage"
 
 interface SettingsResponse {
@@ -31,11 +32,13 @@ interface SettingsResponse {
   customEndpoints: CustomEndpoint[]
   /** ISO timestamp when the daily Claude limit resets, or null if not limited */
   claudeLimitResetAt: string | null
-  /** Remaining Claude Code messages today, or null if not applicable */
+  /** Unit the three amounts below are in — "cost" (USD) for the Claude pool. */
+  claudeLimitUnit: BudgetUnit
+  /** Remaining Claude allowance today, or null if not applicable */
   claudeLimitRemaining: number | null
-  /** Number of shared Claude messages used in current period, or null if not using shared pool */
+  /** Claude allowance used in the current period, or null if not using shared pool */
   claudeLimitUsed: number | null
-  /** Daily limit (10 for free users), or null if pro/unlimited */
+  /** Daily budget for free/pro, or null if unlimited */
   claudeLimitTotal: number | null
   /** Whether user is a pro subscriber */
   claudeIsPro: boolean
@@ -79,6 +82,7 @@ export async function GET(): Promise<Response> {
       credentialFlags: effective.flags,
       customEndpoints: decryptUserEndpoints(user?.customEndpoints),
       claudeLimitResetAt: effective.limitResetAt?.toISOString() ?? null,
+      claudeLimitUnit: effective.limitUnit,
       claudeLimitRemaining: effective.limitRemaining,
       claudeLimitUsed: effective.limitUsed,
       claudeLimitTotal: effective.limitTotal,
@@ -171,6 +175,7 @@ export async function PATCH(req: NextRequest): Promise<Response> {
         newEndpoints ?? (user?.customEndpoints as unknown)
       ),
       claudeLimitResetAt: effective.limitResetAt?.toISOString() ?? null,
+      claudeLimitUnit: effective.limitUnit,
       claudeLimitRemaining: effective.limitRemaining,
       claudeLimitUsed: effective.limitUsed,
       claudeLimitTotal: effective.limitTotal,

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -111,6 +111,7 @@ function HomePageContent({ isMobile }: HomePageContentProps) {
     settings,
     credentialFlags,
     claudeLimitResetAt,
+    claudeLimitUnit,
     claudeLimitUsed,
     claudeLimitTotal,
     isHydrated,
@@ -641,6 +642,7 @@ function HomePageContent({ isMobile }: HomePageContentProps) {
                     setLimitReachedState({
                       show: true,
                       provider: "claude",
+                      unit: claudeLimitUnit,
                       used: claudeLimitUsed,
                       limit: claudeLimitTotal,
                       resetAt: claudeLimitResetAt ? new Date(claudeLimitResetAt) : undefined,

--- a/packages/web/components/admin/UsageByUserTable.tsx
+++ b/packages/web/components/admin/UsageByUserTable.tsx
@@ -10,10 +10,13 @@ interface UsageByUserTableProps {
   users: UserUsage[]
   metric: UsageMetric
   /**
-   * Whether a dollar figure means real spend for this provider. False for
-   * subscription-backed pools (Claude, Gemini), where tokscale's cost is a
-   * notional API-equivalent price — the Cost column is dropped from the
-   * per-model detail rather than shown as if it were a bill.
+   * Whether a dollar figure says anything useful for this provider. True for
+   * OpenCode (billed per token) and Claude (shared pool budgeted in dollars, so
+   * per-model cost is what explains a user hitting their cap). False for Gemini,
+   * capped by message count — the Cost column is dropped from the per-model
+   * detail rather than shown as a number nobody can act on. Whether those
+   * dollars are an actual invoice line is a separate question, labelled at the
+   * section header.
    */
   showCost?: boolean
   isLoading?: boolean

--- a/packages/web/components/modals/LimitReachedDialog.tsx
+++ b/packages/web/components/modals/LimitReachedDialog.tsx
@@ -40,11 +40,13 @@ const PROVIDER_LABEL: Record<string, string> = {
 
 type BudgetUnit = "tokens" | "cost" | "messages"
 
-/** Map provider to its budget unit. Mirrors server usage-budgets. */
+/**
+ * Map provider to its budget unit. Mirrors server usage-budgets, and is only a
+ * fallback for a caller that didn't pass the server-resolved unit.
+ */
 function unitForProvider(provider?: string): BudgetUnit {
-  if (provider === "opencode") return "cost"
   if (provider === "gemini") return "messages"
-  return "tokens"
+  return "cost"
 }
 
 export function LimitReachedDialog({

--- a/packages/web/components/modals/settings/UsageSection.tsx
+++ b/packages/web/components/modals/settings/UsageSection.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils"
 import { MobileSectionHeader } from "./shared"
 import type { UsageResponse, PoolUsage } from "@/app/api/user/usage/route"
 import { fmtBudgetAmount } from "@/lib/format"
+import { PRO_BUDGET_MULTIPLIER } from "@/lib/server/usage-budgets"
 
 /** Tailwind classes for the bar fill based on how close to the limit we are. */
 function fillClass(pct: number): string {
@@ -66,10 +67,10 @@ interface UsageSectionProps {
 }
 
 /**
- * Daily token usage for each shared credential pool. Free and Pro users see
- * their usage against the per-provider daily budget (Pro's is 3× the free one);
- * unlimited-plan users and own-key providers show as unlimited. The "tokens"
- * shown are the cache-excluded limited measure that the rate limiter counts.
+ * Daily usage for each shared credential pool, in that pool's own budget unit
+ * (USD for Claude and OpenCode, messages for Gemini). Free and Pro users see
+ * their usage against the per-provider daily budget (Pro's is PRO_BUDGET_MULTIPLIER×
+ * the free one); unlimited-plan users and own-key providers show as unlimited.
  */
 export function UsageSection({ isMobile }: UsageSectionProps) {
   const [data, setData] = useState<UsageResponse | null>(null)
@@ -100,8 +101,8 @@ export function UsageSection({ isMobile }: UsageSectionProps) {
 
       <p className="text-xs text-muted-foreground mb-2">
         Daily usage on the shared credential pools. Resets at 00:00 UTC. Each
-        pool has its own limit (tokens, cost, or messages); cache reads
-        aren&apos;t counted.
+        pool has its own limit, measured in whatever best reflects its cost
+        (spend, or messages).
       </p>
 
       {error ? (
@@ -126,7 +127,7 @@ export function UsageSection({ isMobile }: UsageSectionProps) {
             </p>
           ) : data.plan === "pro" ? (
             <p className="text-[11px] text-primary mt-2">
-              Pro plan — 3× the free daily budget on each shared pool.
+              Pro plan — {PRO_BUDGET_MULTIPLIER}× the free daily budget on each shared pool.
             </p>
           ) : null}
         </div>

--- a/packages/web/lib/chat-messages.ts
+++ b/packages/web/lib/chat-messages.ts
@@ -2,13 +2,11 @@
 //
 // Extracted from useChatWithSync. The cache-update transforms here are the
 // fiddly "given a chat, produce the next chat" steps of an optimistic send
-// (apply, roll back, succeed, error) plus the agent/model resolution and the
-// shared-pool predicate. They're pure and deterministic, so they're unit-tested
+// (apply, roll back, succeed, error) plus the agent/model resolution. They're
+// pure and deterministic, so they're unit-tested
 // in chat-messages.test.ts instead of being buried inline in the hook.
 
-import type { Chat, Message, CredentialFlags } from "@/lib/types"
-import { sharedClaudePoolEligible } from "@/lib/types"
-import type { SettingsData } from "@/lib/query"
+import type { Chat, Message } from "@/lib/types"
 import type { Plan } from "@/lib/server/usage-budgets"
 import { isPlan } from "@/lib/usage-limit-copy"
 import { generateBranchName } from "@/lib/utils"
@@ -133,15 +131,6 @@ export async function sendMessageToApi(
 // Pure resolution helpers
 // =============================================================================
 
-/**
- * Whether this send draws from the shared Claude pool (Claude Code, no personal
- * Anthropic credentials, shared pool available) — used to optimistically
- * decrement the usage counter.
- */
-export function usesSharedClaudePool(agent: string, flags: CredentialFlags): boolean {
-  return agent === "claude-code" && sharedClaudePoolEligible(flags)
-}
-
 /** Branch arg for the send payload: a new agent branch unless the sandbox exists. */
 export function newBranchForSend(chat: Pick<Chat, "sandboxId">): string | undefined {
   return chat.sandboxId ? undefined : `agent/${generateBranchName()}`
@@ -215,15 +204,3 @@ export function applySendError(chat: Chat, assistantMessageId: string, errorMess
   }
 }
 
-/** Optimistically decrement the shared-pool Claude usage counter. No-op if unknown. */
-export function decrementClaudeUsage(old: SettingsData | undefined): SettingsData | undefined {
-  if (!old || old.claudeLimitUsed === null || old.claudeLimitUsed === undefined) return old
-  return {
-    ...old,
-    claudeLimitUsed: old.claudeLimitUsed + 1,
-    claudeLimitRemaining:
-      old.claudeLimitRemaining !== null && old.claudeLimitRemaining !== undefined
-        ? Math.max(0, old.claudeLimitRemaining - 1)
-        : null,
-  }
-}

--- a/packages/web/lib/db/token-usage.ts
+++ b/packages/web/lib/db/token-usage.ts
@@ -9,7 +9,11 @@
  *
  * `sumSharedUsage` is the read path the rate limiter uses: total tokens/cost a
  * user has consumed from a given shared pool since the start of the period.
+ * `sumSharedUsageInUnit` wraps it (and the message count) to answer in whatever
+ * unit a pool's budget is denominated in.
  */
+
+import type { BudgetUnit } from "@/lib/server/usage-budgets"
 
 import { prisma } from "./prisma"
 
@@ -281,4 +285,24 @@ export async function sumSharedUsage(params: {
     },
   })
   return toTotals(agg._sum)
+}
+
+/**
+ * A user's shared-pool usage for one provider since `since`, expressed in that
+ * provider's budget unit. The one place that knows how each unit maps onto the
+ * ledger — the limiter, the settings limit display and the usage view all read
+ * through it, so they can't disagree about what "used" means.
+ */
+export async function sumSharedUsageInUnit(params: {
+  userId: string
+  provider: string
+  unit: BudgetUnit
+  since: Date
+}): Promise<number> {
+  const { userId, provider, unit, since } = params
+  if (unit === "messages") {
+    return countSharedMessages({ userId, provider, since })
+  }
+  const { limitedTokens, costUsd } = await sumSharedUsage({ userId, provider, since })
+  return unit === "cost" ? costUsd : limitedTokens
 }

--- a/packages/web/lib/db/usage-limit.ts
+++ b/packages/web/lib/db/usage-limit.ts
@@ -1,20 +1,21 @@
 /**
- * Token-based usage limits for the shared credential pools.
+ * Usage limits for the shared credential pools.
  *
- * Free users get a daily, per-provider, cache-excluded token budget when using
- * a shared pool (Claude OAuth / Gemini / OpenCode server keys). Pro users get
- * the same daily budget scaled by PRO_BUDGET_MULTIPLIER; only `unlimited`-plan
- * users (and anyone running on their own key) are uncapped. Usage is summed from
- * the TokenUsage ledger (populated post-turn by tokscale metering).
+ * Free users get a daily, per-provider budget when using a shared pool (Claude
+ * OAuth / Gemini / OpenCode server keys), denominated in whatever unit that pool
+ * is metered in — see lib/server/usage-budgets. Pro users get the same budget
+ * scaled by PRO_BUDGET_MULTIPLIER; only `unlimited`-plan users (and anyone
+ * running on their own key) are uncapped. Usage is summed from the TokenUsage
+ * ledger (populated post-turn by tokscale metering).
  *
- * Because a turn's token cost is only known after it runs, enforcement is
- * post-hoc: we block the NEXT turn once the period's usage has met the budget.
+ * Because a turn's cost is only known after it runs, enforcement is post-hoc:
+ * we block the NEXT turn once the period's usage has met the budget.
  */
 
 import type { Agent, ProviderName } from "@background-agents/common"
 
 import { prisma } from "./prisma"
-import { sumSharedUsage, countSharedMessages } from "./token-usage"
+import { sumSharedUsageInUnit } from "./token-usage"
 import { providerForRun, resolvePool } from "@/lib/server/shared-pool"
 import { decryptUserCredentials } from "./api-helpers"
 import { formatUsageLimitMessage } from "@/lib/usage-limit-copy"
@@ -94,8 +95,12 @@ export async function checkSharedPoolUsage(
     return { ...base, allowed: true, limit: null, remaining: null }
   }
 
-  const since = getStartOfUtcDay()
-  const used = await getSharedUsage(userId, provider, budget.unit, since)
+  const used = await sumSharedUsageInUnit({
+    userId,
+    provider,
+    unit: budget.unit,
+    since: getStartOfUtcDay(),
+  })
 
   const remaining = Math.max(0, budget.limit - used)
   const allowed = used < budget.limit
@@ -111,18 +116,4 @@ export async function checkSharedPoolUsage(
       ? undefined
       : formatUsageLimitMessage({ plan, provider, unit: budget.unit, limit: budget.limit }),
   }
-}
-
-/** Usage in the period, measured in the provider's budget unit. */
-async function getSharedUsage(
-  userId: string,
-  provider: ProviderName,
-  unit: BudgetUnit,
-  since: Date
-): Promise<number> {
-  if (unit === "messages") {
-    return countSharedMessages({ userId, provider, since })
-  }
-  const { limitedTokens, costUsd } = await sumSharedUsage({ userId, provider, since })
-  return unit === "cost" ? costUsd : limitedTokens
 }

--- a/packages/web/lib/format.ts
+++ b/packages/web/lib/format.ts
@@ -19,12 +19,15 @@ export function fmtTokens(n: number): string {
 
 /**
  * Format a usage amount in its budget unit:
- *   cost     → "$1.23"
+ *   cost     → "$1.23", or "<$0.01" for a nonzero amount that rounds to nothing
  *   messages → "3 messages" / "1 message"
  *   tokens   → "12.3K tokens"
+ *
+ * The sub-cent case matters: a daily cost budget is a fraction of a dollar, so
+ * the first turn of the day would otherwise read "$0.00 used" and look broken.
  */
 export function fmtBudgetAmount(n: number, unit: "tokens" | "cost" | "messages"): string {
-  if (unit === "cost") return `$${n.toFixed(2)}`
+  if (unit === "cost") return n > 0 && n < 0.005 ? "<$0.01" : `$${n.toFixed(2)}`
   if (unit === "messages") {
     const m = Math.round(n)
     return `${m} ${m === 1 ? "message" : "messages"}`

--- a/packages/web/lib/hooks/useChatWithSync.ts
+++ b/packages/web/lib/hooks/useChatWithSync.ts
@@ -99,6 +99,7 @@ export function useChatWithSync() {
   const settings = settingsQuery.data?.settings ?? DEFAULT_SETTINGS
   const credentialFlags = settingsQuery.data?.credentialFlags ?? {}
   const claudeLimitResetAt = settingsQuery.data?.claudeLimitResetAt ?? null
+  const claudeLimitUnit = settingsQuery.data?.claudeLimitUnit
   const claudeLimitUsed = settingsQuery.data?.claudeLimitUsed ?? null
   const claudeLimitTotal = settingsQuery.data?.claudeLimitTotal ?? null
   const claudeLimitRemaining = settingsQuery.data?.claudeLimitRemaining ?? null
@@ -344,6 +345,7 @@ export function useChatWithSync() {
     settings,
     credentialFlags,
     claudeLimitResetAt,
+    claudeLimitUnit,
     claudeLimitUsed,
     claudeLimitTotal,
     claudeLimitRemaining,

--- a/packages/web/lib/hooks/useMessageDispatch.ts
+++ b/packages/web/lib/hooks/useMessageDispatch.ts
@@ -26,13 +26,11 @@ import { queryKeys, type SettingsData } from "@/lib/query"
 import { resolveAgentAndModel } from "@/lib/types"
 import {
   sendMessageToApi,
-  usesSharedClaudePool,
   newBranchForSend,
   applyOptimisticSend,
   removeOptimisticMessages,
   applySendSuccess,
   applySendError,
-  decrementClaudeUsage,
   type SendMessagePayload,
 } from "@/lib/chat-messages"
 
@@ -240,11 +238,6 @@ export function useMessageDispatch({
         ))
 
         startStreaming(chatId, data.sandboxId, "project", data.backgroundSessionId, assistantMessage.id, data.previewUrlPattern ?? undefined, data.branch, undefined, planMode)
-
-        // Optimistically update Claude usage count if using shared pool with Claude Code
-        if (usesSharedClaudePool(selectedAgent, credentialFlags)) {
-          queryClient.setQueryData<SettingsData>(queryKeys.settings.all, decrementClaudeUsage)
-        }
 
         if (isFirstMessage) {
           suggestNameMutation.mutate({ chatId, prompt: content })

--- a/packages/web/lib/query/hooks/useSettingsQuery.ts
+++ b/packages/web/lib/query/hooks/useSettingsQuery.ts
@@ -6,6 +6,7 @@ import { useSession } from "next-auth/react"
 import { queryKeys } from "../keys"
 import { fetchSettings, fetchSharedPoolFlags } from "@/lib/sync/api"
 import type { Settings, CredentialFlags, CustomEndpoint } from "@/lib/types"
+import type { BudgetUnit } from "@/lib/server/usage-budgets"
 import { DEFAULT_SETTINGS } from "@/lib/storage"
 
 export interface SettingsData {
@@ -13,6 +14,7 @@ export interface SettingsData {
   credentialFlags: CredentialFlags
   customEndpoints?: CustomEndpoint[]
   claudeLimitResetAt?: string | null
+  claudeLimitUnit?: BudgetUnit
   claudeLimitRemaining?: number | null
   claudeLimitUsed?: number | null
   claudeLimitTotal?: number | null
@@ -58,6 +60,7 @@ export function useSettingsQuery() {
         credentialFlags: response.credentialFlags,
         customEndpoints: response.customEndpoints,
         claudeLimitResetAt: response.claudeLimitResetAt,
+        claudeLimitUnit: response.claudeLimitUnit,
         claudeLimitRemaining: response.claudeLimitRemaining,
         claudeLimitUsed: response.claudeLimitUsed,
         claudeLimitTotal: response.claudeLimitTotal,

--- a/packages/web/lib/server/claude-pricing.test.ts
+++ b/packages/web/lib/server/claude-pricing.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for first-party Claude pricing.
+ */
+import { describe, it, expect } from "vitest"
+
+import { normalizeClaudeModel, priceClaudeTurn } from "./claude-pricing"
+
+const NO_TOKENS = {
+  inputTokens: 0,
+  outputTokens: 0,
+  cacheReadTokens: 0,
+  cacheWriteTokens: 0,
+  reasoningTokens: 0,
+}
+
+describe("normalizeClaudeModel", () => {
+  it("normalizes current ids, with and without a release date", () => {
+    expect(normalizeClaudeModel("claude-opus-4-5")).toBe("opus-4.5")
+    expect(normalizeClaudeModel("claude-opus-4-5-20251101")).toBe("opus-4.5")
+    expect(normalizeClaudeModel("claude-sonnet-4-6")).toBe("sonnet-4.6")
+    expect(normalizeClaudeModel("claude-haiku-4-5-20251001")).toBe("haiku-4.5")
+  })
+
+  it("does not read a release date as the minor version", () => {
+    expect(normalizeClaudeModel("claude-opus-5")).toBe("opus-5")
+    expect(normalizeClaudeModel("claude-opus-5-20260101")).toBe("opus-5")
+    expect(normalizeClaudeModel("claude-sonnet-5-20260315")).toBe("sonnet-5")
+  })
+
+  it("accepts dotted versions, vendor prefixes and suffixes", () => {
+    expect(normalizeClaudeModel("claude-opus-4.8")).toBe("opus-4.8")
+    expect(normalizeClaudeModel("anthropic/claude-sonnet-5")).toBe("sonnet-5")
+    expect(normalizeClaudeModel("us.anthropic.claude-opus-4-5-20251101-v1:0")).toBe(
+      "opus-4.5"
+    )
+    expect(normalizeClaudeModel("claude-opus-4-6-thinking")).toBe("opus-4.6")
+    expect(normalizeClaudeModel("CLAUDE-OPUS-5")).toBe("opus-5")
+  })
+
+  it("handles the legacy version-first ordering", () => {
+    expect(normalizeClaudeModel("claude-3-5-haiku-20241022")).toBe("haiku-3.5")
+  })
+
+  it("returns null for non-Claude and empty ids", () => {
+    expect(normalizeClaudeModel("gpt-5.3")).toBeNull()
+    expect(normalizeClaudeModel("glm-5.2")).toBeNull()
+    expect(normalizeClaudeModel(null)).toBeNull()
+    expect(normalizeClaudeModel("")).toBeNull()
+  })
+})
+
+describe("priceClaudeTurn", () => {
+  it("prices base input and output at the published rates", () => {
+    // Opus 5: $5/MTok in, $25/MTok out.
+    const cost = priceClaudeTurn("claude-opus-5", {
+      ...NO_TOKENS,
+      inputTokens: 50_000,
+      outputTokens: 15_000,
+    })
+    // 50k × $5/M = $0.25, 15k × $25/M = $0.375 — the worked example from
+    // Anthropic's pricing page, minus its session-runtime line.
+    expect(cost).toBeCloseTo(0.625, 10)
+  })
+
+  it("prices cache reads at 0.1x and cache writes at 1.25x base input", () => {
+    const cost = priceClaudeTurn("claude-opus-5", {
+      ...NO_TOKENS,
+      cacheReadTokens: 40_000,
+      cacheWriteTokens: 8_000,
+    })
+    // 40k × $5 × 0.1/M = $0.02; 8k × $5 × 1.25/M = $0.05
+    expect(cost).toBeCloseTo(0.07, 10)
+  })
+
+  it("bills reasoning tokens at the output rate", () => {
+    const cost = priceClaudeTurn("claude-sonnet-5", {
+      ...NO_TOKENS,
+      reasoningTokens: 10_000,
+    })
+    // Sonnet 5 output is $10/MTok.
+    expect(cost).toBeCloseTo(0.1, 10)
+  })
+
+  it("scales with the model tier", () => {
+    const tokens = { ...NO_TOKENS, inputTokens: 1_000_000, outputTokens: 1_000_000 }
+    expect(priceClaudeTurn("claude-haiku-4-5", tokens)).toBeCloseTo(6, 10)
+    expect(priceClaudeTurn("claude-sonnet-5", tokens)).toBeCloseTo(12, 10)
+    expect(priceClaudeTurn("claude-sonnet-4-6", tokens)).toBeCloseTo(18, 10)
+    expect(priceClaudeTurn("claude-opus-5", tokens)).toBeCloseTo(30, 10)
+    expect(priceClaudeTurn("claude-fable-5", tokens)).toBeCloseTo(60, 10)
+    expect(priceClaudeTurn("claude-opus-4-1", tokens)).toBeCloseTo(90, 10)
+  })
+
+  it("returns 0 for a known model with no tokens", () => {
+    expect(priceClaudeTurn("claude-opus-5", NO_TOKENS)).toBe(0)
+  })
+
+  it("returns null for models it has no rates for", () => {
+    expect(priceClaudeTurn("gpt-5.3", { ...NO_TOKENS, outputTokens: 1000 })).toBeNull()
+    // A Claude family/version that isn't in the table.
+    expect(
+      priceClaudeTurn("claude-3-7-sonnet-20250219", { ...NO_TOKENS, outputTokens: 1000 })
+    ).toBeNull()
+    expect(priceClaudeTurn(null, NO_TOKENS)).toBeNull()
+  })
+})

--- a/packages/web/lib/server/claude-pricing.ts
+++ b/packages/web/lib/server/claude-pricing.ts
@@ -1,0 +1,143 @@
+/**
+ * First-party Claude token pricing.
+ *
+ * The shared Claude pool is budgeted in USD, so the dollar figure that gates a
+ * user has to be one we can defend. tokscale reports a cost of its own, but it
+ * derives it from LiteLLM's price table fetched over the network at run time
+ * (falling back to models.dev / OpenRouter), keyed by whatever model id the CLI
+ * happened to write. A miss there is silent and yields $0 — i.e. an unmetered
+ * turn. So for the Claude pool we price the turn ourselves from the token
+ * counts tokscale reports, using Anthropic's published rates, and fall back to
+ * tokscale's cost only for models we don't recognise.
+ *
+ * Rates: https://platform.claude.com/docs/en/about-claude/pricing (checked
+ * 2026-08-30). Only base input and output are listed per model — the cache
+ * rates are fixed multipliers of base input, per the same page:
+ *   5-minute cache write  1.25× input
+ *   1-hour cache write    2×    input
+ *   cache read (hit)      0.1×  input
+ *
+ * Not modelled (none of it applies to a Claude Code turn on the shared pool):
+ * batch discounts, the `inference_geo: "us"` 1.1× multiplier, fast mode, and
+ * server-side tool surcharges such as web search.
+ */
+
+/** USD per million tokens, base rates. Cache rates derive from `input`. */
+interface ClaudeRate {
+  input: number
+  output: number
+}
+
+/** Cache-write price as a multiple of base input (5-minute TTL). */
+const CACHE_WRITE_5M_MULTIPLIER = 1.25
+/** Cache-read (hit) price as a multiple of base input. */
+const CACHE_READ_MULTIPLIER = 0.1
+
+/**
+ * Rates keyed by `<family>-<version>`, the normalized form produced by
+ * {@link normalizeClaudeModel}. Retired models are kept because old sessions
+ * can still be metered against them.
+ */
+const CLAUDE_RATES: Record<string, ClaudeRate> = {
+  "fable-5": { input: 10, output: 50 },
+  "mythos-5": { input: 10, output: 50 },
+  "opus-5": { input: 5, output: 25 },
+  "opus-4.8": { input: 5, output: 25 },
+  "opus-4.7": { input: 5, output: 25 },
+  "opus-4.6": { input: 5, output: 25 },
+  "opus-4.5": { input: 5, output: 25 },
+  "opus-4.1": { input: 15, output: 75 },
+  "opus-4": { input: 15, output: 75 },
+  "sonnet-5": { input: 2, output: 10 },
+  "sonnet-4.6": { input: 3, output: 15 },
+  "sonnet-4.5": { input: 3, output: 15 },
+  "sonnet-4": { input: 3, output: 15 },
+  "haiku-4.5": { input: 1, output: 5 },
+  "haiku-3.5": { input: 0.8, output: 4 },
+}
+
+/** Model families we price. */
+const FAMILIES = "opus|sonnet|haiku|fable|mythos"
+
+/**
+ * A version is one or two dot/dash-separated parts of at most two digits each
+ * (`5`, `4-5`, `4.8`). The trailing `(?!\d)` stops the optional minor part from
+ * swallowing the leading digits of a release date: in `sonnet-5-20260101` it
+ * forces a backtrack to just `5`.
+ */
+const VERSION = "(\\d{1,2}(?:[-.]\\d{1,2})?)(?!\\d)"
+/** Current id shape: `claude-opus-4-5`, `claude-sonnet-5-20260101`, … */
+const MODERN = new RegExp(`claude[-_.]?(${FAMILIES})[-_.]${VERSION}`)
+/** Legacy id shape, version before family: `claude-3-5-haiku-20241022`. */
+const LEGACY = new RegExp(`claude[-_.]${VERSION}[-_.](${FAMILIES})`)
+
+/**
+ * Reduce a model id to a `<family>-<version>` pricing key, or null when it
+ * isn't a Claude model we price.
+ *
+ * Absorbs the shapes a session file can carry: vendor prefixes
+ * (`anthropic/`, `us.anthropic.`), a trailing release date
+ * (`-20251101`), Bedrock's `-v1:0` suffix, `4-5` vs `4.5` version separators,
+ * and the pre-4.x ordering (`claude-3-5-haiku`). Suffixes the price doesn't
+ * depend on (`-thinking`, `-latest`) fall out for free — the version is read
+ * from the first match, and anything after it is ignored.
+ */
+export function normalizeClaudeModel(model: string | null | undefined): string | null {
+  if (!model) return null
+  const id = model.toLowerCase()
+  const m = MODERN.exec(id)
+  if (m) return `${m[1]}-${m[2].replace("-", ".")}`
+  const l = LEGACY.exec(id)
+  if (l) return `${l[2]}-${l[1].replace("-", ".")}`
+  return null
+}
+
+/** Token counts for one turn, as reported by tokscale. */
+export interface ClaudeTokenCounts {
+  /** Uncached input tokens. */
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  cacheWriteTokens: number
+  /** Extended-thinking tokens, when a client reports them separately. */
+  reasoningTokens: number
+}
+
+/**
+ * Price one turn in USD, or null when the model isn't a Claude model we have
+ * rates for (caller should then fall back to tokscale's own figure).
+ *
+ * These are Anthropic's first-party rates, so only call this for a run actually
+ * served by Anthropic. A Claude model reached through a reseller (OpenCode,
+ * Kilo, a custom endpoint) is priced by that reseller, not by this table.
+ *
+ * Cache writes are billed at the 5-minute rate: Claude Code's cache breakpoints
+ * are ephemeral 5m by default, and tokscale reports a single cache-write count
+ * with no TTL, so there's nothing to distinguish a 1-hour write by. That makes
+ * this a slight under-estimate for a session that opts into 1h caching.
+ *
+ * Reasoning tokens are billed at the output rate — Anthropic bills extended
+ * thinking as output. Claude Code folds thinking into `output_tokens` and
+ * reports no separate reasoning count, so this term is 0 for the shared pool;
+ * it exists for clients that do split the two.
+ */
+export function priceClaudeTurn(
+  model: string | null | undefined,
+  tokens: ClaudeTokenCounts
+): number | null {
+  const key = normalizeClaudeModel(model)
+  if (!key) return null
+  const rate = CLAUDE_RATES[key]
+  if (!rate) return null
+
+  const perToken = (usdPerMillion: number, count: number) =>
+    (usdPerMillion * count) / 1_000_000
+
+  return (
+    perToken(rate.input, tokens.inputTokens) +
+    perToken(rate.output, tokens.outputTokens) +
+    perToken(rate.output, tokens.reasoningTokens) +
+    perToken(rate.input * CACHE_READ_MULTIPLIER, tokens.cacheReadTokens) +
+    perToken(rate.input * CACHE_WRITE_5M_MULTIPLIER, tokens.cacheWriteTokens)
+  )
+}

--- a/packages/web/lib/server/credential-flags.ts
+++ b/packages/web/lib/server/credential-flags.ts
@@ -5,14 +5,15 @@
 
 import { prisma } from "@/lib/db/prisma"
 import { isSharedPoolAvailable } from "@/lib/claude-credentials"
-import { sumSharedUsage } from "@/lib/db/token-usage"
+import { sumSharedUsageInUnit } from "@/lib/db/token-usage"
 import { decryptUserCredentials } from "@/lib/db/api-helpers"
 import {
-  getDailyTokenBudget,
+  getProviderBudget,
   getStartOfUtcDay,
   getNextUtcDayReset,
   getStartOfUtcWeek,
   getNextUtcWeekReset,
+  type BudgetUnit,
   type Plan,
 } from "@/lib/server/usage-budgets"
 import { flagsFromCredentials, CREDENTIAL_KEYS, type CredentialFlags } from "@/lib/credentials"
@@ -22,11 +23,13 @@ import { sharedClaudePoolEligible } from "@background-agents/common"
 export interface EffectiveFlags {
   flags: CredentialFlags
   limitResetAt: Date | null
-  /** Remaining limited tokens (cache-excluded) for free users; null = unlimited. */
+  /** Unit the three amounts below are measured in (USD cost for Claude). */
+  limitUnit: BudgetUnit
+  /** Remaining allowance for capped plans; null = unlimited. */
   limitRemaining: number | null
-  /** Limited tokens used by the shared Claude pool this period (daily capped / weekly unlimited). */
+  /** Amount used from the shared Claude pool this period (daily capped / weekly unlimited). */
   limitUsed: number | null
-  /** Daily token budget for capped plans (free/pro); null when unlimited. */
+  /** Daily budget for capped plans (free/pro); null when unlimited. */
   limitTotal: number | null
   /** Whether usage is tracked weekly (unlimited plan) vs daily (free/pro) */
   isWeekly: boolean
@@ -136,37 +139,52 @@ export async function getEffectiveCredentialFlags(userId: string): Promise<Effec
   let limitTotal: number | null = null
   let isWeekly = false
 
+  // The unit the Claude pool is budgeted in (USD cost). Read from the free-tier
+  // descriptor so it's still defined on the `unlimited` plan, which has no
+  // budget of its own but still displays usage.
+  const budget = getProviderBudget("claude", plan)
+  const limitUnit: BudgetUnit = budget?.unit ?? getProviderBudget("claude")?.unit ?? "cost"
+
   if (usesSharedPool) {
-    // Limited tokens (cache-excluded) consumed from the shared Claude pool.
     if (plan === "unlimited") {
       // Unlimited plan: weekly usage for display only — no cap.
       isWeekly = true
-      const { limitedTokens } = await sumSharedUsage({
+      limitUsed = await sumSharedUsageInUnit({
         userId,
         provider: "claude",
+        unit: limitUnit,
         since: getStartOfUtcWeek(),
       })
-      limitUsed = limitedTokens
       limitResetAt = getNextUtcWeekReset()
       // limitTotal / limitRemaining stay null (unlimited)
     } else {
-      // Free and Pro users: daily token budget (Pro = 3× free).
-      const { limitedTokens } = await sumSharedUsage({
+      // Free and Pro users: daily budget (Pro = PRO_BUDGET_MULTIPLIER× free).
+      const used = await sumSharedUsageInUnit({
         userId,
         provider: "claude",
+        unit: limitUnit,
         since: getStartOfUtcDay(),
       })
-      limitUsed = limitedTokens
+      limitUsed = used
       limitResetAt = getNextUtcDayReset()
 
-      const budget = getDailyTokenBudget("claude", plan)
       if (budget != null) {
-        limitTotal = budget
-        limitRemaining = Math.max(0, budget - limitedTokens)
-        flags.CLAUDE_DAILY_LIMIT_EXCEEDED = limitedTokens >= budget
+        limitTotal = budget.limit
+        limitRemaining = Math.max(0, budget.limit - used)
+        flags.CLAUDE_DAILY_LIMIT_EXCEEDED = used >= budget.limit
       }
     }
   }
 
-  return { flags, limitResetAt, limitRemaining, limitUsed, limitTotal, isPro, isWeekly, plan }
+  return {
+    flags,
+    limitResetAt,
+    limitUnit,
+    limitRemaining,
+    limitUsed,
+    limitTotal,
+    isPro,
+    isWeekly,
+    plan,
+  }
 }

--- a/packages/web/lib/server/token-metering.ts
+++ b/packages/web/lib/server/token-metering.ts
@@ -7,9 +7,12 @@
  * recorded for the session (sum of prior delta rows) to get this turn's delta,
  * and append it to the TokenUsage ledger.
  *
- * Pricing lives entirely inside the tokscale binary — the web app owns no price
- * tables. The only thing tokscale can't know (which credential pool ran, and
- * which user) is supplied by the caller.
+ * Pricing comes from tokscale for every provider but Claude. The Claude pool is
+ * budgeted in dollars, so its cost is recomputed here from Anthropic's
+ * published rates (see lib/server/claude-pricing) rather than trusted from
+ * tokscale's network-fetched price table, which returns $0 for any model id it
+ * fails to resolve. The only thing tokscale can't know (which credential pool
+ * ran, and which user) is supplied by the caller.
  *
  * Everything here is best-effort: metering must never break turn finalization.
  */
@@ -27,6 +30,7 @@ import {
   type UsagePool,
 } from "@/lib/db/token-usage"
 import { isFreeModel } from "@/lib/server/usage-budgets"
+import { priceClaudeTurn } from "@/lib/server/claude-pricing"
 import { readUsageMeta } from "@/lib/server/shared-pool"
 
 /** `tokscale models --json --group-by session,model` entry shape (subset). */
@@ -186,7 +190,32 @@ async function meterTurnUsage(
     // Free models: tokscale misprices them, so force cost to 0. They're still
     // recorded (counted in overall totals) but flagged out of shared budgets.
     const free = isFreeModel(e.model)
-    const costUsd = free ? 0 : Math.max(0, e.cost - prev.costUsd)
+    // The Claude pool's budget is denominated in dollars, so price its deltas
+    // from Anthropic's own rates. Every other provider (and any model these
+    // rates don't cover) keeps tokscale's figure, diffed like the token
+    // components. Note this prices the *delta* directly rather than differencing
+    // two cumulative costs — same result, one less place to drift.
+    const ownPrice =
+      provider === "claude"
+        ? priceClaudeTurn(e.model, {
+            inputTokens,
+            outputTokens,
+            cacheReadTokens,
+            cacheWriteTokens,
+            reasoningTokens,
+          })
+        : null
+    if (provider === "claude" && ownPrice === null && !free) {
+      // A model id our rate table doesn't cover — usually a release we haven't
+      // added yet. Worth a line in the logs: the fallback is only as good as
+      // whatever tokscale resolved, which may be $0.
+      console.warn(
+        `[token-metering] no first-party rate for Claude model "${e.model}" — using tokscale's cost`
+      )
+    }
+    const costUsd = free
+      ? 0
+      : (ownPrice ?? Math.max(0, e.cost - prev.costUsd))
 
     // Skip no-op turns (nothing new since last capture).
     if (totalTokens === 0 && costUsd === 0) continue
@@ -213,6 +242,8 @@ async function meterTurnUsage(
       coverage: e.performance?.tokenCoverage ?? null,
       sessionId,
       cumulativeTotal: Math.round(cumulativeTokens),
+      // tokscale's own cumulative, kept verbatim as an audit trail — for Claude
+      // it won't match the sum of our repriced deltas.
       cumulativeCost: e.cost,
       createdAt: baselineAt,
     })

--- a/packages/web/lib/server/usage-budgets.test.ts
+++ b/packages/web/lib/server/usage-budgets.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Unit tests for shared-pool budget resolution.
+ */
+import { describe, it, expect } from "vitest"
+
+import {
+  getProviderBudget,
+  isFreeModel,
+  PRO_BUDGET_MULTIPLIER,
+} from "./usage-budgets"
+
+describe("getProviderBudget", () => {
+  it("meters the Claude pool in cost, not tokens", () => {
+    // The pool spans a 10× price-per-token spread (Haiku → Fable), so the
+    // budget has to be denominated in money for the tiers to mean anything.
+    expect(getProviderBudget("claude")?.unit).toBe("cost")
+  })
+
+  it("scales the free budget by the Pro multiplier", () => {
+    const free = getProviderBudget("claude", "free")!
+    const pro = getProviderBudget("claude", "pro")!
+    expect(pro.unit).toBe(free.unit)
+    expect(pro.limit).toBeCloseTo(free.limit * PRO_BUDGET_MULTIPLIER, 10)
+  })
+
+  it("leaves the unlimited plan uncapped", () => {
+    expect(getProviderBudget("claude", "unlimited")).toBeNull()
+  })
+
+  it("returns null for providers with no shared-pool budget", () => {
+    expect(getProviderBudget("codex")).toBeNull()
+  })
+})
+
+describe("isFreeModel", () => {
+  it("catches the explicit set and the -free/:free conventions", () => {
+    expect(isFreeModel("big-pickle")).toBe(true)
+    expect(isFreeModel("nemotron-3-ultra-free")).toBe(true)
+    expect(isFreeModel("some-new-model:free")).toBe(true)
+    expect(isFreeModel("claude-opus-5")).toBe(false)
+    expect(isFreeModel(null)).toBe(false)
+  })
+})

--- a/packages/web/lib/server/usage-budgets.ts
+++ b/packages/web/lib/server/usage-budgets.ts
@@ -4,14 +4,20 @@
  * Budgets scale by plan: `free` gets the base daily budget, `pro` gets 2× that
  * budget (still daily), and `unlimited` is uncapped. The budget *unit* differs
  * by provider — each pool is metered in whatever measure best reflects its cost:
- *   - claude   → "tokens": cache-excluded limited tokens (input + output +
- *                reasoning; see UsageTotals.limitedTokens).
+ *   - claude   → "cost": USD spend, priced from Anthropic's published rates in
+ *                lib/server/claude-pricing. The pool spans Haiku through Fable,
+ *                a 10× spread in price per token, so a token cap would hand a
+ *                Fable user ten times the value of a Haiku user for the same
+ *                allowance.
  *   - opencode → "cost": USD spend (tokscale's per-turn cost), since OpenCode
  *                spans many models with wildly different per-token prices.
  *   - gemini   → "messages": number of assistant turns, a simple message cap.
  *
- * NOTE: numbers below are PLACEHOLDERS. Tune them once real usage has been
- * logged to the TokenUsage ledger. Omit a provider to leave it unlimited.
+ * Unlike the token unit, "cost" counts cache reads and writes: they're priced
+ * at 0.1× and 1.25× base input, so they no longer swamp the measure the way raw
+ * cache token *counts* do.
+ *
+ * Omit a provider to leave it unlimited.
  */
 
 import type { ProviderName } from "@background-agents/common"
@@ -31,10 +37,28 @@ export interface ProviderBudget {
 /** Multiplier applied to the free daily budget for `pro` users. */
 export const PRO_BUDGET_MULTIPLIER = 2
 
-/** Free-tier daily budget per shared-pool provider, with its unit. */
+/**
+ * Free-tier daily budget per shared-pool provider, with its unit.
+ *
+ * Sizing the Claude budget, for a pool of ~200 users behind one shared
+ * subscription. A typical Claude Code turn (~1k uncached input, ~1.5k output,
+ * ~60k cache read, ~8k cache write) costs roughly:
+ *
+ *   Haiku 4.5   ~$0.024      Sonnet 5   ~$0.049
+ *   Opus 5      ~$0.12       Fable 5    ~$0.25
+ *
+ * At $0.50/day a free user gets ~20 Haiku, ~10 Sonnet, ~4 Opus or ~2 Fable
+ * turns; Pro doubles that. Worst case (all 200 users maxing out daily) is
+ * $100/day, far past what one subscription covers — but that shape never
+ * happens: at a realistic ~10% daily-active rate spending ~60% of the cap,
+ * it lands near $6/day, comfortably inside a Max-tier subscription with room
+ * for the tail. Revisit once the ledger has enough history to replace those two
+ * assumptions with measurements, and consider a pool-wide daily ceiling before
+ * the user count grows much past 200.
+ */
 const FREE_DAILY_BUDGETS: Partial<Record<ProviderName, ProviderBudget>> = {
-  // TODO(token-budgets): replace placeholders with tuned values.
-  claude: { unit: "tokens", limit: 100_000 },
+  claude: { unit: "cost", limit: 0.5 },
+  // TODO(token-budgets): tune these two against the ledger, as above.
   opencode: { unit: "cost", limit: 0.5 },
   gemini: { unit: "messages", limit: 100 },
 }
@@ -55,19 +79,6 @@ export function getProviderBudget(
     return { unit: base.unit, limit: base.limit * PRO_BUDGET_MULTIPLIER }
   }
   return base
-}
-
-/**
- * Daily token budget for a provider on a given plan, or null when the provider
- * isn't metered in tokens (cost/message-based) or is unlimited. Used by the
- * Claude-specific limit display in credential-flags.
- */
-export function getDailyTokenBudget(
-  provider: ProviderName,
-  plan: Plan = "free"
-): number | null {
-  const b = getProviderBudget(provider, plan)
-  return b && b.unit === "tokens" ? b.limit : null
 }
 
 /**

--- a/packages/web/lib/server/usage-budgets.ts
+++ b/packages/web/lib/server/usage-budgets.ts
@@ -40,24 +40,31 @@ export const PRO_BUDGET_MULTIPLIER = 2
 /**
  * Free-tier daily budget per shared-pool provider, with its unit.
  *
- * Sizing the Claude budget, for a pool of ~200 users behind one shared
- * subscription. A typical Claude Code turn (~1k uncached input, ~1.5k output,
- * ~60k cache read, ~8k cache write) costs roughly:
+ * The Claude figure is sized from the ledger, not modelled. Over 77 active days
+ * (Jun–Aug 2026): 106 users, 6,463 shared turns, $14,846 of API-equivalent
+ * value — ~$193/day at ~11.9 users active per day, averaging $2.30 a turn. Note
+ * a "turn" here is a whole agentic run (many API round-trips, each re-reading
+ * cache), not a single call, which is why it costs orders of magnitude more than
+ * a chat message.
  *
- *   Haiku 4.5   ~$0.024      Sonnet 5   ~$0.049
- *   Opus 5      ~$0.12       Fable 5    ~$0.25
+ * Cost per user-day was distributed:  p50 $8.37 · p75 $17.26 · p90 $42.55 ·
+ * max $237.39. The tail is the problem this cap exists to solve — 8 of those 106
+ * users accounted for 75% of all spend, and left alone they crowd everyone else
+ * out as the pool grows.
  *
- * At $0.50/day a free user gets ~20 Haiku, ~10 Sonnet, ~4 Opus or ~2 Fable
- * turns; Pro doubles that. Worst case (all 200 users maxing out daily) is
- * $100/day, far past what one subscription covers — but that shape never
- * happens: at a realistic ~10% daily-active rate spending ~60% of the cap,
- * it lands near $6/day, comfortably inside a Max-tier subscription with room
- * for the tail. Revisit once the ledger has enough history to replace those two
- * assumptions with measurements, and consider a pool-wide daily ceiling before
- * the user count grows much past 200.
+ * $10/day leaves ~56% of historical user-days completely untouched while cutting
+ * the top decile hard. Replayed over that history it would have allowed ~$76/day
+ * against 11.9 active users; at 200 users on the same ~11% daily-active rate
+ * (~22 active) that projects to ~$140/day — below the ~$193/day the pool already
+ * sustains without complaint (2 rate-limit errors on claude-code in 77 days).
+ *
+ * What this does NOT do is bound the pool as a whole: it caps any single user,
+ * but 200 users active at once is still 200 × the cap. If daily-active rate
+ * spikes, total draw scales with it. A pool-wide daily ceiling is the only thing
+ * that hard-bounds that, and it does not exist yet.
  */
 const FREE_DAILY_BUDGETS: Partial<Record<ProviderName, ProviderBudget>> = {
-  claude: { unit: "cost", limit: 0.5 },
+  claude: { unit: "cost", limit: 10 },
   // TODO(token-budgets): tune these two against the ledger, as above.
   opencode: { unit: "cost", limit: 0.5 },
   gemini: { unit: "messages", limit: 100 },

--- a/packages/web/lib/server/usage-budgets.ts
+++ b/packages/web/lib/server/usage-budgets.ts
@@ -52,19 +52,27 @@ export const PRO_BUDGET_MULTIPLIER = 2
  * users accounted for 75% of all spend, and left alone they crowd everyone else
  * out as the pool grows.
  *
- * $10/day leaves ~56% of historical user-days completely untouched while cutting
- * the top decile hard. Replayed over that history it would have allowed ~$76/day
- * against 11.9 active users; at 200 users on the same ~11% daily-active rate
- * (~22 active) that projects to ~$140/day — below the ~$193/day the pool already
- * sustains without complaint (2 rate-limit errors on claude-code in 77 days).
+ * The old 100k-token cap it replaces was worth a median of $8.10 of real value
+ * per user-day — but anywhere from $4.80 (p25) to $26.78 (p90), because the same
+ * token allowance buys wildly different amounts depending on the model. That
+ * spread is why a token cap never controlled the pool: we were hitting the
+ * subscription's weekly limit (77 times in this window, plus 57 Fable-specific
+ * and 26 session limits) while the cap looked like it was holding.
  *
- * What this does NOT do is bound the pool as a whole: it caps any single user,
- * but 200 users active at once is still 200 × the cap. If daily-active rate
- * spikes, total draw scales with it. A pool-wide daily ceiling is the only thing
- * that hard-bounds that, and it does not exist yet.
+ * $5/day sits below that $8.10 median, so it is a genuine tightening rather than
+ * a sideways move. Replayed over the same history with plan multipliers applied,
+ * it would have allowed ~$88/day against ~$193/day actual — a 54% reduction,
+ * most of it taken off the tail the token rule let run unchecked.
+ *
+ * Two things this does NOT bound:
+ *   - The `unlimited` plan, which is uncapped by definition. It accounted for
+ *     $44/day of the historical draw, and no value here touches it.
+ *   - The pool as a whole. This caps a single user; 200 users active at once is
+ *     still 200 × the cap. A pool-wide daily ceiling is the only hard bound, and
+ *     it does not exist yet.
  */
 const FREE_DAILY_BUDGETS: Partial<Record<ProviderName, ProviderBudget>> = {
-  claude: { unit: "cost", limit: 10 },
+  claude: { unit: "cost", limit: 5 },
   // TODO(token-budgets): tune these two against the ledger, as above.
   opencode: { unit: "cost", limit: 0.5 },
   gemini: { unit: "messages", limit: 100 },

--- a/packages/web/lib/sync/api.ts
+++ b/packages/web/lib/sync/api.ts
@@ -8,6 +8,7 @@
 
 import type { Chat, Message, Settings, CustomEndpoint } from "@/lib/types"
 import type { Credentials, CredentialFlags } from "@/lib/credentials"
+import type { BudgetUnit } from "@/lib/server/usage-budgets"
 
 // =============================================================================
 // Types
@@ -66,6 +67,7 @@ export interface SettingsResponse {
   credentialFlags: CredentialFlags
   customEndpoints?: CustomEndpoint[]
   claudeLimitResetAt?: string | null
+  claudeLimitUnit?: BudgetUnit
   claudeLimitRemaining?: number | null
   claudeLimitUsed?: number | null
   claudeLimitTotal?: number | null

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -12,7 +12,8 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:ccauth": "tsx scripts/run-ccauth.ts",
-    "seed:ccauth": "tsx scripts/run-ccauth.ts --seed"
+    "seed:ccauth": "tsx scripts/run-ccauth.ts --seed",
+    "backfill:claude-cost": "tsx scripts/backfill-claude-cost.ts"
   },
   "dependencies": {
     "@ai-sdk/openai": "^1.3.22",

--- a/packages/web/scripts/backfill-claude-cost.ts
+++ b/packages/web/scripts/backfill-claude-cost.ts
@@ -15,11 +15,16 @@
  *   npm run backfill:claude-cost -- --apply --include-nonzero
  *
  * `--apply` alone touches only rows currently at $0 with real tokens, which is
- * the safe, obviously-wrong set. `--include-nonzero` additionally corrects rows
- * whose stored cost disagrees with our own by more than a cent — review the dry
- * run before reaching for it. tokscale's known defect — dropping cache pricing
- * for models it can't fully resolve, e.g. Opus and Fable — produces wrong
- * non-zero costs, not zeros, so --include-nonzero is the flag that fixes it.
+ * the safe, obviously-wrong set. `--include-nonzero` additionally raises rows
+ * tokscale under-priced — in practice ones where it dropped cache entirely and
+ * billed input+output only, its observed failure mode, which produces wrong
+ * non-zero costs rather than zeros.
+ *
+ * Repricing only ever moves a cost UP. Rows where tokscale priced *higher* than
+ * we do are reported but never rewritten: those are most likely 1-hour cache
+ * writes (2x input) that we bill at the 5-minute 1.25x rate because tokscale
+ * reports no TTL — so tokscale is probably the more accurate of the two, and
+ * rewriting them down would trade a likely-right number for a likely-wrong one.
  *
  * Before writing, the original costUsd of every affected row is dumped to a
  * timestamped JSON file beside this script, so a run can be undone.
@@ -87,6 +92,8 @@ async function main() {
   const byModel = new Map<string, Bucket>()
 
   const toReprice: { id: string; from: number; to: number; zero: boolean }[] = []
+  /** Rows where tokscale priced HIGHER than us — reported, never rewritten. */
+  const overpriced: number[] = []
 
   for (const r of rows) {
     const key = r.model ?? "(null)"
@@ -125,8 +132,17 @@ async function main() {
     if (ours === null || ours === r.costUsd) continue
     if (isZero) {
       toReprice.push({ id: r.id, from: r.costUsd, to: ours, zero: true })
-    } else if (Math.abs(ours - r.costUsd) > NONZERO_TOLERANCE_USD) {
+    } else if (ours - r.costUsd > NONZERO_TOLERANCE_USD) {
+      // Only ever correct UPWARD. A row where we price higher than tokscale is
+      // one where tokscale dropped a component we can account for (in practice:
+      // cache, priced as input+output only). A row where we price *lower* is
+      // more likely a gap on our side — most plausibly a 1-hour cache write,
+      // which bills at 2x input while we assume the 5-minute 1.25x rate because
+      // tokscale reports no TTL. Rewriting those down would replace a probably-
+      // right number with a probably-wrong one, so leave them alone.
       toReprice.push({ id: r.id, from: r.costUsd, to: ours, zero: false })
+    } else if (r.costUsd - ours > NONZERO_TOLERANCE_USD) {
+      overpriced.push(r.costUsd - ours)
     }
   }
 
@@ -162,10 +178,13 @@ async function main() {
   const nonZeros = toReprice.filter((t) => !t.zero)
   const sum = (xs: typeof toReprice) => xs.reduce((a, t) => a + (t.to - t.from), 0)
 
+  const overpricedTotal = overpriced.reduce((a, b) => a + b, 0)
   console.log(
-    `\nZero-cost rows to fill: ${zeros.length} (adds ${usd(sum(zeros))})` +
-      `\nNon-zero rows disagreeing by >${usd(NONZERO_TOLERANCE_USD)}: ${nonZeros.length}` +
-      ` (would shift ${usd(sum(nonZeros))})`
+    `\nZero-cost rows to fill:      ${zeros.length} (adds ${usd(sum(zeros))})` +
+      `\nUnder-priced rows to raise:  ${nonZeros.length} (adds ${usd(sum(nonZeros))})` +
+      `\nOver-priced rows LEFT ALONE: ${overpriced.length} (would have removed ` +
+      `${usd(overpricedTotal)}; likely 1h cache writes we under-price, so ` +
+      `tokscale is probably the more accurate of the two there)`
   )
 
   const targets = INCLUDE_NONZERO ? toReprice : zeros
@@ -205,13 +224,16 @@ async function main() {
   )
   console.log(`\nOriginals saved to ${backupPath}`)
 
-  // Chunked so a large backfill doesn't hold one enormous transaction open on
-  // the pooled connection.
-  const CHUNK = 100
+  // Small concurrent batches rather than one interactive transaction: over a
+  // pgbouncer pooler a 100-update transaction blows Prisma's 5s limit (P2028)
+  // and rolls the whole thing back. Each row is independent and the reprice is
+  // idempotent — it recomputes from the token components every run — so a
+  // partial pass is harmless and re-running simply finishes the job.
+  const CHUNK = 20
   let written = 0
   for (let i = 0; i < targets.length; i += CHUNK) {
     const chunk = targets.slice(i, i + CHUNK)
-    await prisma.$transaction(
+    await Promise.all(
       chunk.map((t) =>
         prisma.tokenUsage.update({
           where: { id: t.id },

--- a/packages/web/scripts/backfill-claude-cost.ts
+++ b/packages/web/scripts/backfill-claude-cost.ts
@@ -1,0 +1,206 @@
+/**
+ * One-off backfill: re-price historical Claude rows in the TokenUsage ledger.
+ *
+ * Rows written before the pool moved to a cost budget carry whatever cost
+ * tokscale reported, which it resolved from LiteLLM's price table over the
+ * network. A model id it failed to resolve was recorded at $0 — an unmetered
+ * turn that a dollar budget can't see. This recomputes `costUsd` from
+ * Anthropic's published rates (lib/server/claude-pricing) using the token
+ * components each row already stores.
+ *
+ * Read-only by default: prints a survey and the repricing it would do.
+ *
+ *   npm run backfill:claude-cost             # survey + dry run
+ *   npm run backfill:claude-cost -- --apply  # write the zero-cost rows
+ *   npm run backfill:claude-cost -- --apply --include-nonzero
+ *
+ * `--apply` alone touches only rows currently at $0 with real tokens, which is
+ * the safe, obviously-wrong set. `--include-nonzero` additionally corrects rows
+ * whose stored cost disagrees with our own by more than a cent — review the dry
+ * run before reaching for it.
+ */
+
+import { PrismaClient } from "@prisma/client"
+import { PrismaPg } from "@prisma/adapter-pg"
+import pg from "pg"
+
+import { priceClaudeTurn } from "../lib/server/claude-pricing"
+
+const connectionString = process.env.DATABASE_URL ?? process.env.POSTGRES_URL
+if (!connectionString) throw new Error("DATABASE_URL is not set")
+
+// Say out loud which database is about to be read (and possibly written).
+console.log(`Database: ${connectionString.replace(/:\/\/[^@]*@/, "://***@")}`)
+
+const prisma = new PrismaClient({
+  adapter: new PrismaPg(new pg.Pool({ connectionString, max: 5 })),
+})
+
+const APPLY = process.argv.includes("--apply")
+const INCLUDE_NONZERO = process.argv.includes("--include-nonzero")
+
+/** Ignore sub-cent disagreement when deciding a non-zero row is "wrong". */
+const NONZERO_TOLERANCE_USD = 0.01
+
+const usd = (n: number) => `$${n.toFixed(4)}`
+
+async function main() {
+  const rows = await prisma.tokenUsage.findMany({
+    where: { provider: "claude" },
+    select: {
+      id: true,
+      model: true,
+      pool: true,
+      costUsd: true,
+      inputTokens: true,
+      outputTokens: true,
+      cacheReadTokens: true,
+      cacheWriteTokens: true,
+      reasoningTokens: true,
+      totalTokens: true,
+      createdAt: true,
+    },
+    orderBy: { createdAt: "asc" },
+  })
+
+  console.log(`\nClaude rows in the ledger: ${rows.length}`)
+  if (rows.length === 0) return
+
+  // ── Survey, per model ─────────────────────────────────────────────────────
+  interface Bucket {
+    rows: number
+    tokens: number
+    storedCost: number
+    ourCost: number
+    zeroCostRows: number
+    zeroCostTokens: number
+    unpriced: number
+  }
+  const byModel = new Map<string, Bucket>()
+
+  const toReprice: { id: string; from: number; to: number; zero: boolean }[] = []
+
+  for (const r of rows) {
+    const key = r.model ?? "(null)"
+    const b = byModel.get(key) ?? {
+      rows: 0,
+      tokens: 0,
+      storedCost: 0,
+      ourCost: 0,
+      zeroCostRows: 0,
+      zeroCostTokens: 0,
+      unpriced: 0,
+    }
+
+    const ours = priceClaudeTurn(r.model, {
+      inputTokens: r.inputTokens,
+      outputTokens: r.outputTokens,
+      cacheReadTokens: r.cacheReadTokens,
+      cacheWriteTokens: r.cacheWriteTokens,
+      reasoningTokens: r.reasoningTokens,
+    })
+
+    b.rows += 1
+    b.tokens += r.totalTokens
+    b.storedCost += r.costUsd
+    if (ours === null) b.unpriced += 1
+    else b.ourCost += ours
+
+    const isZero = r.costUsd === 0 && r.totalTokens > 0
+    if (isZero) {
+      b.zeroCostRows += 1
+      b.zeroCostTokens += r.totalTokens
+    }
+
+    byModel.set(key, b)
+
+    if (ours === null || ours === r.costUsd) continue
+    if (isZero) {
+      toReprice.push({ id: r.id, from: r.costUsd, to: ours, zero: true })
+    } else if (Math.abs(ours - r.costUsd) > NONZERO_TOLERANCE_USD) {
+      toReprice.push({ id: r.id, from: r.costUsd, to: ours, zero: false })
+    }
+  }
+
+  console.log("\nPer model (stored = what tokscale recorded, ours = Anthropic rates):\n")
+  const header = [
+    "model".padEnd(32),
+    "rows".padStart(6),
+    "tokens".padStart(12),
+    "stored".padStart(11),
+    "ours".padStart(11),
+    "$0 rows".padStart(8),
+    "unpriced".padStart(9),
+  ].join("  ")
+  console.log(header)
+  console.log("-".repeat(header.length))
+  for (const [model, b] of [...byModel.entries()].sort(
+    (a, z) => z[1].tokens - a[1].tokens
+  )) {
+    console.log(
+      [
+        model.slice(0, 32).padEnd(32),
+        String(b.rows).padStart(6),
+        b.tokens.toLocaleString("en-US").padStart(12),
+        usd(b.storedCost).padStart(11),
+        usd(b.ourCost).padStart(11),
+        String(b.zeroCostRows).padStart(8),
+        String(b.unpriced).padStart(9),
+      ].join("  ")
+    )
+  }
+
+  const zeros = toReprice.filter((t) => t.zero)
+  const nonZeros = toReprice.filter((t) => !t.zero)
+  const sum = (xs: typeof toReprice) => xs.reduce((a, t) => a + (t.to - t.from), 0)
+
+  console.log(
+    `\nZero-cost rows to fill: ${zeros.length} (adds ${usd(sum(zeros))})` +
+      `\nNon-zero rows disagreeing by >${usd(NONZERO_TOLERANCE_USD)}: ${nonZeros.length}` +
+      ` (would shift ${usd(sum(nonZeros))})`
+  )
+
+  const targets = INCLUDE_NONZERO ? toReprice : zeros
+  if (!APPLY) {
+    console.log(
+      `\nDry run — nothing written. ${targets.length} row(s) would change.` +
+        `\nRe-run with --apply to write them.`
+    )
+    for (const t of targets.slice(0, 20)) {
+      console.log(`  ${t.id}  ${usd(t.from)} -> ${usd(t.to)}`)
+    }
+    if (targets.length > 20) console.log(`  … and ${targets.length - 20} more`)
+    return
+  }
+
+  if (targets.length === 0) {
+    console.log("\nNothing to write.")
+    return
+  }
+
+  // Chunked so a large backfill doesn't hold one enormous transaction open on
+  // the pooled connection.
+  const CHUNK = 100
+  let written = 0
+  for (let i = 0; i < targets.length; i += CHUNK) {
+    const chunk = targets.slice(i, i + CHUNK)
+    await prisma.$transaction(
+      chunk.map((t) =>
+        prisma.tokenUsage.update({
+          where: { id: t.id },
+          data: { costUsd: t.to },
+        })
+      )
+    )
+    written += chunk.length
+    console.log(`  wrote ${written}/${targets.length}`)
+  }
+  console.log(`\nDone. Repriced ${written} row(s).`)
+}
+
+main()
+  .catch((err) => {
+    console.error(err)
+    process.exitCode = 1
+  })
+  .finally(() => prisma.$disconnect())

--- a/packages/web/scripts/backfill-claude-cost.ts
+++ b/packages/web/scripts/backfill-claude-cost.ts
@@ -17,8 +17,16 @@
  * `--apply` alone touches only rows currently at $0 with real tokens, which is
  * the safe, obviously-wrong set. `--include-nonzero` additionally corrects rows
  * whose stored cost disagrees with our own by more than a cent — review the dry
- * run before reaching for it.
+ * run before reaching for it. tokscale's known defect — dropping cache pricing
+ * for models it can't fully resolve, e.g. Opus and Fable — produces wrong
+ * non-zero costs, not zeros, so --include-nonzero is the flag that fixes it.
+ *
+ * Before writing, the original costUsd of every affected row is dumped to a
+ * timestamped JSON file beside this script, so a run can be undone.
  */
+
+import { writeFileSync } from "node:fs"
+import path from "node:path"
 
 import { PrismaClient } from "@prisma/client"
 import { PrismaPg } from "@prisma/adapter-pg"
@@ -177,6 +185,25 @@ async function main() {
     console.log("\nNothing to write.")
     return
   }
+
+  // Snapshot the originals before overwriting them. Repricing is the one step
+  // here that loses information: the ledger's per-row costUsd is what tokscale
+  // believed at the time, and nothing else records it (cumulativeCost is a
+  // running session total, not a per-row original). Dump it next to the script
+  // so a bad run can be reversed.
+  const backupPath = path.join(
+    __dirname,
+    `backfill-claude-cost.backup.${new Date().toISOString().replace(/[:.]/g, "-")}.json`
+  )
+  writeFileSync(
+    backupPath,
+    JSON.stringify(
+      targets.map((t) => ({ id: t.id, costUsd: t.from, repricedTo: t.to })),
+      null,
+      2
+    )
+  )
+  console.log(`\nOriginals saved to ${backupPath}`)
 
   // Chunked so a large backfill doesn't hold one enormous transaction open on
   // the pooled connection.


### PR DESCRIPTION
# Budget the shared Claude pool in cost, not tokens

The shared Claude pool was capped at **100,000 tokens/day** for free users. This changes it to **$5/day**, and makes us price those dollars ourselves from Anthropic's published rates instead of trusting tokscale's figure.

---

## Why a token cap was the wrong shape

The pool serves six models, and they don't cost the same. Here is one **real turn** from our ledger — 63,399 tokens — priced as each model:

| Model | Cost | vs Haiku |
|---|---|---|
| Haiku 4.5 | $0.045 | 1× |
| Sonnet 5 | $0.090 | 2× |
| Sonnet 4.6 | $0.135 | 3× |
| Opus 5 | $0.225 | 5× |
| Fable 5 | $0.451 | **10×** |

Same work, same token count, **ten times the money**.

Under the old rule all five of those counted as the identical 10,608 tokens, so a Fable user and a Haiku user burned the same slice of their allowance while one of them consumed ten times the value. Budgeting in dollars fixes that: Fable now drains the budget ten times faster, which is the honest answer.

## How Claude costing works now, in plain terms

There are two separate jobs, and the important part of this PR is splitting them:

| Job | Who does it | Source |
|---|---|---|
| **Count** the tokens a turn used | tokscale | Reads the Claude Code session file in the sandbox |
| **Multiply** those tokens by a price | **us**, `lib/server/claude-pricing.ts` | Hard-coded from [platform.claude.com pricing](https://platform.claude.com/docs/en/about-claude/pricing) |

Previously tokscale did *both*, and for the pricing half it downloaded a price list from LiteLLM over the internet at run time. That's the part we're taking back.

**The price table.** For each model we store two numbers copied from the pricing page:

```
opus-5:    input $5/million,   output $25/million
sonnet-5:  input $2/million,   output $10/million
haiku-4.5: input $1/million,   output $5/million
fable-5:   input $10/million,  output $50/million
```

The page also lists two cache prices per model, but says they're always a fixed multiple of the input price — **cache write = input × 1.25**, **cache read = input × 0.1**. So we derive those rather than typing them in. For Opus 5 that gives $6.25 and $0.50, exactly matching the published table. Verified for all 15 models. Storing 2 numbers instead of 4 means they can't drift apart.

**Worked example.** A real Opus turn: 9,270 input + 1,338 output + 32,069 cache-read + 20,722 cache-write tokens. Four multiplications:

```
9,270  × $5.00  / 1,000,000 = $0.0464   input
1,338  × $25.00 / 1,000,000 = $0.0335   output
32,069 × $0.50  / 1,000,000 = $0.0160   cache read
20,722 × $6.25  / 1,000,000 = $0.1295   cache write
                              ────────
                              $0.2253
```

That's the whole method.


## Tiers

Sized from the ledger, not modelled. Over 77 active days (Jun–Aug 2026): **106 users, 6,463 shared turns, $14,846** of API-equivalent value — about $193/day at ~11.9 users active per day, averaging **$2.30 a turn**. (A "turn" here is a whole agentic run — many API round-trips, each re-reading cache — not a single call, which is why it costs orders of magnitude more than a chat message.)

Cost per user-day: **p50 $8.37 · p75 $17.26 · p90 $42.55 · max $237.39**.

| Tier | Daily budget |
|---|---|
| Free | **$5** |
| Pro | **$10** (existing 2× multiplier) |
| Unlimited | uncapped |


