### PR TITLE
Add Fable to Claude Code as BYOK-only model

### DIFF
--- a/packages/common/src/agents.ts
+++ b/packages/common/src/agents.ts
@@ -781,6 +781,34 @@ export function resolveModelForAgent(
 }
 
 /**
+ * Resolve the model a chat should actually run on.
+ *
+ * Normally the chat's own stored model, but it downgrades to the agent's default
+ * usable model (via resolveModelForAgent) when the stored model isn't runnable
+ * for this user — either it's locked (no credentials, e.g. a BYOK-only model like
+ * Fable on a keyless account) or it's no longer offered by the agent (removed from
+ * the picker). This keeps an existing chat sending instead of stranding it on a
+ * model it can never use — the composer would otherwise just block with a lock.
+ *
+ * A stored model the user *can* run is always kept, so a chat on Fable with the
+ * user's own Anthropic key stays on Fable.
+ */
+export function resolveChatModel(
+  agent: Agent,
+  storedModel: string | null | undefined,
+  flags: CredentialFlags | null | undefined,
+  preferredModel?: string | null | undefined,
+  endpoints?: CustomEndpoint[]
+): string {
+  if (storedModel) {
+    const models = getAgentModels(agent, endpoints)
+    const config = models.find((m) => m.value === storedModel)
+    if (config && hasCredentialsForModel(config, flags, agent)) return storedModel
+  }
+  return resolveModelForAgent(agent, flags, preferredModel, endpoints)
+}
+
+/**
  * Resolve which agent to use, following the precedence:
  * caller-preferred → user's saved default → the hardcoded default agent.
  * Centralizes the `as Agent` cast so call sites don't each repeat it.

--- a/packages/common/src/agents.ts
+++ b/packages/common/src/agents.ts
@@ -220,11 +220,24 @@ const SHARED_GEMINI_POOL_PRO_MODELS = new Set<string>([
   "google/gemini-3.1-pro-preview",
 ])
 
+/**
+ * Claude Code models the server-shared Claude pool must NOT unlock. Unlike every
+ * other anthropic model on claude-code, these run only on the user's OWN key or
+ * subscription token — never the free shared pool. Fable ($10/M) is too costly to
+ * serve for free, so it's BYOK-only. This also retroactively gates existing chats
+ * still pointed at such a model: with no personal Anthropic credential the picker
+ * shows a lock and the send path (hasRequiredCredentials) blocks the turn.
+ */
+const SHARED_CLAUDE_POOL_EXCLUDED_MODELS = new Set<string>(["fable"])
+
 export const agentModels: Record<Agent, ModelOption[]> = {
   "claude-code": [
     { value: "sonnet", label: "Sonnet", requiresKey: "anthropic", priceLabel: "$2/M" },
     { value: "opus", label: "Opus", requiresKey: "anthropic", priceLabel: "$5/M" },
     { value: "haiku", label: "Haiku", requiresKey: "anthropic", priceLabel: "$1/M" },
+    // BYOK-only: excluded from the shared Claude pool (see
+    // SHARED_CLAUDE_POOL_EXCLUDED_MODELS) — no priceLabel since it never draws it.
+    { value: "fable", label: "Fable", requiresKey: "anthropic" },
     { value: "default", label: "Auto", requiresKey: "anthropic" },
     { value: "best", label: "Best", requiresKey: "anthropic" },
   ],
@@ -646,6 +659,12 @@ export function hasCredentialsForModel(
     // (see resolveSendCredentials). Every other agent (OpenCode, Pi, Goose, …)
     // needs a real API key.
     if (agent !== "claude-code") return !!flags?.ANTHROPIC_API_KEY
+    // BYOK-only Claude models (e.g. Fable) never run on the shared pool — they
+    // require the user's own API key or subscription, regardless of balance. This
+    // is what gates existing chats still pointed at such a model.
+    if (SHARED_CLAUDE_POOL_EXCLUDED_MODELS.has(model.value)) {
+      return !!flags?.ANTHROPIC_API_KEY || !!flags?.CLAUDE_CODE_CREDENTIALS
+    }
     // Claude Code can use either API key, the user's pasted subscription, or the shared pool.
     // With the credit allowance spent, only the user's own credentials remain.
     if (flags?.SHARED_BALANCE_EXHAUSTED) {

--- a/packages/common/src/agents.ts
+++ b/packages/common/src/agents.ts
@@ -177,8 +177,9 @@ export interface ModelOption {
    * Only set for models that don't require the user's own key — either the
    * server's shared credential pool (a real per-input-token $/M rate, e.g.
    * "$2/M" or "30¢/M") or "FREE" for models needing no key at all (requiresKey
-   * "none"). Omitted for BYOK models and for auto/default routers, whose
-   * resolved model — and so cost — is unknown ahead of time.
+   * "none"). May also be set on a BYOK model as an indicative list rate (e.g.
+   * Fable's "$10/M"). Omitted for auto/default routers, whose resolved model —
+   * and so cost — is unknown ahead of time.
    */
   priceLabel?: string
 }
@@ -236,8 +237,9 @@ export const agentModels: Record<Agent, ModelOption[]> = {
     { value: "opus", label: "Opus", requiresKey: "anthropic", priceLabel: "$5/M" },
     { value: "haiku", label: "Haiku", requiresKey: "anthropic", priceLabel: "$1/M" },
     // BYOK-only: excluded from the shared Claude pool (see
-    // SHARED_CLAUDE_POOL_EXCLUDED_MODELS) — no priceLabel since it never draws it.
-    { value: "fable", label: "Fable", requiresKey: "anthropic" },
+    // SHARED_CLAUDE_POOL_EXCLUDED_MODELS). priceLabel is shown as an indicative
+    // list rate even though the user runs it on their own key.
+    { value: "fable", label: "Fable", requiresKey: "anthropic", priceLabel: "$10/M" },
     { value: "default", label: "Auto", requiresKey: "anthropic" },
     { value: "best", label: "Best", requiresKey: "anthropic" },
   ],

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -51,6 +51,7 @@ export {
   getDefaultModelForAgent,
   getFreeModelForAgent,
   resolveModelForAgent,
+  resolveChatModel,
   resolveAgent,
   resolveAgentAndModel,
   getAgentModels,

--- a/packages/web/lib/agent-status.test.ts
+++ b/packages/web/lib/agent-status.test.ts
@@ -15,6 +15,7 @@ import {
   getFreeModelForAgent,
   modelRequiresKey,
   getAgentModels,
+  resolveChatModel,
   type CredentialFlags,
 } from "@background-agents/common"
 
@@ -155,6 +156,31 @@ describe("shared Claude pool does not unlock BYOK-only models (Fable)", () => {
 
   it("unlocks Fable with the user's pasted subscription token", () => {
     expect(hasCredentialsForModel(fable, { CLAUDE_CODE_CREDENTIALS: true }, "claude-code")).toBe(true)
+  })
+})
+
+describe("resolveChatModel downgrades locked/removed stored models", () => {
+  // An existing chat carries its own stored model. If the user can't run it
+  // (locked BYOK-only model, or a model since removed from the picker), the chat
+  // should fall back to a usable default instead of stranding on a lock.
+  it("downgrades an existing Fable chat to Sonnet when there's no key", () => {
+    expect(resolveChatModel("claude-code", "fable", sharedPoolFresh)).toBe("sonnet")
+  })
+
+  it("keeps Fable when the user has their own Anthropic key", () => {
+    expect(resolveChatModel("claude-code", "fable", { ANTHROPIC_API_KEY: true })).toBe("fable")
+  })
+
+  it("keeps a normal, usable stored model as-is", () => {
+    expect(resolveChatModel("claude-code", "sonnet", sharedPoolFresh)).toBe("sonnet")
+  })
+
+  it("downgrades a model no longer offered by the agent", () => {
+    expect(resolveChatModel("claude-code", "some-removed-model", sharedPoolFresh)).toBe("sonnet")
+  })
+
+  it("falls back to the default when the chat has no stored model", () => {
+    expect(resolveChatModel("claude-code", null, sharedPoolFresh)).toBe("sonnet")
   })
 })
 

--- a/packages/web/lib/agent-status.test.ts
+++ b/packages/web/lib/agent-status.test.ts
@@ -134,6 +134,30 @@ describe("shared Gemini pool unlocks Flash but not Pro", () => {
   })
 })
 
+describe("shared Claude pool does not unlock BYOK-only models (Fable)", () => {
+  // Fable is back in the claude-code picker but excluded from the shared pool
+  // (SHARED_CLAUDE_POOL_EXCLUDED_MODELS): it runs only on the user's own key or
+  // subscription. The other claude-code models stay available on the shared pool.
+  const fable = { value: "fable", label: "Fable", requiresKey: "anthropic" as const }
+  const sonnet = { value: "sonnet", label: "Sonnet", requiresKey: "anthropic" as const }
+
+  it("blocks Fable on the shared pool alone", () => {
+    expect(hasCredentialsForModel(fable, sharedPoolFresh, "claude-code")).toBe(false)
+  })
+
+  it("still allows the regular Sonnet model on the shared pool", () => {
+    expect(hasCredentialsForModel(sonnet, sharedPoolFresh, "claude-code")).toBe(true)
+  })
+
+  it("unlocks Fable with the user's own Anthropic key", () => {
+    expect(hasCredentialsForModel(fable, { ANTHROPIC_API_KEY: true }, "claude-code")).toBe(true)
+  })
+
+  it("unlocks Fable with the user's pasted subscription token", () => {
+    expect(hasCredentialsForModel(fable, { CLAUDE_CODE_CREDENTIALS: true }, "claude-code")).toBe(true)
+  })
+})
+
 describe("free models survive a spent balance", () => {
   // The escape hatch: with the balance gone, OpenCode's free tier is what a
   // user is told to switch to. Two separate gates have to agree on that — the

--- a/packages/web/lib/hooks/useChatComposer.ts
+++ b/packages/web/lib/hooks/useChatComposer.ts
@@ -22,7 +22,7 @@ import {
   agentModels,
   hasCredentialsForModel,
   resolveAgent,
-  resolveModelForAgent,
+  resolveChatModel,
   agentSupportsPlanMode,
 } from "@/lib/types"
 import { filterSlashCommandsWithConflict, filterSingleCommand, CREATE_REPO_COMMAND } from "@background-agents/common"
@@ -125,7 +125,10 @@ export function useChatComposer({
   }, [])
 
   // Resolve the model for the current agent (honoring the saved default).
-  const currentModel = chat?.model ?? resolveModelForAgent(currentAgent, credentialFlags, settings.defaultModel)
+  // Use the chat's stored model, but downgrade to a usable default when that model
+  // is locked (no credentials, e.g. an existing Fable chat on a keyless account) or
+  // no longer offered — so the chat keeps sending instead of stranding on a lock.
+  const currentModel = resolveChatModel(currentAgent, chat?.model, credentialFlags, settings.defaultModel)
 
   // Check if the selected model has required credentials
   const availableModels = agentModels[currentAgent] ?? []

--- a/packages/web/lib/types.ts
+++ b/packages/web/lib/types.ts
@@ -21,6 +21,7 @@ export {
   getDefaultModelForAgent,
   getFreeModelForAgent,
   resolveModelForAgent,
+  resolveChatModel,
   resolveAgent,
   resolveAgentAndModel,
   getAgentModels,


### PR DESCRIPTION
Re-add the Fable model to Claude Code as a BYOK-only model, restoring its functionality after it was previously removed. This change ensures Fable is available only to users with their own key.