### PR TITLE
Fix/token metering row bugs

### DIFF
--- a/packages/web/lib/db/token-usage.ts
+++ b/packages/web/lib/db/token-usage.ts
@@ -12,6 +12,8 @@
  * answers the same question for one provider, for the usage views.
  */
 
+import { Prisma } from "@prisma/client"
+
 import { BALANCE_POOL_PROVIDERS } from "@/lib/server/usage-budgets"
 import {
   ZERO_CUMULATIVE,
@@ -22,6 +24,45 @@ import { prisma } from "./prisma"
 
 /** Credential pool a turn ran against. */
 export type UsagePool = "shared" | "user"
+
+/**
+ * A Prisma client or an interactive-transaction handle. The cursor read and
+ * the row insert must be able to run on the *same* transaction, or the lock
+ * that serialises them has nothing to protect.
+ */
+export type UsageDb = Prisma.TransactionClient | typeof prisma
+
+/**
+ * Namespace for this app's Postgres advisory locks, so a key derived from a
+ * session id cannot collide with a lock taken for some unrelated purpose.
+ * Arbitrary, but must stay stable: "toku" as ASCII.
+ */
+const ADVISORY_LOCK_NAMESPACE = 0x746f6b75
+
+/**
+ * Serialise metering for one agent session against every other writer.
+ *
+ * The ledger's delta is computed read-modify-write — read the prior rows, sum
+ * them, insert the difference — with nothing making that atomic. Two writers
+ * that read before either inserts compute the same delta and both persist it,
+ * which is how one production reply came to be billed twice at $44.10.
+ *
+ * Takes a *transaction-scoped* advisory lock, which matters twice over: it is
+ * released when the transaction ends however it ends (commit, rollback, or a
+ * dropped connection), so a crashed finalizer cannot strand the session; and
+ * it is the only advisory-lock form that is safe through a transaction-mode
+ * pooler such as the Supabase/pgbouncer endpoint this app connects on, because
+ * the transaction is pinned to one server connection for its whole life.
+ *
+ * The loser blocks here, then reads a cursor that already includes the
+ * winner's rows, computes a zero delta, and writes nothing.
+ */
+export async function lockSessionForMetering(
+  sessionId: string,
+  tx: UsageDb
+): Promise<void> {
+  await tx.$executeRaw`SELECT pg_advisory_xact_lock(${ADVISORY_LOCK_NAMESPACE}::int, hashtext(${sessionId})::int)`
+}
 
 /** A single delta row to persist for one (session, model) of one turn. */
 export interface TokenUsageInsert {
@@ -74,9 +115,10 @@ export { ZERO_CUMULATIVE, type SessionCumulative }
  * Keyed by `model ?? ""`. Missing key ⇒ first capture for that model.
  */
 export async function getSessionCumulatives(
-  sessionId: string
+  sessionId: string,
+  tx: UsageDb = prisma
 ): Promise<Map<string, SessionCumulative>> {
-  const grouped = await prisma.tokenUsage.groupBy({
+  const grouped = await tx.tokenUsage.groupBy({
     by: ["model"],
     where: { sessionId },
     _sum: {
@@ -109,10 +151,11 @@ export async function getSessionCumulatives(
  * Persist a batch of per-turn delta rows. No-op for an empty array.
  */
 export async function insertTokenUsageRows(
-  rows: TokenUsageInsert[]
+  rows: TokenUsageInsert[],
+  tx: UsageDb = prisma
 ): Promise<void> {
   if (rows.length === 0) return
-  await prisma.tokenUsage.createMany({
+  await tx.tokenUsage.createMany({
     data: rows.map((r) => ({
       userId: r.userId,
       chatId: r.chatId ?? null,

--- a/packages/web/lib/db/token-usage.ts
+++ b/packages/web/lib/db/token-usage.ts
@@ -13,6 +13,10 @@
  */
 
 import { BALANCE_POOL_PROVIDERS } from "@/lib/server/usage-budgets"
+import {
+  ZERO_CUMULATIVE,
+  type SessionCumulative,
+} from "@/lib/server/usage-cursor"
 
 import { prisma } from "./prisma"
 
@@ -55,26 +59,10 @@ export interface TokenUsageInsert {
   createdAt?: Date
 }
 
-/** Prior cumulative totals for one (session, model) pair, per component. */
-export interface SessionCumulative {
-  inputTokens: number
-  outputTokens: number
-  cacheReadTokens: number
-  cacheWriteTokens: number
-  reasoningTokens: number
-  totalTokens: number
-  costUsd: number
-}
-
-const ZERO_CUMULATIVE: SessionCumulative = {
-  inputTokens: 0,
-  outputTokens: 0,
-  cacheReadTokens: 0,
-  cacheWriteTokens: 0,
-  reasoningTokens: 0,
-  totalTokens: 0,
-  costUsd: 0,
-}
+// The cursor shape and its keying rules live in lib/server/usage-cursor, which
+// stays free of database imports so they can be unit-tested; re-exported here
+// so callers of this module keep importing them from one place.
+export { ZERO_CUMULATIVE, type SessionCumulative }
 
 /**
  * Reconstruct the prior cumulative per model for a session by summing the
@@ -116,8 +104,6 @@ export async function getSessionCumulatives(
   }
   return out
 }
-
-export { ZERO_CUMULATIVE }
 
 /**
  * Persist a batch of per-turn delta rows. No-op for an empty array.

--- a/packages/web/lib/server/token-metering.ts
+++ b/packages/web/lib/server/token-metering.ts
@@ -25,10 +25,14 @@ import { prisma } from "@/lib/db/prisma"
 import {
   getSessionCumulatives,
   insertTokenUsageRows,
+  lockSessionForMetering,
   type TokenUsageInsert,
   type UsagePool,
 } from "@/lib/db/token-usage"
-import { cursorForModel } from "@/lib/server/usage-cursor"
+import {
+  collapseEntriesByModel,
+  cursorForModel,
+} from "@/lib/server/usage-cursor"
 import { isFreeModel } from "@/lib/server/usage-budgets"
 import { priceClaudeTurn } from "@/lib/server/claude-pricing"
 import { readUsageMeta } from "@/lib/server/shared-pool"
@@ -60,6 +64,21 @@ interface TokscaleOutput {
 
 const TOKSCALE_CMD = "tokscale models --json --group-by session,model"
 const TOKSCALE_TIMEOUT_SEC = 60
+
+/**
+ * Bounds on the metering transaction. The work inside is three fast queries —
+ * the time that actually elapses is a loser waiting on the advisory lock while
+ * the winner finishes.
+ *
+ * Both are deliberately short. In production the Prisma pool is capped at one
+ * connection per instance, so a transaction that lingers blocks everything
+ * else on that instance; and because a missed row only understates one turn
+ * while a duplicate overcharges a real user, giving up early is the right
+ * trade. Exceeding either throws, which the caller logs and treats as
+ * "not metered".
+ */
+const METER_TX_MAX_WAIT_MS = 5_000
+const METER_TX_TIMEOUT_MS = 10_000
 
 export interface MeterTurnParams {
   userId: string
@@ -156,141 +175,185 @@ async function meterTurnUsage(
 
   // Only this turn's session. tokscale ids (UUIDs / "ses_…") are unique per
   // client, so matching on sessionId alone is safe.
-  const entries = parsed.entries.filter((e) => e.sessionId === sessionId)
-  if (entries.length === 0) {
+  const sessionEntries = parsed.entries.filter((e) => e.sessionId === sessionId)
+  if (sessionEntries.length === 0) {
     // Not necessarily an error: e.g. an Eliza turn (no token reporting), or the
     // CLI hadn't flushed its session file yet.
     return 0
   }
 
-  const prior = await getSessionCumulatives(sessionId)
-
-  // First-ever capture of a session. If the chat already has assistant turns
-  // that predate metering, tokscale's cumulative covers that whole backlog —
-  // charging it as this turn's delta would bill the entire history against
-  // today's budget and lock the user out. Detect that case and backdate the
-  // baseline rows: they still advance the diff cursor (getSessionCumulatives
-  // has no date filter) but fall outside every budget window (sumSharedUsage
-  // filters createdAt >= start of day). Only turns after the baseline charge.
-  let baselineAt: Date | undefined
-  if (prior.size === 0) {
-    const assistantTurns = await prisma.message.count({
-      where: { chatId, role: "assistant" },
-    })
-    // >1 ⇒ turns existed before this one (and before metering) ⇒ pre-existing
-    // chat. Exactly 1 ⇒ this is the chat's first turn ⇒ charge normally.
-    if (assistantTurns > 1) baselineAt = new Date(0)
+  // One entry per model, whatever tokscale reported — see collapseEntriesByModel.
+  const { entries, collapsed, conflicted } = collapseEntriesByModel(sessionEntries)
+  if (collapsed > 0) {
+    console.warn(
+      `[token-metering] tokscale reported ${collapsed} repeat entr${collapsed === 1 ? "y" : "ies"} ` +
+        `for session ${sessionId}; kept the highest cumulative per model` +
+        (conflicted.length > 0
+          ? `. Entries disagreed for: ${conflicted.join(", ")}`
+          : "")
+    )
   }
 
-  const rows: TokenUsageInsert[] = []
+  // Everything from here is the read-modify-write the ledger's delta depends
+  // on, and it runs inside one transaction holding this session's advisory
+  // lock. Without it, two finalizers reading the cursor before either inserts
+  // both compute the same delta and both persist it. Left at the default
+  // isolation level (read committed) on purpose: whoever loses the lock must
+  // see the winner's committed rows on its own read, which a snapshot level
+  // would hide, leaving it to write the very duplicate this prevents.
+  try {
+    return await prisma.$transaction(
+      async (tx) => {
+        await lockSessionForMetering(sessionId, tx)
 
-  for (const e of entries) {
-    // Recover a real model id when the CLI reported a placeholder (Droid's
-    // `byok-0`, Claude Code's `<synthetic>`).
-    const model = resolveTurnModel(e.model, runModel)
+        const prior = await getSessionCumulatives(sessionId, tx)
 
-    // Look the diff cursor up under the id we STORE, not the one tokscale
-    // reported — getSessionCumulatives groups by the persisted `model` column.
-    // See cursorForModel for why both ids are summed.
-    const prev = cursorForModel(prior, e.model, model)
+        // First-ever capture of a session. If the chat already has assistant
+        // turns that predate metering, tokscale's cumulative covers that whole
+        // backlog — charging it as this turn's delta would bill the entire
+        // history against today's budget and lock the user out. Detect that
+        // case and backdate the baseline rows: they still advance the diff
+        // cursor (getSessionCumulatives has no date filter) but fall outside
+        // every budget window (sumSharedUsage filters createdAt >= start of
+        // day). Only turns after the baseline charge.
+        let baselineAt: Date | undefined
+        if (prior.size === 0) {
+          const assistantTurns = await tx.message.count({
+            where: { chatId, role: "assistant" },
+          })
+          // >1 ⇒ turns existed before this one (and before metering) ⇒
+          // pre-existing chat. Exactly 1 ⇒ this is the chat's first turn ⇒
+          // charge normally.
+          if (assistantTurns > 1) baselineAt = new Date(0)
+        }
 
-    // Per-component delta = current tokscale cumulative − sum of prior deltas.
-    // Clamp at 0 to absorb any non-monotonic reporting (e.g. session reset).
-    const d = (cur: number, was: number) => Math.max(0, Math.round(cur - was))
+        const rows: TokenUsageInsert[] = []
 
-    const inputTokens = d(e.input, prev.inputTokens)
-    const outputTokens = d(e.output, prev.outputTokens)
-    const cacheReadTokens = d(e.cacheRead, prev.cacheReadTokens)
-    const cacheWriteTokens = d(e.cacheWrite, prev.cacheWriteTokens)
-    const reasoningTokens = d(e.reasoning, prev.reasoningTokens)
-    const totalTokens =
-      inputTokens + outputTokens + cacheReadTokens + cacheWriteTokens + reasoningTokens
-    // Free models: tokscale misprices them, so force cost to 0. They're still
-    // recorded (counted in overall totals) but flagged out of shared budgets.
-    const free = isFreeModel(model)
-    // The Claude pool's budget is denominated in dollars, so price its deltas
-    // from Anthropic's own rates. Every other provider (and any model these
-    // rates don't cover) keeps tokscale's figure, diffed like the token
-    // components. Note this prices the *delta* directly rather than differencing
-    // two cumulative costs — same result, one less place to drift.
-    const ownPrice =
-      provider === "claude"
-        ? priceClaudeTurn(model, {
+        for (const e of entries) {
+          // Recover a real model id when the CLI reported a placeholder
+          // (Droid's `byok-0`, Claude Code's `<synthetic>`).
+          const model = resolveTurnModel(e.model, runModel)
+
+          // Look the diff cursor up under the id we STORE, not the one
+          // tokscale reported — getSessionCumulatives groups by the persisted
+          // `model` column. See cursorForModel for why both ids are summed.
+          const prev = cursorForModel(prior, e.model, model)
+
+          // Per-component delta = current tokscale cumulative − sum of prior
+          // deltas. Clamp at 0 to absorb any non-monotonic reporting (e.g. a
+          // session reset).
+          const d = (cur: number, was: number) => Math.max(0, Math.round(cur - was))
+
+          const inputTokens = d(e.input, prev.inputTokens)
+          const outputTokens = d(e.output, prev.outputTokens)
+          const cacheReadTokens = d(e.cacheRead, prev.cacheReadTokens)
+          const cacheWriteTokens = d(e.cacheWrite, prev.cacheWriteTokens)
+          const reasoningTokens = d(e.reasoning, prev.reasoningTokens)
+          const totalTokens =
+            inputTokens +
+            outputTokens +
+            cacheReadTokens +
+            cacheWriteTokens +
+            reasoningTokens
+          // Free models: tokscale misprices them, so force cost to 0. They're
+          // still recorded (counted in overall totals) but flagged out of
+          // shared budgets.
+          const free = isFreeModel(model)
+          // The Claude pool's budget is denominated in dollars, so price its
+          // deltas from Anthropic's own rates. Every other provider (and any
+          // model these rates don't cover) keeps tokscale's figure, diffed like
+          // the token components. Note this prices the *delta* directly rather
+          // than differencing two cumulative costs — same result, one less
+          // place to drift.
+          const ownPrice =
+            provider === "claude"
+              ? priceClaudeTurn(model, {
+                  inputTokens,
+                  outputTokens,
+                  cacheReadTokens,
+                  cacheWriteTokens,
+                  reasoningTokens,
+                })
+              : null
+          if (provider === "claude" && ownPrice === null && !free) {
+            // A model id our rate table doesn't cover — usually a release we
+            // haven't added yet. Worth a line in the logs: the fallback is only
+            // as good as whatever tokscale resolved, which may be $0.
+            console.warn(
+              `[token-metering] no first-party rate for Claude model "${model}" — using tokscale's cost`
+            )
+          }
+          // Snapped because that subtraction diffs a float against a *sum* of
+          // floats: a no-op turn lands on ~4e-16, not 0, which silently
+          // defeated both `costUsd === 0` tests below. See snapCostResidue.
+          let costUsd = snapCostResidue(
+            free ? 0 : (ownPrice ?? Math.max(0, e.cost - prev.costUsd))
+          )
+
+          // Nothing on a shared pool may cost zero while consuming real tokens:
+          // the daily balance is the only cap, so a $0 turn is a free route
+          // around it. This catches a model id neither our rates nor tokscale
+          // could resolve.
+          if (!free && pool === "shared" && totalTokens > 0 && costUsd === 0) {
+            costUsd = floorCostUsd(totalTokens)
+            console.warn(
+              `[token-metering] no price for "${model}" (${provider}) — ` +
+                `charging the floor rate for ${totalTokens} tokens`
+            )
+          }
+
+          // Skip no-op turns (nothing new since last capture). This is also
+          // what the loser of the advisory lock hits: its cursor already
+          // includes the winner's rows, so every component diffs to zero.
+          if (totalTokens === 0 && costUsd === 0) continue
+
+          const cumulativeTokens =
+            e.input + e.output + e.cacheRead + e.cacheWrite + e.reasoning
+
+          rows.push({
+            userId,
+            chatId,
+            messageId: messageId ?? null,
+            provider,
+            model: model ?? null,
+            pool,
+            keyId: keyId ?? null,
+            freeModel: free,
             inputTokens,
             outputTokens,
             cacheReadTokens,
             cacheWriteTokens,
             reasoningTokens,
+            totalTokens,
+            costUsd,
+            coverage: e.performance?.tokenCoverage ?? null,
+            sessionId,
+            cumulativeTotal: Math.round(cumulativeTokens),
+            // tokscale's own cumulative, kept verbatim as an audit trail — for
+            // Claude it won't match the sum of our repriced deltas.
+            cumulativeCost: e.cost,
+            createdAt: baselineAt,
           })
-        : null
-    if (provider === "claude" && ownPrice === null && !free) {
-      // A model id our rate table doesn't cover — usually a release we haven't
-      // added yet. Worth a line in the logs: the fallback is only as good as
-      // whatever tokscale resolved, which may be $0.
-      console.warn(
-        `[token-metering] no first-party rate for Claude model "${model}" — using tokscale's cost`
-      )
-    }
-    // Snapped because that subtraction diffs a float against a *sum* of
-    // floats: a no-op turn lands on ~4e-16, not 0, which silently defeated
-    // both `costUsd === 0` tests below. See snapCostResidue.
-    let costUsd = snapCostResidue(
-      free ? 0 : (ownPrice ?? Math.max(0, e.cost - prev.costUsd))
+        }
+
+        if (rows.length === 0) return 0
+
+        await insertTokenUsageRows(rows, tx)
+        return rows.length
+      },
+      { maxWait: METER_TX_MAX_WAIT_MS, timeout: METER_TX_TIMEOUT_MS }
     )
-
-    // Nothing on a shared pool may cost zero while consuming real tokens: the
-    // daily balance is the only cap, so a $0 turn is a free route around it.
-    // This catches a model id neither our rates nor tokscale could resolve.
-    if (!free && pool === "shared" && totalTokens > 0 && costUsd === 0) {
-      costUsd = floorCostUsd(totalTokens)
-      console.warn(
-        `[token-metering] no price for "${model}" (${provider}) — ` +
-          `charging the floor rate for ${totalTokens} tokens`
-      )
-    }
-
-    // Skip no-op turns (nothing new since last capture).
-    if (totalTokens === 0 && costUsd === 0) continue
-
-    const cumulativeTokens =
-      e.input + e.output + e.cacheRead + e.cacheWrite + e.reasoning
-
-    rows.push({
-      userId,
-      chatId,
-      messageId: messageId ?? null,
-      provider,
-      model: model ?? null,
-      pool,
-      keyId: keyId ?? null,
-      freeModel: free,
-      inputTokens,
-      outputTokens,
-      cacheReadTokens,
-      cacheWriteTokens,
-      reasoningTokens,
-      totalTokens,
-      costUsd,
-      coverage: e.performance?.tokenCoverage ?? null,
-      sessionId,
-      cumulativeTotal: Math.round(cumulativeTokens),
-      // tokscale's own cumulative, kept verbatim as an audit trail — for Claude
-      // it won't match the sum of our repriced deltas.
-      cumulativeCost: e.cost,
-      createdAt: baselineAt,
-    })
-  }
-
-  if (rows.length === 0) return 0
-
-  try {
-    await insertTokenUsageRows(rows)
   } catch (err) {
-    console.error(`[token-metering] failed to persist usage for session ${sessionId}:`, err)
+    // Covers a lock wait that outlived the timeout and an exhausted connection
+    // pool as well as a failed insert. All of them mean "this turn was not
+    // metered", which is the safe outcome: metering is best-effort, and a
+    // missed row only understates one turn, where a duplicate overcharges.
+    console.error(
+      `[token-metering] failed to persist usage for session ${sessionId}:`,
+      err
+    )
     return 0
   }
-
-  return rows.length
 }
 
 /**

--- a/packages/web/lib/server/token-metering.ts
+++ b/packages/web/lib/server/token-metering.ts
@@ -25,14 +25,18 @@ import { prisma } from "@/lib/db/prisma"
 import {
   getSessionCumulatives,
   insertTokenUsageRows,
-  ZERO_CUMULATIVE,
   type TokenUsageInsert,
   type UsagePool,
 } from "@/lib/db/token-usage"
+import { cursorForModel } from "@/lib/server/usage-cursor"
 import { isFreeModel } from "@/lib/server/usage-budgets"
 import { priceClaudeTurn } from "@/lib/server/claude-pricing"
 import { readUsageMeta } from "@/lib/server/shared-pool"
-import { resolveTurnModel, floorCostUsd } from "@/lib/server/turn-pricing"
+import {
+  resolveTurnModel,
+  floorCostUsd,
+  snapCostResidue,
+} from "@/lib/server/turn-pricing"
 
 /** `tokscale models --json --group-by session,model` entry shape (subset). */
 interface TokscaleEntry {
@@ -181,13 +185,14 @@ async function meterTurnUsage(
   const rows: TokenUsageInsert[] = []
 
   for (const e of entries) {
-    const key = e.model ?? ""
-    const prev = prior.get(key) ?? ZERO_CUMULATIVE
-
-    // Recover a real model id when the CLI reported a placeholder. The diff
-    // cursor above still keys on tokscale's own id (`key`), so substituting
-    // here changes what we price and store without breaking the delta chain.
+    // Recover a real model id when the CLI reported a placeholder (Droid's
+    // `byok-0`, Claude Code's `<synthetic>`).
     const model = resolveTurnModel(e.model, runModel)
+
+    // Look the diff cursor up under the id we STORE, not the one tokscale
+    // reported — getSessionCumulatives groups by the persisted `model` column.
+    // See cursorForModel for why both ids are summed.
+    const prev = cursorForModel(prior, e.model, model)
 
     // Per-component delta = current tokscale cumulative − sum of prior deltas.
     // Clamp at 0 to absorb any non-monotonic reporting (e.g. session reset).
@@ -226,7 +231,12 @@ async function meterTurnUsage(
         `[token-metering] no first-party rate for Claude model "${model}" — using tokscale's cost`
       )
     }
-    let costUsd = free ? 0 : (ownPrice ?? Math.max(0, e.cost - prev.costUsd))
+    // Snapped because that subtraction diffs a float against a *sum* of
+    // floats: a no-op turn lands on ~4e-16, not 0, which silently defeated
+    // both `costUsd === 0` tests below. See snapCostResidue.
+    let costUsd = snapCostResidue(
+      free ? 0 : (ownPrice ?? Math.max(0, e.cost - prev.costUsd))
+    )
 
     // Nothing on a shared pool may cost zero while consuming real tokens: the
     // daily balance is the only cap, so a $0 turn is a free route around it.

--- a/packages/web/lib/server/turn-pricing.test.ts
+++ b/packages/web/lib/server/turn-pricing.test.ts
@@ -6,7 +6,7 @@
  */
 import { describe, it, expect } from "vitest"
 
-import { resolveTurnModel, floorCostUsd } from "./turn-pricing"
+import { resolveTurnModel, floorCostUsd, snapCostResidue } from "./turn-pricing"
 
 describe("resolveTurnModel", () => {
   it("swaps Droid's BYOK placeholder for the model the run actually used", () => {
@@ -68,5 +68,37 @@ describe("floorCostUsd", () => {
 
   it("is zero for an empty turn", () => {
     expect(floorCostUsd(0)).toBe(0)
+  })
+})
+
+describe("snapCostResidue", () => {
+  it("zeroes the float residue a no-op turn actually produces", () => {
+    // These are verbatim values from the production ledger, all on rows whose
+    // token delta was 0. Each defeated a `costUsd === 0` check and was
+    // persisted as a junk row.
+    expect(snapCostResidue(4.44089209850063e-16)).toBe(0)
+    expect(snapCostResidue(2.22044604925031e-16)).toBe(0)
+    expect(snapCostResidue(1.77635683940025e-15)).toBe(0)
+    expect(snapCostResidue(2.77555756156289e-17)).toBe(0)
+    expect(snapCostResidue(4.3368086899420e-19)).toBe(0)
+  })
+
+  it("leaves a real charge alone", () => {
+    // $2.2e-4 is the cheapest genuine charge in the ledger; $0.156263 is a real
+    // cost that landed on a zero-token row (tokscale's cumulative cost grew
+    // while its token counts did not) and must survive.
+    expect(snapCostResidue(0.0002199904)).toBe(0.0002199904)
+    expect(snapCostResidue(0.156263)).toBe(0.156263)
+    expect(snapCostResidue(44.101453)).toBe(44.101453)
+  })
+
+  it("leaves an exact zero at zero", () => {
+    expect(snapCostResidue(0)).toBe(0)
+  })
+
+  it("keeps the floor rate above the threshold, so the $0 guard still fires", () => {
+    // The floor exists to stop a shared turn costing nothing. If a floored
+    // cost could itself be snapped away, that guarantee would be circular.
+    expect(snapCostResidue(floorCostUsd(1))).toBeGreaterThan(0)
   })
 })

--- a/packages/web/lib/server/turn-pricing.ts
+++ b/packages/web/lib/server/turn-pricing.ts
@@ -61,3 +61,26 @@ export function resolveTurnModel(
 export function floorCostUsd(totalTokens: number): number {
   return (FLOOR_USD_PER_MTOK * totalTokens) / 1_000_000
 }
+
+/**
+ * Below this, a cost is floating-point noise rather than money.
+ *
+ * Sized against the production ledger: the largest residue observed there is
+ * ~2e-15 and the cheapest genuine charge $2.2e-4, so this sits several orders
+ * of magnitude clear of both.
+ */
+const COST_EPSILON = 1e-9
+
+/**
+ * Round a computed cost down to exactly zero when it is only residue.
+ *
+ * A turn's cost is derived by subtracting a *sum* of floats from a float, so a
+ * turn that consumed nothing lands on ~4e-16 rather than 0. Two separate rules
+ * test that result against `=== 0`, and both silently stopped working: the
+ * floor-rate guard no longer fired for unpriceable shared turns, and the
+ * skip-empty-turn check no longer fired at all — which persisted 419 junk rows
+ * in production before this existed. Snap the residue before either test.
+ */
+export function snapCostResidue(costUsd: number): number {
+  return costUsd < COST_EPSILON ? 0 : costUsd
+}

--- a/packages/web/lib/server/usage-cursor.test.ts
+++ b/packages/web/lib/server/usage-cursor.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for the diff cursor's keying rules.
+ *
+ * These exist because the bug they cover was invisible by inspection: the
+ * lookup key and the stored key were computed a few lines apart and looked
+ * interchangeable. They are not, and the cost of getting it wrong is a turn
+ * charged the session's entire history instead of its delta.
+ */
+import { describe, it, expect } from "vitest"
+
+import {
+  cursorForModel,
+  sumCumulatives,
+  ZERO_CUMULATIVE,
+  type SessionCumulative,
+} from "./usage-cursor"
+
+/** A cursor entry with every component set to `n`, for terse assertions. */
+const cume = (n: number): SessionCumulative => ({
+  inputTokens: n,
+  outputTokens: n,
+  cacheReadTokens: n,
+  cacheWriteTokens: n,
+  reasoningTokens: n,
+  totalTokens: n,
+  costUsd: n,
+})
+
+describe("sumCumulatives", () => {
+  it("returns zero for no parts", () => {
+    expect(sumCumulatives()).toEqual(ZERO_CUMULATIVE)
+  })
+
+  it("skips absent parts rather than treating them as zero-valued objects", () => {
+    expect(sumCumulatives(undefined, cume(3), undefined)).toEqual(cume(3))
+  })
+
+  it("adds every component", () => {
+    expect(sumCumulatives(cume(2), cume(5))).toEqual(cume(7))
+  })
+
+  it("does not mutate its inputs or the shared zero", () => {
+    const a = cume(1)
+    sumCumulatives(a, cume(4))
+    expect(a).toEqual(cume(1))
+    expect(ZERO_CUMULATIVE).toEqual(cume(0))
+  })
+})
+
+describe("cursorForModel", () => {
+  it("looks up the id the row is STORED under, not the one tokscale reported", () => {
+    // The regression: Droid reports "byok-0", we store "gemini-3-flash".
+    // Keying on the reported id found nothing, so the turn was charged the
+    // whole session cumulative instead of its delta.
+    const prior = new Map([["gemini-3-flash", cume(500)]])
+    expect(cursorForModel(prior, "byok-0", "gemini-3-flash")).toEqual(cume(500))
+  })
+
+  it("sums both ids for a session that straddles the fix", () => {
+    // Rows written before the fix sit under the placeholder; rows written
+    // after sit under the resolved id. Taking either half alone would
+    // understate the cursor and overcharge the turn by the other half.
+    const prior = new Map([
+      ["byok-0", cume(100)],
+      ["gemini-3-flash", cume(400)],
+    ])
+    expect(cursorForModel(prior, "byok-0", "gemini-3-flash")).toEqual(cume(500))
+  })
+
+  it("does not double-count when the id was never rewritten", () => {
+    const prior = new Map([["claude-fable-5", cume(700)]])
+    expect(cursorForModel(prior, "claude-fable-5", "claude-fable-5")).toEqual(
+      cume(700)
+    )
+  })
+
+  it("treats a null model as the empty-string key both modules agree on", () => {
+    const prior = new Map([["", cume(9)]])
+    expect(cursorForModel(prior, null, null)).toEqual(cume(9))
+  })
+
+  it("returns zero on a genuine first capture", () => {
+    expect(cursorForModel(new Map(), "claude-fable-5", "claude-fable-5")).toEqual(
+      ZERO_CUMULATIVE
+    )
+  })
+})

--- a/packages/web/lib/server/usage-cursor.test.ts
+++ b/packages/web/lib/server/usage-cursor.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect } from "vitest"
 
 import {
+  collapseEntriesByModel,
   cursorForModel,
   sumCumulatives,
   ZERO_CUMULATIVE,
@@ -83,5 +84,73 @@ describe("cursorForModel", () => {
     expect(cursorForModel(new Map(), "claude-fable-5", "claude-fable-5")).toEqual(
       ZERO_CUMULATIVE
     )
+  })
+})
+
+describe("collapseEntriesByModel", () => {
+  const entry = (model: string | null, input: number) => ({
+    model,
+    input,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    reasoning: 0,
+  })
+
+  it("passes distinct models through untouched", () => {
+    const given = [entry("claude-fable-5", 10), entry("gemini-3-flash", 20)]
+    const got = collapseEntriesByModel(given)
+    expect(got.entries).toEqual(given)
+    expect(got.collapsed).toBe(0)
+    expect(got.conflicted).toEqual([])
+  })
+
+  it("collapses a model tokscale reported twice", () => {
+    // The regression: one tokscale run reporting the same (session, model)
+    // twice wrote two rows from a single insert, each diffed against the same
+    // cursor, so the turn was charged twice.
+    const got = collapseEntriesByModel([
+      entry("claude-fable-5", 100),
+      entry("claude-fable-5", 100),
+    ])
+    expect(got.entries).toEqual([entry("claude-fable-5", 100)])
+    expect(got.collapsed).toBe(1)
+    expect(got.conflicted).toEqual([])
+  })
+
+  it("keeps the high-water mark, never the sum", () => {
+    // A cumulative is a high-water mark. Summing would invent usage: 100 and
+    // 140 are two readings of one counter, not 240 tokens.
+    const got = collapseEntriesByModel([
+      entry("claude-fable-5", 100),
+      entry("claude-fable-5", 140),
+      entry("claude-fable-5", 120),
+    ])
+    expect(got.entries).toEqual([entry("claude-fable-5", 140)])
+    expect(got.collapsed).toBe(2)
+  })
+
+  it("reports models whose entries disagreed, so the caller can log it", () => {
+    const got = collapseEntriesByModel([
+      entry("claude-fable-5", 100),
+      entry("claude-fable-5", 140),
+      entry("gemini-3-flash", 5),
+      entry("gemini-3-flash", 5),
+    ])
+    expect(got.conflicted).toEqual(["claude-fable-5"])
+  })
+
+  it("treats a null model as its own key rather than dropping it", () => {
+    const got = collapseEntriesByModel([entry(null, 7), entry("claude-fable-5", 3)])
+    expect(got.entries).toHaveLength(2)
+    expect(got.collapsed).toBe(0)
+  })
+
+  it("handles an empty list", () => {
+    expect(collapseEntriesByModel([])).toEqual({
+      entries: [],
+      collapsed: 0,
+      conflicted: [],
+    })
   })
 })

--- a/packages/web/lib/server/usage-cursor.ts
+++ b/packages/web/lib/server/usage-cursor.ts
@@ -1,0 +1,81 @@
+/**
+ * The TokenUsage diff cursor: how a turn's delta finds what was already
+ * recorded for its (session, model).
+ *
+ * Every ledger row holds a per-turn delta, so the sum of prior deltas for a
+ * (session, model) equals tokscale's cumulative at the last capture, and the
+ * next delta is (current cumulative − that sum). Getting the lookup key wrong
+ * therefore does not merely mislabel a row: `prev` falls back to zero and the
+ * turn is charged the session's entire history.
+ *
+ * Kept free of database imports — like lib/server/turn-pricing — so the keying
+ * rules can be unit-tested directly.
+ */
+
+/** Prior cumulative totals for one (session, model) pair, per component. */
+export interface SessionCumulative {
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  cacheWriteTokens: number
+  reasoningTokens: number
+  totalTokens: number
+  costUsd: number
+}
+
+export const ZERO_CUMULATIVE: SessionCumulative = {
+  inputTokens: 0,
+  outputTokens: 0,
+  cacheReadTokens: 0,
+  cacheWriteTokens: 0,
+  reasoningTokens: 0,
+  totalTokens: 0,
+  costUsd: 0,
+}
+
+/** Add cursor entries together, skipping any that are absent. */
+export function sumCumulatives(
+  ...parts: (SessionCumulative | undefined)[]
+): SessionCumulative {
+  const out: SessionCumulative = { ...ZERO_CUMULATIVE }
+  for (const part of parts) {
+    if (!part) continue
+    out.inputTokens += part.inputTokens
+    out.outputTokens += part.outputTokens
+    out.cacheReadTokens += part.cacheReadTokens
+    out.cacheWriteTokens += part.cacheWriteTokens
+    out.reasoningTokens += part.reasoningTokens
+    out.totalTokens += part.totalTokens
+    out.costUsd += part.costUsd
+  }
+  return out
+}
+
+/**
+ * The cursor for a turn, given the prior deltas grouped by the model id as
+ * *stored*.
+ *
+ * `reported` is the id tokscale printed; `resolved` is what resolveTurnModel
+ * turned it into and therefore what the row is filed under. Those differ
+ * whenever the CLI emits a placeholder (Droid's `byok-0`, Claude Code's
+ * `<synthetic>`), and looking up by `reported` — as this did until we found 41
+ * (session, model) pairs in production re-charging their whole cumulative —
+ * misses every row written under the resolved id.
+ *
+ * Both keys are summed rather than preferred one over the other: a session
+ * straddling this fix has rows under each id, and they describe the same model
+ * stream. Taking only one half would understate the cursor and overcharge the
+ * turn by whatever the other half held.
+ */
+export function cursorForModel(
+  prior: Map<string, SessionCumulative>,
+  reported: string | null | undefined,
+  resolved: string | null | undefined
+): SessionCumulative {
+  const key = resolved ?? ""
+  const rawKey = reported ?? ""
+  return sumCumulatives(
+    prior.get(key),
+    rawKey !== key ? prior.get(rawKey) : undefined
+  )
+}

--- a/packages/web/lib/server/usage-cursor.ts
+++ b/packages/web/lib/server/usage-cursor.ts
@@ -12,6 +12,58 @@
  * rules can be unit-tested directly.
  */
 
+/** The part of a tokscale entry that carries a model's cumulative counts. */
+export interface ModelCumulativeEntry {
+  model: string | null
+  input: number
+  output: number
+  cacheRead: number
+  cacheWrite: number
+  reasoning: number
+}
+
+/**
+ * Reduce tokscale's entries to at most one per model.
+ *
+ * `--group-by session,model` should already guarantee that, but production
+ * shows it does not: 19 ledger rows were written by a single insert because
+ * one tokscale run reported the same (session, model) twice. Both were diffed
+ * against the same cursor, so both charged the full delta.
+ *
+ * A model's cumulative is a high-water mark, so the largest entry is the
+ * truthful one and summing would invent usage that never happened. Entries
+ * that disagree are reported in `conflicted` for the caller to log — that
+ * would mean tokscale is partitioning one model across rows, which is worth
+ * knowing about rather than silently resolving.
+ */
+export function collapseEntriesByModel<T extends ModelCumulativeEntry>(
+  entries: T[]
+): { entries: T[]; collapsed: number; conflicted: string[] } {
+  const total = (e: T) =>
+    e.input + e.output + e.cacheRead + e.cacheWrite + e.reasoning
+
+  const best = new Map<string, T>()
+  const conflicted = new Set<string>()
+
+  for (const entry of entries) {
+    const key = entry.model ?? ""
+    const held = best.get(key)
+    if (!held) {
+      best.set(key, entry)
+      continue
+    }
+    if (total(entry) !== total(held)) conflicted.add(key)
+    if (total(entry) > total(held)) best.set(key, entry)
+  }
+
+  const kept = [...best.values()]
+  return {
+    entries: kept,
+    collapsed: entries.length - kept.length,
+    conflicted: [...conflicted],
+  }
+}
+
 /** Prior cumulative totals for one (session, model) pair, per component. */
 export interface SessionCumulative {
   inputTokens: number

--- a/packages/web/scripts/verify-metering.ts
+++ b/packages/web/scripts/verify-metering.ts
@@ -1,0 +1,157 @@
+/**
+ * End-to-end verification of the TokenUsage metering path against a real
+ * Daytona sandbox and a real Postgres.
+ *
+ * Exists because the unit tests only cover the extracted pure helpers
+ * (usage-cursor, turn-pricing). meterTurnUsage itself — the tokscale exec, the
+ * advisory-lock transaction, the delta arithmetic and the insert — had no
+ * coverage at all, and it is the part that was restructured.
+ *
+ * Run:  npx tsx scripts/verify-metering.ts <sandboxId> <agentSessionId>
+ *
+ * Writes throwaway rows to whatever DATABASE_URL points at and deletes them
+ * again; refuses to run against the production host outright.
+ */
+import { readFileSync } from "node:fs"
+
+for (const line of readFileSync(".env", "utf8").split("\n")) {
+  const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$/)
+  if (m && !process.env[m[1]]) process.env[m[1]] = m[2].replace(/^["']|["']$/g, "")
+}
+
+const PROD_HOST_MARKER = "us-east-2"
+if ((process.env.DATABASE_URL ?? "").includes(PROD_HOST_MARKER)) {
+  console.error("refusing to run: DATABASE_URL points at the production host")
+  process.exit(1)
+}
+
+async function main() {
+  const { Daytona } = await import("@daytonaio/sdk")
+  const { prisma } = await import("@/lib/db/prisma")
+  const { meterAssistantTurn } = await import("@/lib/server/token-metering")
+
+  const [sandboxId, sessionId] = process.argv.slice(2)
+  if (!sandboxId || !sessionId) {
+    console.error("usage: tsx scripts/verify-metering.ts <sandboxId> <agentSessionId>")
+    process.exit(1)
+  }
+
+  const TAG = `metering-verify-${Date.now()}`
+  let pass = 0
+  let fail = 0
+
+  const check = (name: string, ok: boolean, detail: string) => {
+    console.log(`   ${ok ? "PASS" : "FAIL"}  ${name} — ${detail}`)
+    ok ? pass++ : fail++
+  }
+
+  const rows = () =>
+    prisma.tokenUsage.findMany({
+      where: { sessionId },
+      orderBy: { createdAt: "asc" },
+    })
+  const wipe = () => prisma.tokenUsage.deleteMany({ where: { sessionId } })
+
+  const daytona = new Daytona({ apiKey: process.env.DAYTONA_API_KEY })
+  const sandbox = await daytona.get(sandboxId)
+
+  // Seed the minimum graph TokenUsage's foreign keys require.
+  const user = await prisma.user.create({
+    data: { name: TAG, email: `${TAG}@invalid.test` },
+  })
+  const chat = await prisma.chat.create({
+    data: { userId: user.id, repo: "__new__", agent: "gemini", status: "ready" },
+  })
+  const message = await prisma.message.create({
+    data: {
+      chatId: chat.id,
+      role: "assistant",
+      content: TAG,
+      timestamp: BigInt(Date.now()),
+      metadata: { usage: { provider: "gemini", pool: "user" } },
+    },
+  })
+
+  const meter = () =>
+    meterAssistantTurn(sandbox, {
+      userId: user.id,
+      chatId: chat.id,
+      messageId: message.id,
+      messageMetadata: message.metadata,
+      agent: "gemini",
+      sessionId,
+    })
+
+  try {
+    await wipe()
+
+    console.log("\n1. First capture writes exactly one correct row")
+    const wrote = await meter()
+    let got = await rows()
+    check("row count", got.length === 1, `wrote=${wrote} rows=${got.length}`)
+    if (got[0]) {
+      const r = got[0]
+      const sum =
+        r.inputTokens +
+        r.outputTokens +
+        r.cacheReadTokens +
+        r.cacheWriteTokens +
+        r.reasoningTokens
+      check(
+        "delta is self-consistent",
+        sum === r.totalTokens && r.totalTokens > 0,
+        `total=${r.totalTokens} components=${sum} cost=${r.costUsd} model=${r.model}`
+      )
+      check(
+        "cumulative recorded",
+        r.cumulativeTotal === r.totalTokens,
+        `cumulativeTotal=${r.cumulativeTotal} (first capture, so equals the delta)`
+      )
+    }
+
+    console.log("\n2. Re-metering the same turn writes nothing (bug 2: no junk row)")
+    const wrote2 = await meter()
+    got = await rows()
+    check(
+      "no second row",
+      wrote2 === 0 && got.length === 1,
+      `wrote=${wrote2} rows=${got.length} (pre-fix this stored a ~4e-16 junk row)`
+    )
+
+    console.log("\n3. Concurrent finalizers write exactly one row (bug 1: the race)")
+    for (let round = 1; round <= 3; round++) {
+      await wipe()
+      const results = await Promise.all([meter(), meter(), meter(), meter()])
+      got = await rows()
+      check(
+        `round ${round}`,
+        got.length === 1,
+        `4 concurrent callers → returned [${results.join(",")}] rows=${got.length}`
+      )
+    }
+
+    console.log("\n4. Ledger totals are not inflated by the concurrent round")
+    const agg = await prisma.tokenUsage.aggregate({
+      where: { sessionId },
+      _sum: { totalTokens: true, costUsd: true },
+    })
+    check(
+      "single charge",
+      (agg._sum.totalTokens ?? 0) === (got[0]?.totalTokens ?? -1),
+      `summed=${agg._sum.totalTokens} cost=${agg._sum.costUsd}`
+    )
+  } finally {
+    await wipe()
+    await prisma.message.deleteMany({ where: { chatId: chat.id } })
+    await prisma.chat.delete({ where: { id: chat.id } })
+    await prisma.user.delete({ where: { id: user.id } })
+    console.log("\ncleaned up test user/chat/message/rows")
+    await prisma.$disconnect()
+  }
+
+  console.log(`\n${fail === 0 ? "ALL PASSED" : "FAILURES"}: ${pass} passed, ${fail} failed`)
+    process.exit(fail === 0 ? 0 : 1)
+
+}
+
+main()


### PR DESCRIPTION
# Fix three defects in the TokenUsage metering path

  The ledger stores per-turn deltas, but tokscale only reports session cumulatives — so  every write is a read-modify-write. All three bugs live in that sequence. No schema
  change; no back-fill.
  ## What was wrong

  **1. Concurrent finalizers billed the same turn twice.** The SSE stream route, the
  every-minute cron, and overlapping cron ticks can all meter one turn. The stream meters,
  *then* pushes to git, and only then releases the chat from `running` — so the cron picks
  it up for that whole window. Both read the cursor before either inserts, both write.
  One reply was billed **twice at $44.10**, 50 ms apart.
  → **156 rows · $302.53 · 71 users**

  **2. Float residue defeated two `costUsd === 0` checks.** Subtracting a *sum* of floats
  lands on `4.4e-16`, not `0`. The skip-empty-turn check never fired (**419 junk rows**),
  and neither did the floor-rate guard — so an unpriceable shared turn could record no
  cost,
  a free route around the daily balance. Claude stopped on 31 Aug by accident; **OpenCode
  and Gemini are still producing them.**

  **3. The cursor was read under the wrong key.** `getSessionCumulatives` groups by the
  *stored* model id; the lookup used the id tokscale *reported*. They diverge when a
  placeholder is rewritten (`byok-0`, `<synthetic>` — both in prod). The lookup missed and
  the turn was charged the session's **entire cumulative**. → **41 pairs**

  ## What changed

  | | |
  |---|---|
  | `snapCostResidue` | Zeroes residue before both `=== 0` tests. `1e-9` sits between the largest residue (~2e-15) and the cheapest real charge ($2.2e-4). |
  | `cursorForModel` | Looks up the stored id, **summing both** — sessions straddling this deploy hold rows under each. |
  | `lockSessionForMetering` | Transaction-scoped advisory lock around read+compute+insert.  |
  | `collapseEntriesByModel` | One entry per model; keeps the **largest**, not the sum (a cumulative is a high-water mark). |

  **Why a lock, not a unique index** — the index is the obvious fix and it's wrong.
  `(sessionId, model, cumulativeTotal)` would reject **419 legitimate rows**; adding
  `messageId` still collides on 345 groups, **197 holding genuinely different values**.
  No unique index on this table is safe.

  `pg_advisory_xact_lock` specifically: the only form safe through a transaction-mode
  pooler, and it releases on commit, rollback *or* dropped connection, so a crashed
  finalizer can't strand a session. The loser reads a cursor containing the winner's rows
  and writes nothing — **which depends on fix 2**; without the snap it writes the duplicate  anyway.

  ## Verification

  **221 unit tests** (29 new), asserting against verbatim production values.

  **End-to-end** (`scripts/verify-metering.ts`, real Daytona sandbox + real Postgres) —
  8/8:
  one correct row on first capture; nothing on re-meter; four concurrent finalizers → one
  row, three rounds; ledger sum is a single charge.

  **The harness reproduces the bug without the fix:**

  ```
  OLD (unguarded)  rows=1 / 45504   ← round 1, serialized by luck
  OLD (unguarded)  rows=4 / 182016  ← rounds 2 and 3, 4× overcharge
  NEW (locked)     rows=1 / 45504   ← all three rounds
  ```

  **Typecheck** — 21 errors, identical to `main`, none in touched files (pre-existing
  `Sidebar.tsx` casing clash).

 