### PR TITLE
Gate scheduled job runs on the daily shared-pool balance

### DIFF
--- a/packages/web/app/api/cron/agent-lifecycle/_lib/scheduled.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/_lib/scheduled.ts
@@ -8,6 +8,8 @@ import { getUserEndpoints } from "@/lib/server/custom-endpoints"
 
 import { prisma } from "@/lib/db/prisma"
 import { decryptUserCredentials, getUserCredentials } from "@/lib/db/api-helpers"
+import { logActivityAsync } from "@/lib/db/activity-log"
+import { checkSharedPoolUsage, UsageLimitError } from "@/lib/db/usage-limit"
 import { getClaudeCredentials } from "@/lib/claude-credentials"
 import { meterAssistantTurn } from "@/lib/server/token-metering"
 import { buildUsageMeta } from "@/lib/server/shared-pool"
@@ -35,6 +37,34 @@ export async function startJobExecution(
   daytona: Daytona
 ) {
   const isRepoLess = job.repo === NEW_REPOSITORY
+
+  // 0. Enforce the daily balance before spending anything.
+  //
+  // Scheduled runs draw on the same shared pools as interactive turns and are
+  // metered the same way (step 9 below stamps the pool; the run finalizer
+  // reports the tokens), so without this a job left enabled on a spent balance
+  // keeps spending — every tick — while the chat UI refuses to send. Checked
+  // here rather than in the trigger routes so cron dispatch, "Run now" and
+  // webhooks are all covered by the one gate. Own-key, custom-endpoint,
+  // free-model and Unlimited-plan runs are uncapped and pass straight through.
+  const usage = await checkSharedPoolUsage(
+    job.userId,
+    job.agent as Agent,
+    job.model ?? undefined
+  )
+  if (!usage.allowed) {
+    logActivityAsync(job.userId, "daily_limit_reached", {
+      provider: usage.provider,
+      agent: job.agent,
+      model: job.model ?? undefined,
+      used: usage.used,
+      limit: usage.limit,
+      resetAt: usage.resetAt.toISOString(),
+      source: "scheduled-job",
+      jobRunId: run.id,
+    })
+    throw new UsageLimitError(usage)
+  }
 
   // 1. Get GitHub token for the user — required for cloned repos, optional
   //    for repo-less jobs (the sandbox never reaches out to GitHub, though
@@ -547,7 +577,14 @@ export async function finalizeScheduledRun(
 export async function failScheduledRun(
   run: ScheduledJobRunWithJob | Prisma.ScheduledJobRunGetPayload<{ include: { job: true } }>,
   error: string,
-  daytona?: Daytona
+  daytona?: Daytona,
+  /**
+   * Whether this failure counts toward the job's consecutive-failure budget
+   * (3 strikes auto-disables the job). Pass false for failures that say nothing
+   * about the job itself — a spent daily balance, which clears at UTC midnight
+   * — so a couple of capped days can't silently disable it.
+   */
+  { countFailure = true }: { countFailure?: boolean } = {}
 ) {
   // Update run status
   await prisma.scheduledJobRun.update({
@@ -567,15 +604,17 @@ export async function failScheduledRun(
   }
 
   // Track consecutive failures, auto-disable after 3
-  const job = run.job
-  const failures = job.consecutiveFailures + 1
-  await prisma.scheduledJob.update({
-    where: { id: run.jobId },
-    data: {
-      consecutiveFailures: failures,
-      enabled: failures < 3,
-    },
-  })
+  if (countFailure) {
+    const job = run.job
+    const failures = job.consecutiveFailures + 1
+    await prisma.scheduledJob.update({
+      where: { id: run.jobId },
+      data: {
+        consecutiveFailures: failures,
+        enabled: failures < 3,
+      },
+    })
+  }
 
   // Delete sandbox now that run is complete
   if (run.sandboxId && daytona) {

--- a/packages/web/app/api/cron/agent-lifecycle/route.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/route.ts
@@ -3,6 +3,7 @@ import { addMinutes, differenceInMinutes } from "date-fns"
 
 import { prisma } from "@/lib/db/prisma"
 import { logLlmProviderError } from "@/lib/db/activity-log"
+import { UsageLimitError } from "@/lib/db/usage-limit"
 
 import { INTERACTIVE_HARD_TIMEOUT, SCHEDULED_HARD_TIMEOUT } from "./_lib/constants"
 import { monitorAgent, stopAgent } from "./_lib/monitor"
@@ -46,6 +47,7 @@ export async function GET(req: Request) {
     completedScheduled: 0,
     timedOutInteractive: 0,
     timedOutScheduled: 0,
+    skippedOverLimit: 0,
     errors: [] as string[],
   }
 
@@ -103,6 +105,16 @@ export async function GET(req: Request) {
         await startJobExecution(run.job, run, daytona)
         results.startedPendingRuns++
       } catch (err) {
+        // A spent daily balance isn't a job failure: record it on the run so
+        // the user can see why it didn't run, but leave the job enabled and
+        // its failure streak untouched. The balance resets at UTC midnight and
+        // nextRunAt was already advanced at dispatch, so the job resumes on
+        // its own.
+        if (err instanceof UsageLimitError) {
+          await failScheduledRun(run, err.message, daytona, { countFailure: false })
+          results.skippedOverLimit++
+          continue
+        }
         await failScheduledRun(run, `Failed to start: ${err}`, daytona)
         results.errors.push(`Failed to start run ${run.id}: ${err}`)
       }

--- a/packages/web/lib/db/usage-limit.ts
+++ b/packages/web/lib/db/usage-limit.ts
@@ -122,3 +122,21 @@ export async function checkSharedPoolUsage(
     error: allowed ? undefined : formatUsageLimitMessage({ plan, limit: allowance }),
   }
 }
+
+/**
+ * Thrown when a run is refused because the daily balance is spent.
+ *
+ * Used by the scheduled-job path, which has no request to answer with a 429:
+ * the starter throws this and the cron turns it into a failed run record
+ * without counting it against the job's consecutive-failure budget (a spent
+ * balance is not the job misbehaving, and it clears at UTC midnight).
+ */
+export class UsageLimitError extends Error {
+  readonly usage: UsageLimitResult
+
+  constructor(usage: UsageLimitResult) {
+    super(usage.error ?? "Daily limit reached")
+    this.name = "UsageLimitError"
+    this.usage = usage
+  }
+}


### PR DESCRIPTION
## Gate scheduled job runs on the daily shared-pool balance

  ### Problem

  Scheduled runs were metered like interactive turns  (`buildUsageMeta` +
  `meterAssistantTurn`) but never checked against the balance
  they spend —
  `checkSharedPoolUsage` was only called from the chat send
  path. A job left
  enabled on a spent balance kept spending on every cron tick
  while the chat UI
  refused to send, and that spend then blocked the user's next  interactive turn.

  ### Fix

  - Check the balance once at the top of `startJobExecution`,
  before any chat row
    or sandbox is created, so cron dispatch, "Run now" and
  webhook triggers are all
    covered by a single gate.
  - A blocked run is recorded as an errored run carrying the
  standard limit copy,
    and logs a `daily_limit_reached` activity row (`source:
  "scheduled-job"`).
  - `failScheduledRun` takes a `countFailure` option, passed
  `false` for limit
    blocks: without it, three capped days in a row would trip
  the 3-strike
    auto-disable and switch the job off permanently. The
  balance resets at UTC
    midnight and `nextRunAt` is already advanced at dispatch,
  so the job resumes
    on its own.
  - Cron response gains a `skippedOverLimit` counter; limit
  blocks stay out of
    `results.errors`.

  Own-key, custom-endpoint, free-model and Unlimited-plan runs  are uncapped and
  pass straight through, same as the send path.

  ### Testing

  Verified `checkSharedPoolUsage` against live data for a
  queued job: a
  `opencode/big-pickle` run resolves to `limit=none` and
  passes through, while
  `claude-code`/`gemini` report the Pro $10 daily balance. The  block path itself
  isn't exercised — that needs a user actually over their
  balance.

