### PR TITLE
feat(web): replace per-provider budgets with one daily balance

### DIFF
--- a/packages/common/src/agents.ts
+++ b/packages/common/src/agents.ts
@@ -77,10 +77,11 @@ export type CredentialFlags = Partial<Record<CredentialId, boolean>> & {
   // credential at the UI gate so the user can pick claude-code without pasting
   // their own token. Not a CredentialId — it's a server capability, not an env var.
   CLAUDE_SHARED_POOL_AVAILABLE?: boolean
-  // Free user has hit daily limit on shared Claude credentials. When true,
-  // hasCredentialsForModel stops treating the shared pool as usable for
-  // Claude models, so the UI falls back to a model the user can actually run.
-  CLAUDE_DAILY_LIMIT_EXCEEDED?: boolean
+  // User has spent their daily balance. It is pooled across every shared pool
+  // (Claude, OpenCode, Gemini), so when true hasCredentialsForModel stops
+  // treating ANY shared pool as usable and the UI falls back to a model the user
+  // can actually run — their own key, or a free model, which never draws it.
+  SHARED_BALANCE_EXHAUSTED?: boolean
   // Whether the OPENCODE_API_KEY originates from the server environment (shared)
   OPENCODE_API_KEY_SHARED?: boolean
   // Whether the OPENCODE_API_KEY is a user-provided credential stored in DB
@@ -537,7 +538,7 @@ export function hasOwnAnthropicCredentials(flags: CredentialFlags | null | undef
 /**
  * Whether a Claude run would draw from the server's shared Claude pool: the
  * shared pool is available and the user has no personal Anthropic credentials.
- * Does not account for the daily limit — see CLAUDE_DAILY_LIMIT_EXCEEDED.
+ * Does not account for the daily balance — see SHARED_BALANCE_EXHAUSTED.
  */
 export function sharedClaudePoolEligible(flags: CredentialFlags | null | undefined): boolean {
   return !!flags?.CLAUDE_SHARED_POOL_AVAILABLE && !hasOwnAnthropicCredentials(flags)
@@ -567,22 +568,19 @@ export function agentUsesSharedPool(
 
 /**
  * Whether the agent's only route to usage is a shared pool that's been used up,
- * leaving nothing the user can actually run. Currently only the Claude shared
- * pool is metered (CLAUDE_DAILY_LIMIT_EXCEEDED); "exhausted" means the limit is
- * hit AND the user has no personal Anthropic credentials to fall back on. The
- * agent picker shows a yellow dot for this state — distinct from "ready" (green)
- * and "needs setup" (no dot).
+ * leaving nothing the user can actually run. The balance is pooled across all
+ * three shared pools, so spending it closes every one of them at once —
+ * but only for a user who is actually drawing on that pool. agentUsesSharedPool
+ * already returns false once the user stores their own key, so someone with a
+ * personal credential keeps working with a zero balance. The agent picker
+ * shows a yellow dot for this state — distinct from "ready" (green) and "needs
+ * setup" (no dot).
  */
 export function agentSharedPoolExhausted(
   agent: Agent,
   flags: CredentialFlags | null | undefined
 ): boolean {
-  if (agent !== "claude-code") return false
-  return (
-    !!flags?.CLAUDE_DAILY_LIMIT_EXCEEDED &&
-    !!flags?.CLAUDE_SHARED_POOL_AVAILABLE &&
-    !hasOwnAnthropicCredentials(flags)
-  )
+  return !!flags?.SHARED_BALANCE_EXHAUSTED && agentUsesSharedPool(agent, flags)
 }
 
 /**
@@ -636,8 +634,8 @@ export function hasCredentialsForModel(
     // needs a real API key.
     if (agent !== "claude-code") return !!flags?.ANTHROPIC_API_KEY
     // Claude Code can use either API key, the user's pasted subscription, or the shared pool.
-    // But if daily limit is exceeded on the shared pool, don't consider it usable.
-    if (flags?.CLAUDE_DAILY_LIMIT_EXCEEDED) {
+    // With the credit allowance spent, only the user's own credentials remain.
+    if (flags?.SHARED_BALANCE_EXHAUSTED) {
       return !!flags?.ANTHROPIC_API_KEY || !!flags?.CLAUDE_CODE_CREDENTIALS
     }
     return !!(flags?.ANTHROPIC_API_KEY || flags?.CLAUDE_CODE_CREDENTIALS || flags?.CLAUDE_SHARED_POOL_AVAILABLE)
@@ -645,8 +643,11 @@ export function hasCredentialsForModel(
   if (model.requiresKey === "opencode") {
     // If the user has their own stored OpenCode key, allow all opencode models
     if (flags?.OPENCODE_API_KEY_USER) return true
-    // If only the server-shared key is available, allow only a curated subset
+    // If only the server-shared key is available, allow only a curated subset —
+    // and only while the user still has balance. OpenCode's free models never
+    // reach here (requiresKey "none" returns true above), so they stay usable.
     if (flags?.OPENCODE_API_KEY_SHARED) {
+      if (flags?.SHARED_BALANCE_EXHAUSTED) return false
       return SHARED_OPENCODE_ALLOWED.has(model.value)
     }
     return false
@@ -656,6 +657,7 @@ export function hasCredentialsForModel(
     // the free pool backs only the cheaper Flash tier — Pro-tier Gemini models
     // stay locked across every agent until the user adds their own key.
     if (flags?.GEMINI_API_KEY_SHARED && !flags?.GEMINI_API_KEY_USER) {
+      if (flags?.SHARED_BALANCE_EXHAUSTED) return false
       return !SHARED_GEMINI_POOL_PRO_MODELS.has(model.value)
     }
     // Otherwise the user's own Gemini key unlocks every Gemini model.
@@ -699,6 +701,21 @@ export function getDefaultModelForAgent(
 
   const firstAvailable = allModels.find(m => hasCredentialsForModel(m, flags, agent))
   return firstAvailable?.value || defaultModel
+}
+
+/**
+ * The agent's first model that needs no credential at all, or undefined when it
+ * has none. OpenCode's free tier is the one that matters: it never draws
+ * the balance, so it stays usable once a user's daily balance is spent.
+ *
+ * Deliberately takes no flags. getDefaultModelForAgent would also land here once
+ * SHARED_BALANCE_EXHAUSTED is set, but that flag arrives with the settings query
+ * and can be a request behind — when we already know the balance is gone (a 429
+ * just came back), picking the free model outright avoids retrying into the same
+ * wall.
+ */
+export function getFreeModelForAgent(agent: Agent): string | undefined {
+  return (agentModels[agent] ?? []).find((m) => m.requiresKey === "none")?.value
 }
 
 /**

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -49,6 +49,7 @@ export {
   hasCredentialsForModel,
   modelRequiresKey,
   getDefaultModelForAgent,
+  getFreeModelForAgent,
   resolveModelForAgent,
   resolveAgent,
   resolveAgentAndModel,

--- a/packages/web/app/api/chats/[chatId]/messages/_lib/resolve-credentials.ts
+++ b/packages/web/app/api/chats/[chatId]/messages/_lib/resolve-credentials.ts
@@ -53,7 +53,6 @@ export async function resolveSendCredentials(
         message: usageCheck.error,
         plan: usageCheck.plan,
         provider: usageCheck.provider,
-        unit: usageCheck.unit,
         used: usageCheck.used,
         remaining: usageCheck.remaining,
         limit: usageCheck.limit,

--- a/packages/web/app/api/chats/[chatId]/usage/route.ts
+++ b/packages/web/app/api/chats/[chatId]/usage/route.ts
@@ -6,9 +6,8 @@ import {
   notFound,
   internalError,
 } from "@/lib/db/api-helpers"
-import { sumChatUsageByProvider, countChatMessagesByProvider } from "@/lib/db/token-usage"
-import { getProviderBudget, type BudgetUnit } from "@/lib/server/usage-budgets"
-import { ALL_AGENTS, agentLabels, agentToProvider, type ProviderName } from "@background-agents/common"
+import { sumChatUsageByProvider } from "@/lib/db/token-usage"
+import { ALL_AGENTS, agentLabels, agentToProvider } from "@background-agents/common"
 
 /** Reverse map: SDK provider id → human label (via its agent). */
 const PROVIDER_LABELS: Record<string, string> = Object.fromEntries(
@@ -19,14 +18,22 @@ function providerLabel(provider: string): string {
   return PROVIDER_LABELS[provider] ?? provider.charAt(0).toUpperCase() + provider.slice(1)
 }
 
-/** Per-provider usage for a single chat, in that provider's budget unit. */
+/**
+ * Per-provider usage for a single chat: tokens and their API list-price value.
+ *
+ * Note this is NOT the daily balance. It spans every provider the chat touched,
+ * including ones with no shared pool, and it counts own-key runs — which cost
+ * the platform nothing. So it answers "what was this conversation worth", not
+ * "what did it take off my allowance". The balance lives in the Usage settings
+ * tab, which is scoped to the shared pools.
+ */
 export interface ChatProviderUsageView {
   provider: string
   label: string
-  /** Unit `value` is measured in: tokens, USD cost, or messages. */
-  unit: BudgetUnit
-  /** Amount used, in `unit`. */
-  value: number
+  /** Total tokens recorded for this provider in the chat (cache included). */
+  totalTokens: number
+  /** Those tokens priced at API list rates, in USD. Zero for free models. */
+  costUsd: number
 }
 
 export interface ChatUsageResponse {
@@ -51,18 +58,12 @@ export async function GET(
     if (!chat) return notFound("Chat not found")
 
     const rows = await sumChatUsageByProvider(chatId)
-    const providers: ChatProviderUsageView[] = await Promise.all(
-      rows.map(async (r) => {
-        const unit = getProviderBudget(r.provider as ProviderName)?.unit ?? "tokens"
-        const value =
-          unit === "cost"
-            ? r.costUsd
-            : unit === "messages"
-              ? await countChatMessagesByProvider(chatId, r.provider)
-              : r.totalTokens
-        return { provider: r.provider, label: providerLabel(r.provider), unit, value }
-      })
-    )
+    const providers: ChatProviderUsageView[] = rows.map((r) => ({
+      provider: r.provider,
+      label: providerLabel(r.provider),
+      totalTokens: r.totalTokens,
+      costUsd: r.costUsd,
+    }))
 
     const response: ChatUsageResponse = { providers }
     return Response.json(response)

--- a/packages/web/app/api/user/settings/route.ts
+++ b/packages/web/app/api/user/settings/route.ts
@@ -22,7 +22,6 @@ import {
   validateEndpoints,
 } from "@/lib/server/custom-endpoints"
 import type { Settings } from "@/lib/types"
-import type { BudgetUnit } from "@/lib/server/usage-budgets"
 import { DEFAULT_SETTINGS } from "@/lib/storage"
 
 interface SettingsResponse {
@@ -31,19 +30,18 @@ interface SettingsResponse {
   /** The user's custom endpoints, headers decrypted for the owner to edit. */
   customEndpoints: CustomEndpoint[]
   /** ISO timestamp when the daily Claude limit resets, or null if not limited */
-  claudeLimitResetAt: string | null
+  balanceResetAt: string | null
   /** Unit the three amounts below are in — "cost" (USD) for the Claude pool. */
-  claudeLimitUnit: BudgetUnit
   /** Remaining Claude allowance today, or null if not applicable */
-  claudeLimitRemaining: number | null
+  balanceRemaining: number | null
   /** Claude allowance used in the current period, or null if not using shared pool */
-  claudeLimitUsed: number | null
+  balanceUsed: number | null
   /** Daily budget for free/pro, or null if unlimited */
-  claudeLimitTotal: number | null
+  balanceTotal: number | null
   /** Whether user is a pro subscriber */
-  claudeIsPro: boolean
+  planIsPro: boolean
   /** Whether usage is tracked weekly (pro) vs daily (free) */
-  claudeIsWeekly: boolean
+  balanceWeekly: boolean
 }
 
 function readSettings(raw: unknown): Settings {
@@ -81,13 +79,12 @@ export async function GET(): Promise<Response> {
       settings: readSettings(user?.settings),
       credentialFlags: effective.flags,
       customEndpoints: decryptUserEndpoints(user?.customEndpoints),
-      claudeLimitResetAt: effective.limitResetAt?.toISOString() ?? null,
-      claudeLimitUnit: effective.limitUnit,
-      claudeLimitRemaining: effective.limitRemaining,
-      claudeLimitUsed: effective.limitUsed,
-      claudeLimitTotal: effective.limitTotal,
-      claudeIsPro: effective.isPro,
-      claudeIsWeekly: effective.isWeekly,
+      balanceResetAt: effective.limitResetAt?.toISOString() ?? null,
+      balanceRemaining: effective.limitRemaining,
+      balanceUsed: effective.limitUsed,
+      balanceTotal: effective.limitTotal,
+      planIsPro: effective.isPro,
+      balanceWeekly: effective.isWeekly,
     }
     return Response.json(response)
   } catch (error) {
@@ -174,13 +171,12 @@ export async function PATCH(req: NextRequest): Promise<Response> {
       customEndpoints: decryptUserEndpoints(
         newEndpoints ?? (user?.customEndpoints as unknown)
       ),
-      claudeLimitResetAt: effective.limitResetAt?.toISOString() ?? null,
-      claudeLimitUnit: effective.limitUnit,
-      claudeLimitRemaining: effective.limitRemaining,
-      claudeLimitUsed: effective.limitUsed,
-      claudeLimitTotal: effective.limitTotal,
-      claudeIsPro: effective.isPro,
-      claudeIsWeekly: effective.isWeekly,
+      balanceResetAt: effective.limitResetAt?.toISOString() ?? null,
+      balanceRemaining: effective.limitRemaining,
+      balanceUsed: effective.limitUsed,
+      balanceTotal: effective.limitTotal,
+      planIsPro: effective.isPro,
+      balanceWeekly: effective.isWeekly,
     }
     return Response.json(response)
   } catch (error) {

--- a/packages/web/app/api/user/usage/route.ts
+++ b/packages/web/app/api/user/usage/route.ts
@@ -1,34 +1,27 @@
 import { requireAuth, isAuthError, internalError, decryptUserCredentials } from "@/lib/db/api-helpers"
 import { prisma } from "@/lib/db/prisma"
-import { sumSharedUsage, countSharedMessages } from "@/lib/db/token-usage"
+import { sumSharedSpendByProvider } from "@/lib/db/token-usage"
 import {
   SHARED_POOL_AGENTS,
   providerForAgent,
   resolvePool,
 } from "@/lib/server/shared-pool"
 import {
-  getProviderBudget,
+  getDailyBalance,
   getStartOfUtcDay,
   getNextUtcDayReset,
-  type BudgetUnit,
   type Plan,
 } from "@/lib/server/usage-budgets"
 import { agentLabels, type Agent } from "@background-agents/common"
 
-/** Per-pool usage for one shared provider, for today (UTC). */
+/** One shared pool's contribution to today's spend. */
 export interface PoolUsage {
   agent: Agent
   provider: string
   label: string
-  /** Unit this pool's budget is measured in: tokens, USD cost, or messages. */
-  unit: BudgetUnit
-  /** Amount used from the shared pool today, in `unit`. */
+  /** What this pool has drawn today, in USD. */
   used: number
-  /** Estimated cost (USD) of today's shared-pool usage for this provider. */
-  costUsd: number
-  /** Daily budget in `unit`, or null when unlimited (unlimited plan, own key, or no budget). */
-  limit: number | null
-  /** True when the user has their own key for this provider (shared pool unused). */
+  /** True when the user has their own key for this provider (pool unused). */
   ownKey: boolean
 }
 
@@ -37,11 +30,16 @@ export interface UsageResponse {
   plan: Plan
   /** ISO timestamp of the next daily reset (UTC midnight). */
   resetAt: string
+  /** Spent today across every shared pool, in USD. */
+  used: number
+  /** Daily balance in USD, or null when uncapped (`unlimited` plan). */
+  limit: number | null
+  /** Per-pool breakdown of `used`, for the detail under the bar. */
   pools: PoolUsage[]
 }
 
 // =============================================================================
-// GET - per-provider shared-pool token usage for the current user (today)
+// GET - today's spend for the current user, with a per-pool breakdown
 // =============================================================================
 
 export async function GET(): Promise<Response> {
@@ -60,43 +58,25 @@ export async function GET(): Promise<Response> {
     )
     const since = getStartOfUtcDay()
 
-    const pools: PoolUsage[] = await Promise.all(
-      SHARED_POOL_AGENTS.map(async (agent) => {
-        const provider = providerForAgent(agent)
-        const ownKey = resolvePool(agent, storedCreds) === "user"
-        const budget = getProviderBudget(provider, plan)
-        const unit = budget?.unit ?? "tokens"
-        const { limitedTokens, costUsd } = await sumSharedUsage({
-          userId,
-          provider,
-          since,
-        })
-        // "used" is reported in the budget's unit so the UI can render it.
-        const used =
-          unit === "messages"
-            ? await countSharedMessages({ userId, provider, since })
-            : unit === "cost"
-              ? costUsd
-              : limitedTokens
-        // Unlimited on own key, or when the plan has no budget (unlimited plan
-        // or a provider with none configured). `budget` already reflects plan.
-        const limit = ownKey ? null : (budget?.limit ?? null)
-        return {
-          agent,
-          provider,
-          label: agentLabels[agent],
-          unit,
-          used,
-          costUsd,
-          limit,
-          ownKey,
-        }
-      })
-    )
+    // One grouped query for the whole breakdown, rather than one per provider.
+    const byProvider = await sumSharedSpendByProvider({ userId, since })
+
+    const pools: PoolUsage[] = SHARED_POOL_AGENTS.map((agent) => {
+      const provider = providerForAgent(agent)
+      return {
+        agent,
+        provider,
+        label: agentLabels[agent],
+        used: byProvider[provider] ?? 0,
+        ownKey: resolvePool(agent, storedCreds) === "user",
+      }
+    })
 
     const response: UsageResponse = {
       plan,
       resetAt: getNextUtcDayReset().toISOString(),
+      used: Object.values(byProvider).reduce((a, b) => a + b, 0),
+      limit: getDailyBalance(plan),
       pools,
     }
     return Response.json(response)

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -110,10 +110,9 @@ function HomePageContent({ isMobile }: HomePageContentProps) {
     currentChatId,
     settings,
     credentialFlags,
-    claudeLimitResetAt,
-    claudeLimitUnit,
-    claudeLimitUsed,
-    claudeLimitTotal,
+    balanceResetAt,
+    balanceUsed,
+    balanceTotal,
     isHydrated,
     isLoading,
     isLoadingMessages,
@@ -642,10 +641,9 @@ function HomePageContent({ isMobile }: HomePageContentProps) {
                     setLimitReachedState({
                       show: true,
                       provider: "claude",
-                      unit: claudeLimitUnit,
-                      used: claudeLimitUsed,
-                      limit: claudeLimitTotal,
-                      resetAt: claudeLimitResetAt ? new Date(claudeLimitResetAt) : undefined,
+                      used: balanceUsed,
+                      limit: balanceTotal,
+                      resetAt: balanceResetAt ? new Date(balanceResetAt) : undefined,
                     })
                   }}
                   onSendMessage={handleSendMessage}

--- a/packages/web/components/AppModals.tsx
+++ b/packages/web/components/AppModals.tsx
@@ -251,7 +251,6 @@ export function AppModals({
         open={limitReachedState.show}
         onClose={onDismissLimitReached}
         provider={limitReachedState.provider}
-        unit={limitReachedState.unit}
         used={limitReachedState.used}
         limit={limitReachedState.limit}
         plan={limitReachedState.plan}

--- a/packages/web/components/chat/AgentModelSelector.tsx
+++ b/packages/web/components/chat/AgentModelSelector.tsx
@@ -131,8 +131,10 @@ export function AgentModelSelector({
     setShowAgentDropdown(false)
     setShowAgentSheet(false)
 
-    // Block switching to claude-code if daily limit is exceeded
-    if (agent === "claude-code" && credentialFlags.CLAUDE_DAILY_LIMIT_EXCEEDED) {
+    // Block switching to any agent whose only route is a shared pool the user
+    // has no balance left for. agentSharedPoolExhausted is per-agent, so an
+    // agent the user has their own key for stays selectable at zero balance.
+    if (agentSharedPoolExhausted(agent, credentialFlags)) {
       showClaudeLimitDialog()
       return
     }

--- a/packages/web/components/modals/ChatUsageModal.tsx
+++ b/packages/web/components/modals/ChatUsageModal.tsx
@@ -8,29 +8,30 @@ import { useModals } from "@/lib/contexts"
 import { AgentIcon } from "@/components/icons/agent-icons"
 import { ALL_AGENTS, agentToProvider, type Agent } from "@background-agents/common"
 import type { ChatUsageResponse } from "@/app/api/chats/[chatId]/usage/route"
-import { fmtTokens } from "@/lib/format"
+import { fmtTokens, fmtBalance } from "@/lib/format"
 
 /** Reverse map: SDK provider id → agent (for the provider's icon). */
 const PROVIDER_TO_AGENT: Record<string, Agent> = Object.fromEntries(
   ALL_AGENTS.map((agent) => [agentToProvider[agent], agent])
 )
 
-/** Render a usage amount in its budget unit (tokens / USD cost / messages). */
-function fmtUsage(value: number, unit: ChatUsageResponse["providers"][number]["unit"]) {
-  if (unit === "cost") return <>${value.toFixed(2)}</>
-  if (unit === "messages")
-    return (
-      <>
-        {Math.round(value)}
-        <span className="text-muted-foreground"> {Math.round(value) === 1 ? "message" : "messages"}</span>
-      </>
-    )
+/** Render a token count with its unit label. */
+function fmtUsage(totalTokens: number) {
   return (
     <>
-      {fmtTokens(value)}
+      {fmtTokens(totalTokens)}
       <span className="text-muted-foreground"> tokens</span>
     </>
   )
+}
+
+/**
+ * Sum a numeric field across the provider rows. The modal shows a total because
+ * a chat that switched agents mid-way splits across several rows, and the useful
+ * number is what the whole conversation came to.
+ */
+function sum(rows: ChatUsageResponse["providers"], key: "totalTokens" | "costUsd") {
+  return rows.reduce((acc, r) => acc + r[key], 0)
 }
 
 interface ChatUsageModalProps {
@@ -107,6 +108,7 @@ export function ChatUsageModal({ chatId, onClose, isMobile = false }: ChatUsageM
                 No tokens recorded for this chat yet.
               </div>
             ) : (
+              <>
               <div className="divide-y divide-border/40">
                 {data.providers.map((p) => {
                   const agent = PROVIDER_TO_AGENT[p.provider]
@@ -116,13 +118,38 @@ export function ChatUsageModal({ chatId, onClose, isMobile = false }: ChatUsageM
                         {agent && <AgentIcon agent={agent} className="h-4 w-4 shrink-0" />}
                         {p.label}
                       </span>
-                      <span className="text-sm font-medium tabular-nums">
-                        {fmtUsage(p.value, p.unit)}
+                      <span className="text-right">
+                        <span className="block text-sm font-medium tabular-nums">
+                          {fmtUsage(p.totalTokens)}
+                        </span>
+                        <span className="block text-xs text-muted-foreground tabular-nums">
+                          {fmtBalance(p.costUsd)}
+                        </span>
                       </span>
                     </div>
                   )
                 })}
+
+                {data.providers.length > 1 && (
+                  <div className="flex items-center justify-between gap-3 py-2">
+                    <span className="text-sm font-medium">Total</span>
+                    <span className="text-right">
+                      <span className="block text-sm font-medium tabular-nums">
+                        {fmtUsage(sum(data.providers, "totalTokens"))}
+                      </span>
+                      <span className="block text-xs text-muted-foreground tabular-nums">
+                        {fmtBalance(sum(data.providers, "costUsd"))}
+                      </span>
+                    </span>
+                  </div>
+                )}
               </div>
+
+              <p className="text-[11px] text-muted-foreground">
+                Cost is what these tokens would bill at API list prices — including
+                turns run on your own key, which cost the platform nothing.
+              </p>
+              </>
             )}
 
             <button

--- a/packages/web/components/modals/LimitReachedDialog.tsx
+++ b/packages/web/components/modals/LimitReachedDialog.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils"
 import { ModalHeader, focusChatPrompt } from "@/components/ui/modal-header"
 import { Crown, Key, Zap } from "lucide-react"
 import { AgentIcon } from "@/components/icons/agent-icons"
-import { fmtBudgetAmount } from "@/lib/format"
+import { fmtBalance } from "@/lib/format"
 import {
   getLimitUpgradeCopy,
   type LimitUpgradeTarget,
@@ -19,11 +19,9 @@ interface LimitReachedDialogProps {
   onContinueWithOpenCode: () => void
   onAddApiKey: () => void
   onUpgradePlan: (targetPlan: LimitUpgradeTarget) => void
-  /** Shared-pool provider that hit its limit (claude | gemini | opencode). */
+  /** Shared-pool provider the blocked run would have used (claude | gemini | opencode). */
   provider?: string
-  /** Unit the budget is measured in; falls back to the provider's default. */
-  unit?: BudgetUnit
-  /** Amount used / daily budget for that provider, in `unit`. */
+  /** Spent today / the daily balance, in USD of API list value. */
   used?: number | null
   limit?: number | null
   /** Current subscription tier; defaults to Free for older responses. */
@@ -38,17 +36,6 @@ const PROVIDER_LABEL: Record<string, string> = {
   opencode: "OpenCode",
 }
 
-type BudgetUnit = "tokens" | "cost" | "messages"
-
-/**
- * Map provider to its budget unit. Mirrors server usage-budgets, and is only a
- * fallback for a caller that didn't pass the server-resolved unit.
- */
-function unitForProvider(provider?: string): BudgetUnit {
-  if (provider === "gemini") return "messages"
-  return "cost"
-}
-
 export function LimitReachedDialog({
   open,
   onClose,
@@ -56,7 +43,6 @@ export function LimitReachedDialog({
   onAddApiKey,
   onUpgradePlan,
   provider,
-  unit: unitProp,
   used,
   limit,
   plan,
@@ -64,11 +50,11 @@ export function LimitReachedDialog({
   isMobile = false,
 }: LimitReachedDialogProps) {
   const providerLabel = PROVIDER_LABEL[provider ?? ""] ?? "shared model"
-  // Don't offer "switch to OpenCode" when OpenCode itself is the limited pool.
-  const canSwitchToOpenCode = provider !== "opencode"
+  // Always offer it, even when OpenCode was the pool that ran the user out: the
+  // balance is pooled, and this routes to OpenCode's *free* models, which never
+  // draw it down and so stay available at zero.
+  const canSwitchToOpenCode = true
   const primaryButtonRef = useRef<HTMLButtonElement>(null)
-  // Prefer the server-provided unit; fall back to the provider's default.
-  const unit = unitProp ?? unitForProvider(provider)
   const upgradeCopy = getLimitUpgradeCopy(plan)
 
   // Focus the primary button when modal opens
@@ -135,19 +121,24 @@ export function LimitReachedDialog({
           <ModalHeader title="Daily Limit Reached" />
           <div className="px-4 pt-3 pb-4 space-y-4">
             <div className="text-sm text-muted-foreground">
-              You've reached your daily{" "}
-              <span className="font-medium text-foreground">{providerLabel}</span> limit
-              {typeof limit === "number" ? ` of ${fmtBudgetAmount(limit, unit)}` : ""}
-              {typeof used === "number" && typeof limit === "number"
-                ? ` (${fmtBudgetAmount(used, unit)} used)`
-                : ""}
+              You&apos;ve used your daily balance
+              {typeof limit === "number" ? (
+                <>
+                  {" "}
+                  &mdash;{" "}
+                  <span className="font-medium text-foreground">
+                    {typeof used === "number" ? fmtBalance(used) : fmtBalance(limit)} of{" "}
+                    {fmtBalance(limit)}
+                  </span>
+                </>
+              ) : null}
               . It resets at{" "}
               <span className="font-medium text-foreground">{resetTimeString}</span>.
+              Your balance is shared across Claude, OpenCode and Gemini.
             </div>
 
             <div className="space-y-2">
-              {/* Primary option: Continue with OpenCode (hidden when OpenCode is
-                  the pool that hit its limit). */}
+              {/* Primary option: OpenCode's free models, which never draw the balance. */}
               {canSwitchToOpenCode && (
                 <button
                   ref={primaryButtonRef}

--- a/packages/web/components/modals/settings/UsageSection.tsx
+++ b/packages/web/components/modals/settings/UsageSection.tsx
@@ -4,8 +4,8 @@ import { useEffect, useState } from "react"
 import { Gauge } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { MobileSectionHeader } from "./shared"
-import type { UsageResponse, PoolUsage } from "@/app/api/user/usage/route"
-import { fmtBudgetAmount } from "@/lib/format"
+import type { UsageResponse } from "@/app/api/user/usage/route"
+import { fmtBalance } from "@/lib/format"
 import { PRO_BUDGET_MULTIPLIER } from "@/lib/server/usage-budgets"
 
 /** Tailwind classes for the bar fill based on how close to the limit we are. */
@@ -15,62 +15,16 @@ function fillClass(pct: number): string {
   return "bg-primary"
 }
 
-function PoolBar({ pool }: { pool: PoolUsage }) {
-  const unlimited = pool.limit == null
-  const pct = unlimited ? 0 : Math.min(1, pool.used / Math.max(1, pool.limit!))
-
-  return (
-    <div className="py-3 border-b border-border/30 last:border-b-0">
-      <div className="flex items-baseline justify-between gap-2 mb-1.5">
-        <span className="text-sm font-medium">{pool.label}</span>
-        <span className="text-xs text-muted-foreground tabular-nums">
-          {pool.ownKey ? (
-            "Your own key"
-          ) : unlimited ? (
-            <>
-              {fmtBudgetAmount(pool.used, pool.unit)}{" "}
-              <span className="text-primary">· Unlimited</span>
-            </>
-          ) : (
-            <>
-              {fmtBudgetAmount(pool.used, pool.unit)} / {fmtBudgetAmount(pool.limit!, pool.unit)}
-            </>
-          )}
-        </span>
-      </div>
-
-      <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
-        {pool.ownKey ? null : (
-          <div
-            className={cn(
-              "h-full rounded-full transition-all",
-              unlimited ? "bg-primary/40" : fillClass(pct)
-            )}
-            style={{ width: unlimited ? "100%" : `${Math.max(2, pct * 100)}%` }}
-          />
-        )}
-      </div>
-
-      {(pool.ownKey || !unlimited) && (
-        <div className="mt-1 text-[11px] text-muted-foreground tabular-nums">
-          {pool.ownKey
-            ? "Using your own key — shared pool not used"
-            : `${fmtBudgetAmount(Math.max(0, pool.limit! - pool.used), pool.unit)} left`}
-        </div>
-      )}
-    </div>
-  )
-}
-
 interface UsageSectionProps {
   isMobile: boolean
 }
 
 /**
- * Daily usage for each shared credential pool, in that pool's own budget unit
- * (USD for Claude and OpenCode, messages for Gemini). Free and Pro users see
- * their usage against the per-provider daily budget (Pro's is PRO_BUDGET_MULTIPLIER×
- * the free one); unlimited-plan users and own-key providers show as unlimited.
+ * Today's spend against the daily balance.
+ *
+ * One balance covers every shared pool, so this is a single bar with a per-pool
+ * breakdown underneath — the breakdown is where the money went, not separate
+ * budgets. Own-key pools are listed as such: they draw nothing.
  */
 export function UsageSection({ isMobile }: UsageSectionProps) {
   const [data, setData] = useState<UsageResponse | null>(null)
@@ -95,39 +49,89 @@ export function UsageSection({ isMobile }: UsageSectionProps) {
     }
   }, [])
 
+  const unlimited = data?.limit == null
+  const pct =
+    data && data.limit != null ? Math.min(1, data.used / Math.max(data.limit, 0.0001)) : 0
+
   return (
     <div>
       {isMobile && <MobileSectionHeader icon={Gauge} label="Usage" />}
 
-      <p className="text-xs text-muted-foreground mb-2">
-        Daily usage on the shared credential pools. Resets at 00:00 UTC. Each
-        pool has its own limit, measured in whatever best reflects its cost
-        (spend, or messages).
+      <p className="text-xs text-muted-foreground mb-3">
+        Your daily balance, spent across every shared pool. Resets at 00:00 UTC.
+        Free models don&apos;t draw from it.
       </p>
 
       {error ? (
         <div className="text-sm text-destructive py-3">{error}</div>
       ) : !data ? (
         <div className="space-y-3 py-3" aria-hidden>
-          {[0, 1, 2].map((i) => (
-            <div key={i} className="space-y-2">
-              <div className="h-3 w-24 rounded bg-muted animate-pulse" />
-              <div className="h-2 w-full rounded-full bg-muted animate-pulse" />
-            </div>
-          ))}
+          <div className="h-3 w-32 rounded bg-muted animate-pulse" />
+          <div className="h-2 w-full rounded-full bg-muted animate-pulse" />
+          <div className="h-3 w-full rounded bg-muted animate-pulse" />
         </div>
       ) : (
         <div>
-          {data.pools.map((pool) => (
-            <PoolBar key={pool.provider} pool={pool} />
-          ))}
+          {/* The allowance */}
+          <div className="flex items-baseline justify-between gap-2 mb-1.5">
+            <span className="text-sm font-medium">Used today</span>
+            <span className="text-xs text-muted-foreground tabular-nums">
+              {unlimited ? (
+                <>
+                  {fmtBalance(data.used)} <span className="text-primary">· Unlimited</span>
+                </>
+              ) : (
+                <>
+                  {fmtBalance(data.used)} / {fmtBalance(data.limit!)}
+                </>
+              )}
+            </span>
+          </div>
+
+          <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+            <div
+              className={cn(
+                "h-full rounded-full transition-all",
+                unlimited ? "bg-primary/40" : fillClass(pct)
+              )}
+              style={{ width: unlimited ? "100%" : `${Math.max(2, pct * 100)}%` }}
+            />
+          </div>
+
+          {!unlimited && (
+            <div className="mt-1 text-[11px] text-muted-foreground tabular-nums">
+              {fmtBalance(Math.max(0, data.limit! - data.used))} left
+            </div>
+          )}
+
+          {/* Where they went */}
+          <div className="mt-4 border-t border-border/30 pt-2">
+            {data.pools.map((pool) => (
+              <div
+                key={pool.provider}
+                className="flex items-baseline justify-between gap-2 py-1.5 text-xs"
+              >
+                <span className="text-muted-foreground">{pool.label}</span>
+                <span className="tabular-nums text-muted-foreground">
+                  {pool.ownKey ? (
+                    "Your own key"
+                  ) : pool.used > 0 ? (
+                    <span className="text-foreground">{fmtBalance(pool.used)}</span>
+                  ) : (
+                    "—"
+                  )}
+                </span>
+              </div>
+            ))}
+          </div>
+
           {data.plan === "unlimited" ? (
             <p className="text-[11px] text-primary mt-2">
               Unlimited plan — shared pools are uncapped. Usage shown for reference.
             </p>
           ) : data.plan === "pro" ? (
             <p className="text-[11px] text-primary mt-2">
-              Pro plan — {PRO_BUDGET_MULTIPLIER}× the free daily budget on each shared pool.
+              Pro plan — {PRO_BUDGET_MULTIPLIER}× the free daily balance.
             </p>
           ) : null}
         </div>

--- a/packages/web/lib/agent-status.test.ts
+++ b/packages/web/lib/agent-status.test.ts
@@ -2,8 +2,9 @@
  * Unit tests for the agent readiness/status logic behind the picker dot:
  * agentSharedPoolExhausted plus its effect on agentHasFreeUsage / agentIsReady.
  *
- * Pure functions — no mocks. The interesting case is the Claude shared pool
- * being used up: the picker should show a red ("exhausted") dot, not green.
+ * Pure functions — no mocks. The interesting case is the daily balance
+ * allowance running out: the picker should show a red ("exhausted") dot, not
+ * green — and it must do so for every shared pool, since the balance is pooled.
  */
 import { describe, it, expect } from "vitest"
 import {
@@ -17,11 +18,11 @@ import {
 const sharedPoolFresh: CredentialFlags = { CLAUDE_SHARED_POOL_AVAILABLE: true }
 const sharedPoolUsedUp: CredentialFlags = {
   CLAUDE_SHARED_POOL_AVAILABLE: true,
-  CLAUDE_DAILY_LIMIT_EXCEEDED: true,
+  SHARED_BALANCE_EXHAUSTED: true,
 }
 const ownKeyButLimit: CredentialFlags = {
   CLAUDE_SHARED_POOL_AVAILABLE: true,
-  CLAUDE_DAILY_LIMIT_EXCEEDED: true,
+  SHARED_BALANCE_EXHAUSTED: true,
   ANTHROPIC_API_KEY: true,
 }
 
@@ -38,13 +39,32 @@ describe("agentSharedPoolExhausted", () => {
     expect(agentSharedPoolExhausted("claude-code", ownKeyButLimit)).toBe(false)
   })
 
-  it("is false for agents without a metered shared pool", () => {
-    expect(agentSharedPoolExhausted("opencode", sharedPoolUsedUp)).toBe(false)
+  it("is false for agents with no shared pool at all", () => {
+    // Kilo's free tier isn't a shared pool, so a spent balance doesn't touch it.
     expect(agentSharedPoolExhausted("kilo", sharedPoolUsedUp)).toBe(false)
+    expect(agentSharedPoolExhausted("codex", sharedPoolUsedUp)).toBe(false)
+  })
+
+  it("closes the OpenCode and Gemini pools too, because the balance is pooled", () => {
+    const allSharedSpent: CredentialFlags = {
+      SHARED_BALANCE_EXHAUSTED: true,
+      OPENCODE_API_KEY_SHARED: true,
+      GEMINI_API_KEY_SHARED: true,
+    }
+    expect(agentSharedPoolExhausted("opencode", allSharedSpent)).toBe(true)
+    expect(agentSharedPoolExhausted("gemini", allSharedSpent)).toBe(true)
+  })
+
+  it("leaves a pool open when the user brought their own key for it", () => {
+    const ownOpencodeKey: CredentialFlags = {
+      SHARED_BALANCE_EXHAUSTED: true,
+      OPENCODE_API_KEY_USER: true,
+    }
+    expect(agentSharedPoolExhausted("opencode", ownOpencodeKey)).toBe(false)
   })
 })
 
-describe("readiness when the Claude pool is used up", () => {
+describe("readiness when the balance runs out", () => {
   it("no longer reports free usage (so the dot won't be green)", () => {
     expect(agentHasFreeUsage("claude-code", sharedPoolFresh)).toBe(true)
     expect(agentHasFreeUsage("claude-code", sharedPoolUsedUp)).toBe(false)

--- a/packages/web/lib/agent-status.test.ts
+++ b/packages/web/lib/agent-status.test.ts
@@ -12,6 +12,9 @@ import {
   agentHasFreeUsage,
   agentIsReady,
   hasCredentialsForModel,
+  getFreeModelForAgent,
+  modelRequiresKey,
+  getAgentModels,
   type CredentialFlags,
 } from "@background-agents/common"
 
@@ -128,5 +131,45 @@ describe("shared Gemini pool unlocks Flash but not Pro", () => {
   it("unlocks Pro once the user brings their own Gemini key", () => {
     expect(hasCredentialsForModel(pro, geminiOwnKey, "gemini")).toBe(true)
     expect(hasCredentialsForModel(piPro, geminiOwnKey, "pi")).toBe(true)
+  })
+})
+
+describe("free models survive a spent balance", () => {
+  // The escape hatch: with the balance gone, OpenCode's free tier is what a
+  // user is told to switch to. Two separate gates have to agree on that — the
+  // picker (hasCredentialsForModel) and the send path (checkSharedPoolUsage,
+  // which keys on modelRequiresKey). If they drift, the UI offers a model the
+  // server then 429s, and "Continue with OpenCode" loops.
+  const spentWithSharedOpencode: CredentialFlags = {
+    SHARED_BALANCE_EXHAUSTED: true,
+    OPENCODE_API_KEY: true,
+    OPENCODE_API_KEY_SHARED: true,
+  }
+
+  const freeModels = getAgentModels("opencode").filter(
+    (m) => m.requiresKey === "none"
+  )
+
+  it("has free OpenCode models to fall back to", () => {
+    expect(freeModels.length).toBeGreaterThan(0)
+    expect(getFreeModelForAgent("opencode")).toBe(freeModels[0].value)
+  })
+
+  it("keeps every free model selectable in the picker", () => {
+    for (const m of freeModels) {
+      expect(hasCredentialsForModel(m, spentWithSharedOpencode, "opencode")).toBe(true)
+    }
+  })
+
+  it("marks them as needing no key, which is what the send path checks", () => {
+    for (const m of freeModels) {
+      expect(modelRequiresKey("opencode", m.value)).toBe("none")
+    }
+  })
+
+  it("still blocks the paid shared models", () => {
+    const paid = { value: "opencode-go/mimo-v2.5-pro", label: "MiMo", requiresKey: "opencode" as const }
+    expect(hasCredentialsForModel(paid, spentWithSharedOpencode, "opencode")).toBe(false)
+    expect(modelRequiresKey("opencode", paid.value)).toBe("opencode")
   })
 })

--- a/packages/web/lib/db/token-usage.ts
+++ b/packages/web/lib/db/token-usage.ts
@@ -7,13 +7,12 @@
  * (sessionId, model) — see `getSessionCumulatives` + `insertTokenUsageRows`,
  * driven by the runner in lib/server/token-metering.ts.
  *
- * `sumSharedUsage` is the read path the rate limiter uses: total tokens/cost a
- * user has consumed from a given shared pool since the start of the period.
- * `sumSharedUsageInUnit` wraps it (and the message count) to answer in whatever
- * unit a pool's budget is denominated in.
+ * `sumSharedSpend` is the read path the limiter uses: what a user has spent
+ * across every shared pool since the start of the period. `sumSharedUsage`
+ * answers the same question for one provider, for the usage views.
  */
 
-import type { BudgetUnit } from "@/lib/server/usage-budgets"
+import { BALANCE_POOL_PROVIDERS } from "@/lib/server/usage-budgets"
 
 import { prisma } from "./prisma"
 
@@ -228,34 +227,6 @@ export async function sumChatUsageByProvider(
 }
 
 /**
- * Count distinct assistant turns (messages) a user ran on one pool for a given
- * provider since `since`. Used for message-based shared-pool budgets (Gemini).
- * Counts distinct messageId so a turn that produced several model rows is one
- * message; free-model turns are excluded from shared budgets like elsewhere.
- */
-export async function countSharedMessages(params: {
-  userId: string
-  provider: string
-  since: Date
-  pool?: UsagePool
-}): Promise<number> {
-  const { userId, provider, since, pool = "shared" } = params
-  const rows = await prisma.tokenUsage.findMany({
-    where: {
-      userId,
-      provider,
-      pool,
-      createdAt: { gte: since },
-      messageId: { not: null },
-      ...(pool === "shared" ? { freeModel: false } : {}),
-    },
-    distinct: ["messageId"],
-    select: { messageId: true },
-  })
-  return rows.length
-}
-
-/**
  * Sum a user's usage from one pool for a given provider since `since`.
  * This is the limiter's aggregation query (indexed by
  * userId+provider+pool+createdAt).
@@ -288,21 +259,56 @@ export async function sumSharedUsage(params: {
 }
 
 /**
- * A user's shared-pool usage for one provider since `since`, expressed in that
- * provider's budget unit. The one place that knows how each unit maps onto the
- * ledger — the limiter, the settings limit display and the usage view all read
- * through it, so they can't disagree about what "used" means.
+ * What a user has spent since `since`, pooled across every shared provider.
+ *
+ * This is the limiter's aggregation query, and the single definition of "used"
+ * — the limiter, the settings display and the usage view all read through it, so
+ * they cannot disagree. Own-key runs are excluded because they were never
+ * stamped `pool: "shared"`; free models are excluded by `freeModel`, which is
+ * what keeps them usable on a spent allowance.
  */
-export async function sumSharedUsageInUnit(params: {
+export async function sumSharedSpend(params: {
   userId: string
-  provider: string
-  unit: BudgetUnit
   since: Date
 }): Promise<number> {
-  const { userId, provider, unit, since } = params
-  if (unit === "messages") {
-    return countSharedMessages({ userId, provider, since })
+  const { userId, since } = params
+  const agg = await prisma.tokenUsage.aggregate({
+    where: {
+      userId,
+      pool: "shared",
+      freeModel: false,
+      provider: { in: [...BALANCE_POOL_PROVIDERS] },
+      createdAt: { gte: since },
+    },
+    _sum: { costUsd: true },
+  })
+  return agg._sum.costUsd ?? 0
+}
+
+/**
+ * The same sum, split by provider — for the breakdown under the usage bar.
+ * Providers with no spend are omitted.
+ */
+export async function sumSharedSpendByProvider(params: {
+  userId: string
+  since: Date
+}): Promise<Record<string, number>> {
+  const { userId, since } = params
+  const grouped = await prisma.tokenUsage.groupBy({
+    by: ["provider"],
+    where: {
+      userId,
+      pool: "shared",
+      freeModel: false,
+      provider: { in: [...BALANCE_POOL_PROVIDERS] },
+      createdAt: { gte: since },
+    },
+    _sum: { costUsd: true },
+  })
+  const out: Record<string, number> = {}
+  for (const g of grouped) {
+    const spend = g._sum.costUsd ?? 0
+    if (spend > 0) out[g.provider] = spend
   }
-  const { limitedTokens, costUsd } = await sumSharedUsage({ userId, provider, since })
-  return unit === "cost" ? costUsd : limitedTokens
+  return out
 }

--- a/packages/web/lib/db/usage-limit.ts
+++ b/packages/web/lib/db/usage-limit.ts
@@ -15,7 +15,7 @@
  * allowance resets at UTC midnight and nothing carries over.
  */
 
-import type { Agent, ProviderName } from "@background-agents/common"
+import { modelRequiresKey, type Agent, type ProviderName } from "@background-agents/common"
 
 import { prisma } from "./prisma"
 import { sumSharedSpend } from "./token-usage"
@@ -85,6 +85,21 @@ export async function checkSharedPoolUsage(
   // genuine shared-pool run (incl. a Gemini model under Pi/Droid), so gating on
   // the resolved pool covers every case without an agent allowlist.
   if (pool === "user") {
+    return { ...base, allowed: true, limit: null, remaining: null }
+  }
+
+  // A model that needs no credential costs the platform nothing and is already
+  // excluded from the balance sum (freeModel), so it stays available at zero.
+  // This mirrors the first line of hasCredentialsForModel, which is what keeps
+  // the picker and the send path in agreement: without it the UI offers
+  // OpenCode's free tier as the way out of a spent balance and the server then
+  // rejects it — including the "Continue with OpenCode" retry, which would loop
+  // straight back into a 429.
+  //
+  // Checked via requiresKey rather than isFreeModel: that helper matches
+  // tokscale's bare ids at write time and misses "opencode/big-pickle", which
+  // has no -free suffix.
+  if (modelRequiresKey(agent, model) === "none") {
     return { ...base, allowed: true, limit: null, remaining: null }
   }
 

--- a/packages/web/lib/db/usage-limit.ts
+++ b/packages/web/lib/db/usage-limit.ts
@@ -1,43 +1,44 @@
 /**
- * Usage limits for the shared credential pools.
+ * The daily spending balance for the shared credential pools.
  *
- * Free users get a daily, per-provider budget when using a shared pool (Claude
- * OAuth / Gemini / OpenCode server keys), denominated in whatever unit that pool
- * is metered in — see lib/server/usage-budgets. Pro users get the same budget
- * scaled by PRO_BUDGET_MULTIPLIER; only `unlimited`-plan users (and anyone
- * running on their own key) are uncapped. Usage is summed from the TokenUsage
- * ledger (populated post-turn by tokscale metering).
+ * Free users get a daily balance, denominated in US dollars of API list value,
+ * spent across every shared pool (Claude OAuth / Gemini / OpenCode server keys)
+ * rather than budgeted per provider. Pro gets the same balance scaled by
+ * PRO_BUDGET_MULTIPLIER; only `unlimited`-plan users, and anyone running on
+ * their own key, are uncapped. Spending is summed from the TokenUsage ledger
+ * (populated post-turn by tokscale metering).
  *
  * Because a turn's cost is only known after it runs, enforcement is post-hoc:
- * we block the NEXT turn once the period's usage has met the budget.
+ * we block the NEXT turn once the day's spending has met the allowance. That
+ * means one turn can overshoot — a single agentic run has been observed at $476
+ * — and nothing here bounds that. The blast radius is one day, since the
+ * allowance resets at UTC midnight and nothing carries over.
  */
 
 import type { Agent, ProviderName } from "@background-agents/common"
 
 import { prisma } from "./prisma"
-import { sumSharedUsageInUnit } from "./token-usage"
+import { sumSharedSpend } from "./token-usage"
 import { providerForRun, resolvePool } from "@/lib/server/shared-pool"
 import { decryptUserCredentials } from "./api-helpers"
 import { formatUsageLimitMessage } from "@/lib/usage-limit-copy"
 import {
-  getProviderBudget,
+  getDailyBalance,
   getNextUtcDayReset,
   getStartOfUtcDay,
-  type BudgetUnit,
   type Plan,
 } from "@/lib/server/usage-budgets"
 
 export interface UsageLimitResult {
   allowed: boolean
   plan: Plan
+  /** Provider this run would have been billed to — for logging and telemetry. */
   provider: ProviderName
-  /** "shared" pools are limited; "user" pools are always allowed. */
+  /** "shared" pools draw the balance; "user" pools are always allowed. */
   pool: "shared" | "user"
-  /** Unit the budget is measured in: tokens, USD cost, or message count. */
-  unit: BudgetUnit
-  /** Amount used in the current period, in `unit` (tokens / USD / messages). */
+  /** Spent today, across every shared pool. */
   used: number
-  /** Daily budget in `unit` (Free/Pro), or null for Unlimited/own-key runs. */
+  /** Daily balance (Free/Pro), or null for Unlimited/own-key runs. */
   limit: number | null
   remaining: number | null
   resetAt: Date
@@ -45,10 +46,16 @@ export interface UsageLimitResult {
 }
 
 /**
- * Check whether a user may start a turn on `agent` given the shared-pool token
- * budget. Unlimited (allowed, no limit) when: the agent has no shared pool, the
- * user supplied their own key for it, or the user is on the `unlimited` plan.
- * Free and Pro users are capped (Pro at PRO_BUDGET_MULTIPLIER× the free budget).
+ * Check whether a user may start a turn on `agent` given their daily
+ * balance. Uncapped (allowed, no limit) when: the agent has no shared pool,
+ * the user supplied their own key for it, or the user is on the `unlimited`
+ * plan. Free and Pro are capped (Pro at PRO_BUDGET_MULTIPLIER× free).
+ *
+ * Note the asymmetry, and that it is deliberate: whether *this* run is metered
+ * depends on the agent and model being used right now, but how much has been
+ * *spent* is pooled across every shared provider. So a user who spent their
+ * balance on Claude is blocked on Gemini too — unless they have their own
+ * Gemini key, in which case this run resolves to the "user" pool and is allowed.
  */
 export async function checkSharedPoolUsage(
   userId: string,
@@ -68,52 +75,35 @@ export async function checkSharedPoolUsage(
     user?.credentials as Record<string, unknown> | null
   )
   // resolvePool folds in the model: custom endpoints and own-key runs read as
-  // "user" (never rate-limited), and a Gemini model under a BYOK agent (Pi,
-  // Droid) reads as the shared Gemini pool.
+  // "user" (never limited), and a Gemini model under a BYOK agent (Pi, Droid)
+  // reads as the shared Gemini pool.
   const pool = resolvePool(agent, storedCreds, model)
 
-  const budget = getProviderBudget(provider, plan)
+  const base = { plan, provider, pool, used: 0, resetAt }
 
-  const base = {
-    plan,
-    provider,
-    pool,
-    unit: budget?.unit ?? ("tokens" as BudgetUnit),
-    used: 0,
-    resetAt,
-  }
-
-  // Not a shared-pool run → unlimited. resolvePool returns "shared" only for a
+  // Not a shared-pool run → uncapped. resolvePool returns "shared" only for a
   // genuine shared-pool run (incl. a Gemini model under Pi/Droid), so gating on
   // the resolved pool covers every case without an agent allowlist.
   if (pool === "user") {
     return { ...base, allowed: true, limit: null, remaining: null }
   }
 
-  if (budget == null) {
-    // Unlimited plan, or a provider with no configured budget ⇒ unlimited.
+  const allowance = getDailyBalance(plan)
+  if (allowance == null) {
+    // Unlimited plan ⇒ uncapped.
     return { ...base, allowed: true, limit: null, remaining: null }
   }
 
-  const used = await sumSharedUsageInUnit({
-    userId,
-    provider,
-    unit: budget.unit,
-    since: getStartOfUtcDay(),
-  })
-
-  const remaining = Math.max(0, budget.limit - used)
-  const allowed = used < budget.limit
+  const used = await sumSharedSpend({ userId, since: getStartOfUtcDay() })
+  const remaining = Math.max(0, allowance - used)
+  const allowed = used < allowance
 
   return {
     ...base,
-    unit: budget.unit,
     allowed,
     used,
-    limit: budget.limit,
+    limit: allowance,
     remaining,
-    error: allowed
-      ? undefined
-      : formatUsageLimitMessage({ plan, provider, unit: budget.unit, limit: budget.limit }),
+    error: allowed ? undefined : formatUsageLimitMessage({ plan, limit: allowance }),
   }
 }

--- a/packages/web/lib/format.ts
+++ b/packages/web/lib/format.ts
@@ -18,19 +18,13 @@ export function fmtTokens(n: number): string {
 }
 
 /**
- * Format a usage amount in its budget unit:
- *   cost     → "$1.23", or "<$0.01" for a nonzero amount that rounds to nothing
- *   messages → "3 messages" / "1 message"
- *   tokens   → "12.3K tokens"
+ * Format a balance for display: "$5.00", "$4.20", or "<$0.01".
  *
- * The sub-cent case matters: a daily cost budget is a fraction of a dollar, so
- * the first turn of the day would otherwise read "$0.00 used" and look broken.
+ * The balance is denominated in dollars of API list value, so it reads as money
+ * — "$4.20 of $5.00", not "4.20 credits". The sub-cent case matters: a daily
+ * balance is a handful of dollars, so the first turn of the day would otherwise
+ * read "$0.00 used" and look broken.
  */
-export function fmtBudgetAmount(n: number, unit: "tokens" | "cost" | "messages"): string {
-  if (unit === "cost") return n > 0 && n < 0.005 ? "<$0.01" : `$${n.toFixed(2)}`
-  if (unit === "messages") {
-    const m = Math.round(n)
-    return `${m} ${m === 1 ? "message" : "messages"}`
-  }
-  return `${fmtTokens(n)} tokens`
+export function fmtBalance(n: number): string {
+  return n > 0 && n < 0.005 ? "<$0.01" : `$${n.toFixed(2)}`
 }

--- a/packages/web/lib/hooks/useChatWithSync.ts
+++ b/packages/web/lib/hooks/useChatWithSync.ts
@@ -12,7 +12,7 @@ import { useEffect, useCallback, useMemo, useRef } from "react"
 import { useSession } from "next-auth/react"
 import { useQueryClient } from "@tanstack/react-query"
 import type { Chat, ChatStatus, CustomEndpoint } from "@/lib/types"
-import { getDefaultModelForAgent } from "@/lib/types"
+import { getDefaultModelForAgent, getFreeModelForAgent } from "@/lib/types"
 import type { Credentials } from "@/lib/credentials"
 import { basename } from "@/lib/format"
 import { DEFAULT_SETTINGS } from "@/lib/storage"
@@ -98,13 +98,12 @@ export function useChatWithSync() {
 
   const settings = settingsQuery.data?.settings ?? DEFAULT_SETTINGS
   const credentialFlags = settingsQuery.data?.credentialFlags ?? {}
-  const claudeLimitResetAt = settingsQuery.data?.claudeLimitResetAt ?? null
-  const claudeLimitUnit = settingsQuery.data?.claudeLimitUnit
-  const claudeLimitUsed = settingsQuery.data?.claudeLimitUsed ?? null
-  const claudeLimitTotal = settingsQuery.data?.claudeLimitTotal ?? null
-  const claudeLimitRemaining = settingsQuery.data?.claudeLimitRemaining ?? null
-  const claudeIsPro = settingsQuery.data?.claudeIsPro ?? false
-  const claudeIsWeekly = settingsQuery.data?.claudeIsWeekly ?? false
+  const balanceResetAt = settingsQuery.data?.balanceResetAt ?? null
+  const balanceUsed = settingsQuery.data?.balanceUsed ?? null
+  const balanceTotal = settingsQuery.data?.balanceTotal ?? null
+  const balanceRemaining = settingsQuery.data?.balanceRemaining ?? null
+  const planIsPro = settingsQuery.data?.planIsPro ?? false
+  const balanceWeekly = settingsQuery.data?.balanceWeekly ?? false
   const currentChat = useMemo(() => chats.find((c) => c.id === currentChatId) ?? null, [chats, currentChatId])
   // While NextAuth is still resolving the session, the chats/settings queries
   // are disabled (enabled: isAuthenticated). A disabled React Query reports
@@ -324,8 +323,13 @@ export function useChatWithSync() {
     // Close the dialog first
     setLimitReachedState({ show: false })
 
-    // Get the default model for OpenCode
-    const openCodeModel = getDefaultModelForAgent("opencode", credentialFlags)
+    // The balance is spent, so route straight to a model that never draws it.
+    // Falling back through getDefaultModelForAgent would depend on the settings
+    // query having already delivered SHARED_BALANCE_EXHAUSTED, which it may not
+    // have — and retrying into a paid model would just hit the same 429.
+    const openCodeModel =
+      getFreeModelForAgent("opencode") ??
+      getDefaultModelForAgent("opencode", credentialFlags)
 
     // Send the message with OpenCode agent
     sendMessage(
@@ -344,13 +348,12 @@ export function useChatWithSync() {
     currentChatId,
     settings,
     credentialFlags,
-    claudeLimitResetAt,
-    claudeLimitUnit,
-    claudeLimitUsed,
-    claudeLimitTotal,
-    claudeLimitRemaining,
-    claudeIsPro,
-    claudeIsWeekly,
+    balanceResetAt,
+    balanceUsed,
+    balanceTotal,
+    balanceRemaining,
+    planIsPro,
+    balanceWeekly,
     isHydrated,
     isLoading,
     isLoadingMessages,

--- a/packages/web/lib/hooks/useMessageDispatch.ts
+++ b/packages/web/lib/hooks/useMessageDispatch.ts
@@ -221,7 +221,6 @@ export function useMessageDispatch({
               pendingMessage: { chatId, content, files, planMode },
               plan: result.plan,
               provider: result.provider,
-              unit: result.unit,
               used: result.used,
               limit: result.limit,
               resetAt: result.resetAt ? new Date(result.resetAt) : undefined,

--- a/packages/web/lib/query/hooks/useSettingsQuery.ts
+++ b/packages/web/lib/query/hooks/useSettingsQuery.ts
@@ -6,20 +6,18 @@ import { useSession } from "next-auth/react"
 import { queryKeys } from "../keys"
 import { fetchSettings, fetchSharedPoolFlags } from "@/lib/sync/api"
 import type { Settings, CredentialFlags, CustomEndpoint } from "@/lib/types"
-import type { BudgetUnit } from "@/lib/server/usage-budgets"
 import { DEFAULT_SETTINGS } from "@/lib/storage"
 
 export interface SettingsData {
   settings: Settings
   credentialFlags: CredentialFlags
   customEndpoints?: CustomEndpoint[]
-  claudeLimitResetAt?: string | null
-  claudeLimitUnit?: BudgetUnit
-  claudeLimitRemaining?: number | null
-  claudeLimitUsed?: number | null
-  claudeLimitTotal?: number | null
-  claudeIsPro?: boolean
-  claudeIsWeekly?: boolean
+  balanceResetAt?: string | null
+  balanceRemaining?: number | null
+  balanceUsed?: number | null
+  balanceTotal?: number | null
+  planIsPro?: boolean
+  balanceWeekly?: boolean
 }
 
 /**
@@ -59,13 +57,12 @@ export function useSettingsQuery() {
         settings: response.settings,
         credentialFlags: response.credentialFlags,
         customEndpoints: response.customEndpoints,
-        claudeLimitResetAt: response.claudeLimitResetAt,
-        claudeLimitUnit: response.claudeLimitUnit,
-        claudeLimitRemaining: response.claudeLimitRemaining,
-        claudeLimitUsed: response.claudeLimitUsed,
-        claudeLimitTotal: response.claudeLimitTotal,
-        claudeIsPro: response.claudeIsPro,
-        claudeIsWeekly: response.claudeIsWeekly,
+        balanceResetAt: response.balanceResetAt,
+        balanceRemaining: response.balanceRemaining,
+        balanceUsed: response.balanceUsed,
+        balanceTotal: response.balanceTotal,
+        planIsPro: response.planIsPro,
+        balanceWeekly: response.balanceWeekly,
       }
     },
     // Wait until NextAuth resolves so we don't fetch the anon endpoint for a

--- a/packages/web/lib/query/hooks/useUpdateSettingsMutation.ts
+++ b/packages/web/lib/query/hooks/useUpdateSettingsMutation.ts
@@ -48,18 +48,18 @@ export function useUpdateSettingsMutation() {
     },
     onSuccess: (response) => {
       // Update with the full server response. Must carry every field —
-      // dropping any (e.g. customEndpoints or the claudeLimit* fields) would
+      // dropping any (e.g. customEndpoints or the balance* fields) would
       // blank it in the cache until the next refetch.
       queryClient.setQueryData<SettingsData>(queryKeys.settings.all, {
         settings: response.settings,
         credentialFlags: response.credentialFlags,
         customEndpoints: response.customEndpoints,
-        claudeLimitResetAt: response.claudeLimitResetAt,
-        claudeLimitRemaining: response.claudeLimitRemaining,
-        claudeLimitUsed: response.claudeLimitUsed,
-        claudeLimitTotal: response.claudeLimitTotal,
-        claudeIsPro: response.claudeIsPro,
-        claudeIsWeekly: response.claudeIsWeekly,
+        balanceResetAt: response.balanceResetAt,
+        balanceRemaining: response.balanceRemaining,
+        balanceUsed: response.balanceUsed,
+        balanceTotal: response.balanceTotal,
+        planIsPro: response.planIsPro,
+        balanceWeekly: response.balanceWeekly,
       })
     },
     onError: (err, _, context) => {

--- a/packages/web/lib/server/credential-flags.ts
+++ b/packages/web/lib/server/credential-flags.ts
@@ -5,31 +5,29 @@
 
 import { prisma } from "@/lib/db/prisma"
 import { isSharedPoolAvailable } from "@/lib/claude-credentials"
-import { sumSharedUsageInUnit } from "@/lib/db/token-usage"
+import { sumSharedSpend } from "@/lib/db/token-usage"
 import { decryptUserCredentials } from "@/lib/db/api-helpers"
 import {
-  getProviderBudget,
+  getDailyBalance,
   getStartOfUtcDay,
   getNextUtcDayReset,
   getStartOfUtcWeek,
   getNextUtcWeekReset,
-  type BudgetUnit,
   type Plan,
 } from "@/lib/server/usage-budgets"
 import { flagsFromCredentials, CREDENTIAL_KEYS, type CredentialFlags } from "@/lib/credentials"
 import { hasSharedOpencodeKey } from "@/lib/server/opencode-pool"
-import { sharedClaudePoolEligible } from "@background-agents/common"
+import { SHARED_POOL_AGENTS } from "@/lib/server/shared-pool"
+import { agentUsesSharedPool } from "@background-agents/common"
 
 export interface EffectiveFlags {
   flags: CredentialFlags
   limitResetAt: Date | null
-  /** Unit the three amounts below are measured in (USD cost for Claude). */
-  limitUnit: BudgetUnit
-  /** Remaining allowance for capped plans; null = unlimited. */
+  /** Balance remaining for capped plans; null = unlimited. */
   limitRemaining: number | null
-  /** Amount used from the shared Claude pool this period (daily capped / weekly unlimited). */
+  /** Spent across the shared pools this period (daily capped / weekly unlimited). */
   limitUsed: number | null
-  /** Daily budget for capped plans (free/pro); null when unlimited. */
+  /** Daily balance for capped plans (free/pro); null when unlimited. */
   limitTotal: number | null
   /** Whether usage is tracked weekly (unlimited plan) vs daily (free/pro) */
   isWeekly: boolean
@@ -127,9 +125,12 @@ export async function getEffectiveCredentialFlags(userId: string): Promise<Effec
     flags.CLAUDE_SHARED_POOL_AVAILABLE = true
   }
 
-  // Check daily limit only for free users who would use the shared pool
-  // (no personal API key or subscription token)
-  const usesSharedPool = sharedClaudePoolEligible(flags)
+  // The balance is pooled across every shared pool, so track it for anyone who
+  // draws on at least one of them. A user with their own key everywhere spends
+  // nothing and gets no balance display.
+  const usesSharedPool = SHARED_POOL_AGENTS.some((agent) =>
+    agentUsesSharedPool(agent, flags)
+  )
   const plan: Plan = user?.plan ?? "free"
   const isPro = plan !== "free"
 
@@ -139,47 +140,29 @@ export async function getEffectiveCredentialFlags(userId: string): Promise<Effec
   let limitTotal: number | null = null
   let isWeekly = false
 
-  // The unit the Claude pool is budgeted in (USD cost). Read from the free-tier
-  // descriptor so it's still defined on the `unlimited` plan, which has no
-  // budget of its own but still displays usage.
-  const budget = getProviderBudget("claude", plan)
-  const limitUnit: BudgetUnit = budget?.unit ?? getProviderBudget("claude")?.unit ?? "cost"
-
   if (usesSharedPool) {
-    if (plan === "unlimited") {
-      // Unlimited plan: weekly usage for display only — no cap.
+    const allowance = getDailyBalance(plan)
+
+    if (allowance == null) {
+      // Unlimited plan: weekly spend for display only — no cap.
       isWeekly = true
-      limitUsed = await sumSharedUsageInUnit({
-        userId,
-        provider: "claude",
-        unit: limitUnit,
-        since: getStartOfUtcWeek(),
-      })
+      limitUsed = await sumSharedSpend({ userId, since: getStartOfUtcWeek() })
       limitResetAt = getNextUtcWeekReset()
       // limitTotal / limitRemaining stay null (unlimited)
     } else {
-      // Free and Pro users: daily budget (Pro = PRO_BUDGET_MULTIPLIER× free).
-      const used = await sumSharedUsageInUnit({
-        userId,
-        provider: "claude",
-        unit: limitUnit,
-        since: getStartOfUtcDay(),
-      })
+      // Free and Pro: daily allowance (Pro = PRO_BUDGET_MULTIPLIER× free).
+      const used = await sumSharedSpend({ userId, since: getStartOfUtcDay() })
       limitUsed = used
       limitResetAt = getNextUtcDayReset()
-
-      if (budget != null) {
-        limitTotal = budget.limit
-        limitRemaining = Math.max(0, budget.limit - used)
-        flags.CLAUDE_DAILY_LIMIT_EXCEEDED = used >= budget.limit
-      }
+      limitTotal = allowance
+      limitRemaining = Math.max(0, allowance - used)
+      flags.SHARED_BALANCE_EXHAUSTED = used >= allowance
     }
   }
 
   return {
     flags,
     limitResetAt,
-    limitUnit,
     limitRemaining,
     limitUsed,
     limitTotal,

--- a/packages/web/lib/server/shared-pool.ts
+++ b/packages/web/lib/server/shared-pool.ts
@@ -95,6 +95,19 @@ export interface UsageMeta {
    * keys. Absent for own-key runs and single-credential pools.
    */
   keyId?: string
+  /**
+   * The model this run was actually started with.
+   *
+   * Normally redundant — tokscale reports the model itself. It exists for the
+   * CLIs that don't: Droid runs a BYOK model through a synthetic
+   * `custom:byok-0` entry and writes `byok-0` as the model id, which no price
+   * table can resolve, so the turn would meter at $0. Metering falls back to
+   * this when tokscale's id is a known placeholder (see token-metering).
+   *
+   * Omitted for custom endpoints, whose `endpoint:<id>` value names our config
+   * row rather than a model anyone can price.
+   */
+  model?: string
 }
 
 /**
@@ -118,7 +131,16 @@ export function buildUsageMeta(
     pool === "shared" && provider === "opencode"
       ? fingerprintKey(resolvedKey)
       : undefined
-  return { pool, provider, ...(keyId ? { keyId } : {}) }
+  // An `endpoint:<id>` value names a config row, not a model, so it would be
+  // useless (and misleading) as a pricing fallback.
+  const runModel =
+    model && !model.startsWith(ENDPOINT_MODEL_PREFIX) ? model : undefined
+  return {
+    pool,
+    provider,
+    ...(keyId ? { keyId } : {}),
+    ...(runModel ? { model: runModel } : {}),
+  }
 }
 
 /**
@@ -129,16 +151,18 @@ export function readUsageMeta(metadata: unknown): UsageMeta | null {
   if (!metadata || typeof metadata !== "object") return null
   const usage = (metadata as { usage?: unknown }).usage
   if (!usage || typeof usage !== "object") return null
-  const { pool, provider, keyId } = usage as {
+  const { pool, provider, keyId, model } = usage as {
     pool?: unknown
     provider?: unknown
     keyId?: unknown
+    model?: unknown
   }
   if ((pool === "shared" || pool === "user") && typeof provider === "string") {
     return {
       pool,
       provider: provider as ProviderName,
       ...(typeof keyId === "string" && keyId ? { keyId } : {}),
+      ...(typeof model === "string" && model ? { model } : {}),
     }
   }
   return null

--- a/packages/web/lib/server/token-metering.ts
+++ b/packages/web/lib/server/token-metering.ts
@@ -32,6 +32,7 @@ import {
 import { isFreeModel } from "@/lib/server/usage-budgets"
 import { priceClaudeTurn } from "@/lib/server/claude-pricing"
 import { readUsageMeta } from "@/lib/server/shared-pool"
+import { resolveTurnModel, floorCostUsd } from "@/lib/server/turn-pricing"
 
 /** `tokscale models --json --group-by session,model` entry shape (subset). */
 interface TokscaleEntry {
@@ -69,6 +70,12 @@ export interface MeterTurnParams {
   keyId?: string | null
   /** the agent session id (matches tokscale's groupBy=session value) */
   sessionId: string
+  /**
+   * The model the run was started with, from the stamped usage metadata. Used
+   * only to replace a placeholder id the CLI reported (see resolveTurnModel);
+   * null when unknown or when the run used a custom endpoint.
+   */
+  runModel?: string | null
 }
 
 /**
@@ -110,7 +117,8 @@ async function meterTurnUsage(
   sandbox: DaytonaSandbox,
   params: MeterTurnParams
 ): Promise<number> {
-  const { userId, chatId, messageId, provider, pool, keyId, sessionId } = params
+  const { userId, chatId, messageId, provider, pool, keyId, sessionId, runModel } =
+    params
 
   if (!sessionId) return 0
 
@@ -176,6 +184,11 @@ async function meterTurnUsage(
     const key = e.model ?? ""
     const prev = prior.get(key) ?? ZERO_CUMULATIVE
 
+    // Recover a real model id when the CLI reported a placeholder. The diff
+    // cursor above still keys on tokscale's own id (`key`), so substituting
+    // here changes what we price and store without breaking the delta chain.
+    const model = resolveTurnModel(e.model, runModel)
+
     // Per-component delta = current tokscale cumulative − sum of prior deltas.
     // Clamp at 0 to absorb any non-monotonic reporting (e.g. session reset).
     const d = (cur: number, was: number) => Math.max(0, Math.round(cur - was))
@@ -189,7 +202,7 @@ async function meterTurnUsage(
       inputTokens + outputTokens + cacheReadTokens + cacheWriteTokens + reasoningTokens
     // Free models: tokscale misprices them, so force cost to 0. They're still
     // recorded (counted in overall totals) but flagged out of shared budgets.
-    const free = isFreeModel(e.model)
+    const free = isFreeModel(model)
     // The Claude pool's budget is denominated in dollars, so price its deltas
     // from Anthropic's own rates. Every other provider (and any model these
     // rates don't cover) keeps tokscale's figure, diffed like the token
@@ -197,7 +210,7 @@ async function meterTurnUsage(
     // two cumulative costs — same result, one less place to drift.
     const ownPrice =
       provider === "claude"
-        ? priceClaudeTurn(e.model, {
+        ? priceClaudeTurn(model, {
             inputTokens,
             outputTokens,
             cacheReadTokens,
@@ -210,12 +223,21 @@ async function meterTurnUsage(
       // added yet. Worth a line in the logs: the fallback is only as good as
       // whatever tokscale resolved, which may be $0.
       console.warn(
-        `[token-metering] no first-party rate for Claude model "${e.model}" — using tokscale's cost`
+        `[token-metering] no first-party rate for Claude model "${model}" — using tokscale's cost`
       )
     }
-    const costUsd = free
-      ? 0
-      : (ownPrice ?? Math.max(0, e.cost - prev.costUsd))
+    let costUsd = free ? 0 : (ownPrice ?? Math.max(0, e.cost - prev.costUsd))
+
+    // Nothing on a shared pool may cost zero while consuming real tokens: the
+    // daily balance is the only cap, so a $0 turn is a free route around it.
+    // This catches a model id neither our rates nor tokscale could resolve.
+    if (!free && pool === "shared" && totalTokens > 0 && costUsd === 0) {
+      costUsd = floorCostUsd(totalTokens)
+      console.warn(
+        `[token-metering] no price for "${model}" (${provider}) — ` +
+          `charging the floor rate for ${totalTokens} tokens`
+      )
+    }
 
     // Skip no-op turns (nothing new since last capture).
     if (totalTokens === 0 && costUsd === 0) continue
@@ -228,7 +250,7 @@ async function meterTurnUsage(
       chatId,
       messageId: messageId ?? null,
       provider,
-      model: e.model ?? null,
+      model: model ?? null,
       pool,
       keyId: keyId ?? null,
       freeModel: free,
@@ -290,5 +312,6 @@ export async function meterAssistantTurn(
     pool: meta?.pool ?? "user",
     keyId: meta?.keyId ?? null,
     sessionId: params.sessionId,
+    runModel: meta?.model ?? null,
   })
 }

--- a/packages/web/lib/server/turn-pricing.test.ts
+++ b/packages/web/lib/server/turn-pricing.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Unit tests for the two decisions that keep a metered turn from costing $0.
+ *
+ * Both exist because the daily balance is now the only cap: an unpriceable turn
+ * is not a rounding error, it is a free route around it.
+ */
+import { describe, it, expect } from "vitest"
+
+import { resolveTurnModel, floorCostUsd } from "./turn-pricing"
+
+describe("resolveTurnModel", () => {
+  it("swaps Droid's BYOK placeholder for the model the run actually used", () => {
+    // Droid runs a BYOK model through `-m custom:byok-0` and writes "byok-0"
+    // as the model id, which no price table resolves. Before this, a Gemini
+    // model under Droid on the shared key metered at $0.
+    expect(resolveTurnModel("byok-0", "gemini-3.5-flash-lite")).toBe(
+      "gemini-3.5-flash-lite"
+    )
+    expect(resolveTurnModel("custom:byok-0", "gemini-2.5-flash")).toBe(
+      "gemini-2.5-flash"
+    )
+  })
+
+  it("swaps Claude Code's synthetic placeholder too", () => {
+    expect(resolveTurnModel("<synthetic>", "claude-opus-4-8")).toBe("claude-opus-4-8")
+  })
+
+  it("matches placeholders regardless of case", () => {
+    expect(resolveTurnModel("BYOK-0", "gemini-2.5-flash")).toBe("gemini-2.5-flash")
+  })
+
+  it("never overrides a real model id", () => {
+    // The reported id is the authority whenever it names something priceable —
+    // the chat's model can drift from what the CLI actually ran.
+    expect(resolveTurnModel("claude-fable-5", "claude-sonnet-5")).toBe("claude-fable-5")
+    expect(resolveTurnModel("mimo-v2.5-pro", "glm-5.2")).toBe("mimo-v2.5-pro")
+  })
+
+  it("keeps the placeholder when no run model is known", () => {
+    // Older messages carry no model in their usage metadata. The row is still
+    // written — the floor rate is what stops it being free.
+    expect(resolveTurnModel("byok-0", null)).toBe("byok-0")
+    expect(resolveTurnModel("byok-0", undefined)).toBe("byok-0")
+  })
+
+  it("returns null for a turn with no model at all", () => {
+    expect(resolveTurnModel(null, null)).toBeNull()
+    expect(resolveTurnModel(undefined, "gemini-2.5-flash")).toBeNull()
+  })
+})
+
+describe("floorCostUsd", () => {
+  it("is never zero for a turn that consumed tokens", () => {
+    // The whole point: $0 on a shared pool is uncapped usage.
+    expect(floorCostUsd(1)).toBeGreaterThan(0)
+    expect(floorCostUsd(6_807_223)).toBeGreaterThan(0)
+  })
+
+  it("is cheap enough not to punish a user for our gap", () => {
+    // Priced off the cheapest paid model in use, so ~7M tokens — the observed
+    // byok-0 volume — costs under a tenth of a dollar against a $5 balance.
+    expect(floorCostUsd(6_807_223)).toBeLessThan(0.1)
+  })
+
+  it("scales linearly with tokens", () => {
+    expect(floorCostUsd(2_000_000)).toBeCloseTo(floorCostUsd(1_000_000) * 2, 12)
+  })
+
+  it("is zero for an empty turn", () => {
+    expect(floorCostUsd(0)).toBe(0)
+  })
+})

--- a/packages/web/lib/server/turn-pricing.ts
+++ b/packages/web/lib/server/turn-pricing.ts
@@ -1,0 +1,63 @@
+/**
+ * The two rules that stop a metered turn from costing $0.
+ *
+ * Both exist because the daily balance (lib/server/usage-budgets) is the only
+ * cap on shared-pool usage. A turn that consumes real tokens but records no
+ * cost is not a rounding error — it is free, uncapped usage that no limit can
+ * see, and it stays that way until somebody notices.
+ *
+ * Kept free of database imports so they can be unit-tested directly.
+ */
+
+/**
+ * Model ids that name no model, so no price table can resolve them.
+ *
+ * `byok-0` is Droid's synthetic entry for a BYOK run (`droid exec -m
+ * custom:byok-0`); `<synthetic>` is Claude Code's placeholder for internal
+ * calls. Production has both: 15 shared `byok-0` rows over 6.8M tokens, all at
+ * $0, because a Gemini model under Droid meters against the shared Gemini pool
+ * while reporting an unpriceable id.
+ */
+const PLACEHOLDER_MODEL_IDS: ReadonlySet<string> = new Set([
+  "byok-0",
+  "custom:byok-0",
+  "<synthetic>",
+])
+
+/**
+ * Last-resort price for a shared turn nothing else could price, in USD per
+ * million tokens.
+ *
+ * Taken from the cheapest paid model actually in use (`deepseek-v4-flash`,
+ * ~$0.0125/M blended over the ledger) so it never over-charges a user for a gap
+ * on our side — but never charges zero either.
+ */
+const FLOOR_USD_PER_MTOK = 0.0125
+
+/**
+ * The model id to record and price for a turn: what the CLI reported, unless
+ * that is a placeholder naming no model, in which case the model the run was
+ * actually started with (from the usage metadata stamped at send time).
+ *
+ * The reported id wins whenever it names something real — the chat's configured
+ * model can drift from what the CLI actually ran, and the CLI is the authority
+ * on that.
+ *
+ * Falls back to the placeholder when no run model is known (an older message, or
+ * a turn predating `UsageMeta.model`) so the row is still written; the floor
+ * rate is then what keeps it from being free.
+ */
+export function resolveTurnModel(
+  reported: string | null | undefined,
+  runModel?: string | null
+): string | null {
+  if (reported && runModel && PLACEHOLDER_MODEL_IDS.has(reported.toLowerCase())) {
+    return runModel
+  }
+  return reported ?? null
+}
+
+/** The floor price for `totalTokens`, in USD. Never zero for a non-empty turn. */
+export function floorCostUsd(totalTokens: number): number {
+  return (FLOOR_USD_PER_MTOK * totalTokens) / 1_000_000
+}

--- a/packages/web/lib/server/usage-budgets.test.ts
+++ b/packages/web/lib/server/usage-budgets.test.ts
@@ -1,64 +1,47 @@
 /**
- * Unit tests for shared-pool budget resolution.
+ * Unit tests for the daily balance.
  */
 import { describe, it, expect } from "vitest"
 
 import {
-  BUDGET_BOOSTS,
-  getProviderBudget,
+  getDailyBalance,
   isFreeModel,
+  BALANCE_POOL_PROVIDERS,
   PRO_BUDGET_MULTIPLIER,
 } from "./usage-budgets"
 
-describe("getProviderBudget", () => {
-  it("meters the Claude pool in cost, not tokens", () => {
-    // The pool spans a 10× price-per-token spread (Haiku → Fable), so the
-    // budget has to be denominated in money for the tiers to mean anything.
-    expect(getProviderBudget("claude")?.unit).toBe("cost")
+describe("getDailyBalance", () => {
+  it("gives free users a finite daily balance", () => {
+    const free = getDailyBalance("free")
+    expect(free).toBeGreaterThan(0)
+    expect(Number.isFinite(free!)).toBe(true)
   })
 
-  it("scales the free budget by the Pro multiplier", () => {
-    const free = getProviderBudget("claude", "free")!
-    const pro = getProviderBudget("claude", "pro")!
-    expect(pro.unit).toBe(free.unit)
-    expect(pro.limit).toBeCloseTo(free.limit * PRO_BUDGET_MULTIPLIER, 10)
-  })
-
-  it("scales both plans by a live boost, and drops it once it expires", () => {
-    const boost = BUDGET_BOOSTS.claude
-    if (!boost) return // no boost configured — nothing to assert
-
-    const during = new Date(boost.until.getTime() - 1000)
-    const after = boost.until
-
-    const baseFree = getProviderBudget("claude", "free", after)!
-    expect(getProviderBudget("claude", "free", during)!.limit).toBeCloseTo(
-      baseFree.limit * boost.multiplier,
+  it("scales the free balance by the Pro multiplier", () => {
+    expect(getDailyBalance("pro")).toBeCloseTo(
+      getDailyBalance("free")! * PRO_BUDGET_MULTIPLIER,
       10
     )
-    expect(getProviderBudget("claude", "pro", during)!.limit).toBeCloseTo(
-      baseFree.limit * boost.multiplier * PRO_BUDGET_MULTIPLIER,
-      10
-    )
-    expect(getProviderBudget("claude", "pro", after)!.limit).toBeCloseTo(
-      baseFree.limit * PRO_BUDGET_MULTIPLIER,
-      10
-    )
-  })
-
-  it("leaves the unlimited plan uncapped while a boost is live", () => {
-    const boost = BUDGET_BOOSTS.claude
-    if (!boost) return
-    const during = new Date(boost.until.getTime() - 1000)
-    expect(getProviderBudget("claude", "unlimited", during)).toBeNull()
   })
 
   it("leaves the unlimited plan uncapped", () => {
-    expect(getProviderBudget("claude", "unlimited")).toBeNull()
+    expect(getDailyBalance("unlimited")).toBeNull()
   })
 
-  it("returns null for providers with no shared-pool budget", () => {
-    expect(getProviderBudget("codex")).toBeNull()
+  it("defaults to the free balance when no plan is given", () => {
+    expect(getDailyBalance()).toBe(getDailyBalance("free"))
+  })
+})
+
+describe("BALANCE_POOL_PROVIDERS", () => {
+  it("covers every shared pool, so the balance can't be routed around", () => {
+    // A provider missing here is an unmetered path: the user would keep working
+    // on it with nothing left.
+    expect([...BALANCE_POOL_PROVIDERS].sort()).toEqual([
+      "claude",
+      "gemini",
+      "opencode",
+    ])
   })
 })
 

--- a/packages/web/lib/server/usage-budgets.ts
+++ b/packages/web/lib/server/usage-budgets.ts
@@ -1,24 +1,32 @@
 /**
- * Per-provider daily budgets for the shared credential pools.
+ * The daily spending balance for the shared credential pools.
  *
- * Budgets scale by plan: `free` gets the base daily budget, `pro` gets 2× that
- * budget (still daily), and `unlimited` is uncapped. A temporary, self-expiring
- * multiplier can sit on top of both — see `BUDGET_BOOSTS`. The budget *unit* differs
- * by provider — each pool is metered in whatever measure best reflects its cost:
- *   - claude   → "cost": USD spend, priced from Anthropic's published rates in
- *                lib/server/claude-pricing. The pool spans Haiku through Fable,
- *                a 10× spread in price per token, so a token cap would hand a
- *                Fable user ten times the value of a Haiku user for the same
- *                allowance.
- *   - opencode → "cost": USD spend (tokscale's per-turn cost), since OpenCode
- *                spans many models with wildly different per-token prices.
- *   - gemini   → "messages": number of assistant turns, a simple message cap.
+ * One balance, spent across every shared pool. It is denominated in US dollars of
+ * published API list value — the same figure the ledger already stores in
+ * `TokenUsage.costUsd`, priced from Anthropic's rates for Claude (see
+ * lib/server/claude-pricing) and from tokscale for everything else.
  *
- * Unlike the token unit, "cost" counts cache reads and writes: they're priced
- * at 0.1× and 1.25× base input, so they no longer swamp the measure the way raw
- * cache token *counts* do.
+ * It is deliberately NOT a dollar anyone paid: Claude runs on a flat Max 20x
+ * subscription, so the number is notional value, exactly as the admin dashboard
+ * labels it. Keeping the meter denominated in list value means the only question
+ * it has to answer is "what would these tokens have cost", which has a checkable
+ * answer.
  *
- * Omit a provider to leave it unlimited.
+ * Why one pooled allowance instead of a budget per provider:
+ *   - Three budgets in three units (USD, USD, messages) gave three different
+ *     answers to "how much do I have left", and a user who exhausted one could
+ *     simply move to another. One number is both honest and unroutable-around.
+ *   - Claude is ~98% of the draw, so pooling costs almost nothing. Replayed over
+ *     1,194 user-days (Jun–Sep 2026) the pooled rule allowed $7,150 against
+ *     $7,185 under the old per-provider rules — a $35 difference, and exactly
+ *     one additional capped user-day.
+ *
+ * Free models are excluded entirely (see isFreeModel), so a user with nothing
+ * left can still work on OpenCode's free tier. That is the intended floor.
+ *
+ * Enforcement is post-hoc: a turn's cost is only knowable once it has run, so
+ * spending is checked before the NEXT turn. One turn can therefore overshoot —
+ * see lib/db/usage-limit.
  */
 
 import type { ProviderName } from "@background-agents/common"
@@ -26,114 +34,103 @@ import type { ProviderName } from "@background-agents/common"
 /** Subscription tier (mirrors Prisma's `Plan` enum). */
 export type Plan = "free" | "pro" | "unlimited"
 
-/** Unit a provider's shared-pool budget is measured in. */
-export type BudgetUnit = "tokens" | "cost" | "messages"
+/**
+ * Shared pools that draw on the daily balance.
+ *
+ * A run only counts when it actually used the server's credential — rows are
+ * stamped `pool: "shared"` at write time — so a user on their own key is never
+ * charged, even for a provider listed here.
+ */
+export const BALANCE_POOL_PROVIDERS: readonly ProviderName[] = [
+  "claude",
+  "opencode",
+  "gemini",
+]
 
-export interface ProviderBudget {
-  unit: BudgetUnit
-  /** Daily allowance in the unit: tokens, USD, or message count. */
-  limit: number
-}
-
-/** Multiplier applied to the free daily budget for `pro` users. */
+/** Multiplier applied to the free daily balance for `pro` users. */
 export const PRO_BUDGET_MULTIPLIER = 2
 
 /**
- * Free-tier daily budget per shared-pool provider, with its unit.
+ * Free-tier daily balance, in USD of API list value.
  *
- * The Claude figure is sized from the ledger, not modelled. Over 77 active days
- * (Jun–Aug 2026): 106 users, 6,463 shared turns, $14,846 of API-equivalent
- * value — ~$193/day at ~11.9 users active per day, averaging $2.30 a turn. Note
- * a "turn" here is a whole agentic run (many API round-trips, each re-reading
- * cache), not a single call, which is why it costs orders of magnitude more than
- * a chat message.
+ * Sized from the ledger, not modelled. Over 77 active days (Jun–Aug 2026): 106
+ * users, 6,463 shared turns, $14,846 of value — ~$193/day at ~11.9 users active
+ * per day, averaging $2.30 a turn. Note a "turn" here is a whole agentic run
+ * (many API round-trips, each re-reading cache), not a single call, which is why
+ * it costs orders of magnitude more than a chat message.
  *
  * Cost per user-day was distributed:  p50 $8.37 · p75 $17.26 · p90 $42.55 ·
  * max $237.39. The tail is the problem this cap exists to solve — 8 of those 106
  * users accounted for 75% of all spend, and left alone they crowd everyone else
  * out as the pool grows.
  *
- * The old 100k-token cap it replaces was worth a median of $8.10 of real value
- * per user-day — but anywhere from $4.80 (p25) to $26.78 (p90), because the same
- * token allowance buys wildly different amounts depending on the model. That
- * spread is why a token cap never controlled the pool: we were hitting the
- * subscription's weekly limit (77 times in this window, plus 57 Fable-specific
- * and 26 session limits) while the cap looked like it was holding.
+ * The 100k-token cap this ultimately replaces was worth a median of $8.10 of
+ * real value per user-day — but anywhere from $4.80 (p25) to $26.78 (p90),
+ * because the same token allowance buys wildly different amounts depending on
+ * the model. That spread is why a token cap never controlled the pool: we were
+ * hitting the subscription's weekly limit (77 times in that window, plus 57
+ * Fable-specific and 26 session limits) while the cap looked like it was holding.
  *
- * $5/day sits below that $8.10 median, so it is a genuine tightening rather than
- * a sideways move. Replayed over the same history with plan multipliers applied,
- * it would have allowed ~$88/day against ~$193/day actual — a 54% reduction,
- * most of it taken off the tail the token rule let run unchecked.
+ * $5/day sits below that $8.10 median, so it is a genuine tightening.
  *
  * Two things this does NOT bound:
- *   - The `unlimited` plan, which is uncapped by definition. It accounted for
- *     $44/day of the historical draw, and no value here touches it.
+ *   - The `unlimited` plan, uncapped by definition. It accounted for $44/day of
+ *     the historical draw, and no value here touches it.
  *   - The pool as a whole. This caps a single user; 200 users active at once is
- *     still 200 × the cap. A pool-wide daily ceiling is the only hard bound, and
- *     it does not exist yet.
+ *     still 200× the balance. A pool-wide daily ceiling is the only hard bound,
+ *     and it does not exist yet.
  */
-const FREE_DAILY_BUDGETS: Partial<Record<ProviderName, ProviderBudget>> = {
-  claude: { unit: "cost", limit: 5 },
-  // TODO(token-budgets): tune these two against the ledger, as above.
-  opencode: { unit: "cost", limit: 0.5 },
-  gemini: { unit: "messages", limit: 100 },
-}
+const FREE_DAILY_BALANCE = 5
 
 /**
- * A temporary boost to one provider's budgets, with a hard expiry.
+ * A temporary boost to the balance, with a hard expiry.
  *
- * While live, the multiplier scales the free daily budget — and through it the
- * Pro budget, which is still `PRO_BUDGET_MULTIPLIER`× free. At `until` the
- * boost lapses on its own and the baseline returns; nothing has to be changed
- * back by hand.
+ * While live, the multiplier scales the free balance — and through it the Pro
+ * balance, which is still `PRO_BUDGET_MULTIPLIER`× free. At `until` the boost
+ * lapses on its own and the baseline returns; nothing has to be changed back by
+ * hand.
  */
-interface BudgetBoost {
+interface BalanceBoost {
   multiplier: number
   /** Instant the boost stops applying (exclusive). */
   until: Date
 }
 
 /**
- * Live boosts, keyed by provider.
+ * The live boost, or null.
  *
- * No boost is currently live — the Claude pool runs on its $5/$10 baseline.
- * Add an entry here (with a hard `until` expiry) to temporarily scale a
- * provider's budget; an entry whose `until` is in the past is inert.
+ * No boost is currently live — the pool runs on its 5/10 baseline. Set an object
+ * here (with a hard `until` expiry) to temporarily scale the balance; one whose
+ * `until` is in the past is inert.
  */
-export const BUDGET_BOOSTS: Partial<Record<ProviderName, BudgetBoost>> = {}
+export const BALANCE_BOOST: BalanceBoost | null = null
 
-/** The provider's boost multiplier at `now` — 1 when no boost is live. */
-function getBoostMultiplier(provider: ProviderName, now: Date): number {
-  const boost = BUDGET_BOOSTS[provider]
-  if (!boost || now >= boost.until) return 1
-  return boost.multiplier
+/** The boost multiplier at `now` — 1 when no boost is live. */
+function getBoostMultiplier(now: Date): number {
+  if (!BALANCE_BOOST || now >= BALANCE_BOOST.until) return 1
+  return BALANCE_BOOST.multiplier
 }
 
 /**
- * Daily budget descriptor for a provider on a given plan, or null when
- * unlimited (the `unlimited` plan, or a provider with no configured budget).
- * `pro` gets `PRO_BUDGET_MULTIPLIER`× the free budget; `free` gets the base.
- * Both are scaled again by any live `BUDGET_BOOSTS` entry.
+ * Daily balance for a plan, or null when uncapped (`unlimited`).
+ * `pro` gets `PRO_BUDGET_MULTIPLIER`× the free balance; both are scaled again
+ * by any live {@link BALANCE_BOOST}.
  */
-export function getProviderBudget(
-  provider: ProviderName,
+export function getDailyBalance(
   plan: Plan = "free",
   now: Date = new Date()
-): ProviderBudget | null {
+): number | null {
   if (plan === "unlimited") return null
-  const base = FREE_DAILY_BUDGETS[provider]
-  if (!base) return null
   const multiplier =
-    (plan === "pro" ? PRO_BUDGET_MULTIPLIER : 1) *
-    getBoostMultiplier(provider, now)
-  if (multiplier === 1) return base
-  return { unit: base.unit, limit: base.limit * multiplier }
+    (plan === "pro" ? PRO_BUDGET_MULTIPLIER : 1) * getBoostMultiplier(now)
+  return FREE_DAILY_BALANCE * multiplier
 }
 
 /**
- * Free models (mostly OpenCode's free tier) that must NOT count against the
- * shared-pool budget. They're still recorded in the ledger (so they appear in
- * overall totals), just flagged `freeModel=true` and excluded from shared sums.
+ * Free models (mostly OpenCode's free tier) that must NOT draw the balance.
+ * They're still recorded in the ledger (so they appear in overall totals), just
+ * flagged `freeModel=true` and excluded from the balance sum — which is what
+ * leaves them usable once a user's allowance is spent.
  *
  * Matching is by tokscale's `model` id: this explicit set OR a `-free`/`:free`
  * suffix (the common convention) — so new free models are auto-caught.
@@ -144,26 +141,26 @@ const FREE_MODELS: ReadonlySet<string> = new Set([
   "nemotron-3-ultra-free",
 ])
 
-/** Whether a model is free (excluded from shared-pool budgets). */
+/** Whether a model is free (never draws the balance). */
 export function isFreeModel(model: string | null | undefined): boolean {
   if (!model) return false
   const m = model.toLowerCase()
   return FREE_MODELS.has(m) || m.endsWith("-free") || m.endsWith(":free")
 }
 
-/** Start of the current UTC day (budget window start for free users). */
+/** Start of the current UTC day (the balance window start). */
 export function getStartOfUtcDay(now: Date = new Date()): Date {
   return new Date(
     Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
   )
 }
 
-/** Next UTC midnight (when the daily budget resets). */
+/** Next UTC midnight (when the balance resets). */
 export function getNextUtcDayReset(now: Date = new Date()): Date {
   return new Date(getStartOfUtcDay(now).getTime() + 24 * 60 * 60 * 1000)
 }
 
-/** Start of the current ISO week (Monday 00:00 UTC) — Pro usage window. */
+/** Start of the current ISO week (Monday 00:00 UTC) — unlimited-plan window. */
 export function getStartOfUtcWeek(now: Date = new Date()): Date {
   const dayOfWeek = now.getUTCDay() // 0=Sun, 1=Mon, …
   const daysSinceMonday = dayOfWeek === 0 ? 6 : dayOfWeek - 1

--- a/packages/web/lib/stores/chat-sync-store.ts
+++ b/packages/web/lib/stores/chat-sync-store.ts
@@ -46,13 +46,11 @@ export interface LimitReachedState {
     files?: File[]
     planMode?: boolean
   }
-  /** Shared-pool provider that hit its limit (claude | gemini | opencode). */
+  /** Shared-pool provider the blocked run would have used. */
   provider?: string
   /** Subscription tier used to select a non-redundant upgrade path. */
   plan?: Plan
-  /** Unit the budget is measured in (tokens | cost | messages). */
-  unit?: "tokens" | "cost" | "messages"
-  /** Amount used / daily budget for that provider, in `unit`. */
+  /** Spent today / the daily balance, in USD. */
   used?: number | null
   limit?: number | null
   resetAt?: Date

--- a/packages/web/lib/sync/api.ts
+++ b/packages/web/lib/sync/api.ts
@@ -8,7 +8,6 @@
 
 import type { Chat, Message, Settings, CustomEndpoint } from "@/lib/types"
 import type { Credentials, CredentialFlags } from "@/lib/credentials"
-import type { BudgetUnit } from "@/lib/server/usage-budgets"
 
 // =============================================================================
 // Types
@@ -66,13 +65,12 @@ export interface SettingsResponse {
   settings: Settings
   credentialFlags: CredentialFlags
   customEndpoints?: CustomEndpoint[]
-  claudeLimitResetAt?: string | null
-  claudeLimitUnit?: BudgetUnit
-  claudeLimitRemaining?: number | null
-  claudeLimitUsed?: number | null
-  claudeLimitTotal?: number | null
-  claudeIsPro?: boolean
-  claudeIsWeekly?: boolean
+  balanceResetAt?: string | null
+  balanceRemaining?: number | null
+  balanceUsed?: number | null
+  balanceTotal?: number | null
+  planIsPro?: boolean
+  balanceWeekly?: boolean
 }
 
 // =============================================================================

--- a/packages/web/lib/types.ts
+++ b/packages/web/lib/types.ts
@@ -19,6 +19,7 @@ export {
   agentLabels,
   agentSupportsPlanMode,
   getDefaultModelForAgent,
+  getFreeModelForAgent,
   resolveModelForAgent,
   resolveAgent,
   resolveAgentAndModel,

--- a/packages/web/lib/usage-limit-copy.test.ts
+++ b/packages/web/lib/usage-limit-copy.test.ts
@@ -5,40 +5,37 @@ import {
 } from "./usage-limit-copy"
 
 describe("formatUsageLimitMessage", () => {
-  it("describes Pro as a higher limit for free users", () => {
-    expect(formatUsageLimitMessage({
-      plan: "free",
-      provider: "claude",
-      unit: "tokens",
-      limit: 100_000,
-    })).toBe(
-      "Daily Claude limit reached (100,000 tokens). " +
-      "Upgrade to Pro for higher daily limits, upgrade to Unlimited for unlimited usage, " +
-      "or add your own Claude key."
+  it("describes Pro as a bigger balance for free users, and names the free-model escape", () => {
+    expect(formatUsageLimitMessage({ plan: "free", limit: 5 })).toBe(
+      "Daily limit reached ($5.00). " +
+      "Upgrade to Pro for twice the daily balance, upgrade to Unlimited for uncapped usage, " +
+      "add your own API key, or switch to a free model."
     )
   })
 
-  it("only offers Unlimited or BYOK after a Pro user reaches the limit", () => {
-    expect(formatUsageLimitMessage({
-      plan: "pro",
-      provider: "gemini",
-      unit: "messages",
-      limit: 200,
-    })).toBe(
-      "Daily Gemini limit reached (200 messages). " +
-      "Upgrade to Unlimited for unlimited usage, or add your own Gemini key."
+  it("only offers Unlimited, BYOK or free models after a Pro user runs out", () => {
+    expect(formatUsageLimitMessage({ plan: "pro", limit: 10 })).toBe(
+      "Daily limit reached ($10.00). " +
+      "Upgrade to Unlimited for uncapped usage, add your own API key, " +
+      "or switch to a free model."
     )
   })
 
-  it("formats cost allowances without promising a plan upgrade to Unlimited users", () => {
-    expect(formatUsageLimitMessage({
-      plan: "unlimited",
-      provider: "opencode",
-      unit: "cost",
-      limit: 1,
-    })).toBe(
-      "Daily OpenCode limit reached ($1.00). Add your own OpenCode key to continue."
+  it("does not promise a plan upgrade to Unlimited users", () => {
+    expect(formatUsageLimitMessage({ plan: "unlimited", limit: 5 })).toBe(
+      "Daily limit reached ($5.00). Add your own API key to continue."
     )
+  })
+
+  it("names no provider — the balance is pooled across all three", () => {
+    const msg = formatUsageLimitMessage({ plan: "free", limit: 5 })
+    for (const provider of ["Claude", "Gemini", "OpenCode"]) {
+      expect(msg).not.toContain(provider)
+    }
+  })
+
+  it("renders the allowance as money", () => {
+    expect(formatUsageLimitMessage({ plan: "free", limit: 2.5 })).toContain("($2.50)")
   })
 })
 
@@ -47,7 +44,7 @@ describe("getLimitUpgradeCopy", () => {
     expect(getLimitUpgradeCopy("free")).toEqual({
       targetPlan: "pro",
       title: "Upgrade to Pro",
-      description: "Higher daily limits on all shared pools and priority support",
+      description: "Twice the daily balance and priority support",
     })
   })
 

--- a/packages/web/lib/usage-limit-copy.ts
+++ b/packages/web/lib/usage-limit-copy.ts
@@ -1,5 +1,5 @@
-import type { ProviderName } from "@background-agents/common"
-import type { BudgetUnit, Plan } from "@/lib/server/usage-budgets"
+import type { Plan } from "@/lib/server/usage-budgets"
+import { fmtBalance } from "@/lib/format"
 
 export type LimitUpgradeTarget = "pro" | "unlimited"
 
@@ -12,19 +12,13 @@ export interface LimitUpgradeCopy {
 const FREE_UPGRADE_COPY: LimitUpgradeCopy = {
   targetPlan: "pro",
   title: "Upgrade to Pro",
-  description: "Higher daily limits on all shared pools and priority support",
+  description: "Twice the daily balance and priority support",
 }
 
 const PRO_UPGRADE_COPY: LimitUpgradeCopy = {
   targetPlan: "unlimited",
   title: "Upgrade to Unlimited",
   description: "Unlimited usage on all shared pools and priority support",
-}
-
-const PROVIDER_LABELS: Partial<Record<ProviderName, string>> = {
-  claude: "Claude",
-  gemini: "Gemini",
-  opencode: "OpenCode",
 }
 
 export function isPlan(value: unknown): value is Plan {
@@ -37,33 +31,30 @@ export function getLimitUpgradeCopy(plan: Plan | undefined): LimitUpgradeCopy | 
   return FREE_UPGRADE_COPY
 }
 
+/**
+ * The message shown when the daily allowance runs out.
+ *
+ * Deliberately names no provider: the balance is pooled, so "your Claude limit"
+ * was both wrong and confusing once the same allowance covered Gemini and
+ * OpenCode. Free models are called out because they genuinely still work — they
+ * never draw down the balance — and that is the most useful thing a blocked user
+ * can be told.
+ */
 export function formatUsageLimitMessage({
   plan,
-  provider,
-  unit,
   limit,
 }: {
   plan: Plan
-  provider: ProviderName
-  unit: BudgetUnit
   limit: number
 }): string {
-  const providerLabel = PROVIDER_LABELS[provider]
-    ?? provider.charAt(0).toUpperCase() + provider.slice(1)
-  const allowance =
-    unit === "tokens"
-      ? `${limit.toLocaleString("en-US")} tokens`
-      : unit === "cost"
-        ? `$${limit.toFixed(2)}`
-        : `${limit.toLocaleString("en-US")} messages`
-
   const nextStep =
     plan === "free"
-      ? "Upgrade to Pro for higher daily limits, upgrade to Unlimited for unlimited usage, " +
-        `or add your own ${providerLabel} key.`
+      ? "Upgrade to Pro for twice the daily balance, upgrade to Unlimited for uncapped usage, " +
+        "add your own API key, or switch to a free model."
       : plan === "pro"
-        ? `Upgrade to Unlimited for unlimited usage, or add your own ${providerLabel} key.`
-        : `Add your own ${providerLabel} key to continue.`
+        ? "Upgrade to Unlimited for uncapped usage, add your own API key, " +
+          "or switch to a free model."
+        : "Add your own API key to continue."
 
-  return `Daily ${providerLabel} limit reached (${allowance}). ${nextStep}`
+  return `Daily limit reached (${fmtBalance(limit)}). ${nextStep}`
 }


### PR DESCRIPTION
# Replace per-provider budgets with one daily balance

Free users get **$5/day**, Pro **$10/day**, spent across Claude, OpenCode and Gemini together. Unlimited stays uncapped.

**No database changes.**

## Why

Each shared pool had its own budget in its own unit — Claude $5/day, OpenCode $0.50/day, Gemini 100 messages/day. So a user had three answers to "how much do I have left", and could route around any one of them by switching pools.

Now there's one number. It's denominated in USD of published API list value — the figure `TokenUsage.costUsd` already stores.

## Why no migration

The whole rule is a sum over columns that already exist:

```sql
SUM(costUsd) WHERE userId = ? AND pool = 'shared' AND freeModel = false
             AND provider IN ('claude','opencode','gemini')
             AND createdAt >= start of UTC day
```

Dropping `provider` from the filter means the old `[userId, provider, pool, createdAt]` index no longer matches its full prefix, so I checked against production rather than assuming — Postgres falls through to the existing `[userId, createdAt]` index at **0.156 ms**, 9 buffer hits, on a 12 MB table. Worth revisiting at a few million rows.


## Behaviour at zero

`CLAUDE_DAILY_LIMIT_EXCEEDED` → **`SHARED_BALANCE_EXHAUSTED`**, which now closes all three pools at once. Two escape hatches keep that from being a wall:

- **Own keys still work** — the check goes through `agentUsesSharedPool`, so it's per-agent.
- **Free models never draw the balance** — excluded from the sum, so they stay usable. The limit dialog now routes to one explicitly via `getFreeModelForAgent`, rather than depending on the settings query having already delivered the flag (a 429 means we already know).


Two rules in a new `lib/server/turn-pricing.ts`:

- `resolveTurnModel` — swaps a placeholder id (`byok-0`, `<synthetic>`) for the model the run actually started with, carried through `UsageMeta.model` (JSON, no migration). A real reported id always wins.
- `floorCostUsd` — anything on a shared pool that still prices at $0 with real tokens gets the cheapest paid model's rate (~$0.0125/M), plus a warn log. Never zero.

Verified pricing coverage separately by running tokscale 3.1.2's own resolver against every model reachable on a shared pool: **30/30 priced** (10 Claude, 14 OpenCode Go, 6 Gemini); the 4 free-tier models correctly return $0.

## Mostly deletion

`BudgetUnit`, `FREE_DAILY_BUDGETS`, `getProviderBudget`, `sumSharedUsageInUnit`, `countSharedMessages`, `limitUnit`, and the `unit` field threaded through the 429 payload → store → dialog all go. `claudeLimit*` wire fields become `balance*`.

## UI

- **Usage settings** — one bar with a per-pool breakdown beneath it, instead of three independent bars.
- **Limit dialog** — "You've used your daily balance — $5.00 of $5.00 … shared across Claude, OpenCode and Gemini."
- **Chat usage modal** — now shows cost beside tokens, with a total row. Note this one spans own-key runs too, so it answers "what was this conversation worth", not "what came off my balance"; there's a line of copy saying so.

## Testing

`tsc --noEmit` clean; **198 tests pass** in `packages/web`, including new coverage that `BALANCE_POOL_PROVIDERS` contains all three pools (a missing one is an unmetered path), that the exhausted flag closes OpenCode and Gemini but *not* a pool the user has their own key for, and that no turn with tokens can price at zero.

The pre-existing `Sidebar.tsx`/`sidebar.tsx` casing collision still fails typecheck on Windows only — unchanged, present on `main`.

## Follow-up, not in this PR

**Double-metering.** The SSE stream route and the lifecycle cron can both meter the same turn ~50 ms apart, each reading the ledger before the other writes. 79 (session, model) pairs in production have recorded more tokens than tokscale ever reported. This mattered less when the ledger was mostly analytics; now a duplicated row draws the balance twice. Fix is a `meteredAt` column plus an atomic claim .
