### PR TITLE
feat(web): the credit balance and the Stripe path 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,14 @@ GITHUB_CLIENT_SECRET="placeholder"
 # Optional: override the built-in dev encryption key.
 # Generate with: openssl rand -hex 32
 # ENCRYPTION_KEY="0000000000000000000000000000000000000000000000000000000000000000"
+
+# -----------------------------------------------------------------------------
+# Stripe — credit top-ups. Optional: leave BILLING_ENABLED unset and the
+# billing routes 404 while the rest of the app runs normally.
+# -----------------------------------------------------------------------------
+# BILLING_ENABLED="true"
+# STRIPE_SECRET_KEY="sk_test_..."
+# STRIPE_WEBHOOK_SECRET="whsec_..."   # per environment: CLI, preview and live all differ
+# Pack id -> Stripe price id. Price ids do not cross test/live mode, so this
+# map differs per environment too. Only ids listed here can be purchased.
+# STRIPE_PRICE_MAP='{"pack_5":"price_...","pack_10":"price_...","pack_50":"price_...","pack_100":"price_..."}'

--- a/package-lock.json
+++ b/package-lock.json
@@ -15180,6 +15180,23 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/stripe": {
+      "version": "22.6.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.6.1.tgz",
+      "integrity": "sha512-hAKSkGeVt2u46TRYhmnvwmVHxBNtOCJnPjc+SH5sP2B2ypElYzAAY3Ljx0Ar8C2w8nfpFQiZ95qoDCDsFkXMTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/strnum": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
@@ -22224,6 +22241,7 @@
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "secure-json-parse": "^2.7.0",
+        "stripe": "^22.6.1",
         "sugar-high": "^0.9.0",
         "tailwind-merge": "^3.3.1",
         "ws": "^8.18.0",

--- a/packages/web/app/api/admin/users/[userId]/credits/route.ts
+++ b/packages/web/app/api/admin/users/[userId]/credits/route.ts
@@ -1,0 +1,140 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import { requireAdmin, isAuthError } from "@/lib/db/api-helpers"
+import { prisma } from "@/lib/db/prisma"
+import { logActivity } from "@/lib/db/activity-log"
+import { applyCreditTransaction, listCreditTransactions } from "@/lib/db/credits"
+import { microToUsd, usdToMicro } from "@/lib/server/credits"
+
+/**
+ * Manual credit movements, for admins.
+ *
+ * This is what makes the credit system operable and testable without Stripe:
+ * grant yourself a balance, watch usage draw it down, and correct anything a
+ * payment got wrong. It is also the tool for the case Stripe cannot handle
+ * itself — a payment that arrived with no resolvable user, which the webhook
+ * deliberately refuses to guess at.
+ */
+
+/**
+ * Ceiling on a single manual movement, in USD.
+ *
+ * Not a policy limit — an admin can simply post twice — but a guard against a
+ * mistyped amount. A credit is real money the platform then spends on the
+ * user's behalf, and there is no undo beyond posting the negative.
+ */
+const MAX_ADJUSTMENT_USD = 10_000
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ userId: string }> }
+) {
+  const auth = await requireAdmin()
+  if (isAuthError(auth)) return auth
+
+  const { userId: targetUserId } = await params
+
+  let body: { amountUsd?: unknown; note?: unknown }
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+  }
+
+  const amountUsd = body.amountUsd
+  if (typeof amountUsd !== "number" || !Number.isFinite(amountUsd) || amountUsd === 0) {
+    return NextResponse.json(
+      { error: "amountUsd must be a non-zero finite number" },
+      { status: 400 }
+    )
+  }
+  if (Math.abs(amountUsd) > MAX_ADJUSTMENT_USD) {
+    return NextResponse.json(
+      { error: `amountUsd must be within +/-${MAX_ADJUSTMENT_USD}` },
+      { status: 400 }
+    )
+  }
+
+  const amountMicroUsd = usdToMicro(amountUsd)
+  if (amountMicroUsd === 0n) {
+    // Below a micro-dollar. Rejected rather than silently written as a no-op
+    // row, so the caller learns nothing happened.
+    return NextResponse.json(
+      { error: "amountUsd is too small to record" },
+      { status: 400 }
+    )
+  }
+
+  const targetUser = await prisma.user.findUnique({
+    where: { id: targetUserId },
+    select: { id: true, name: true, email: true },
+  })
+  if (!targetUser) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 })
+  }
+
+  const note = typeof body.note === "string" ? body.note.slice(0, 500) : null
+
+  // A positive movement is a gift of credits; a negative one is a correction.
+  // They are separate types so the ledger (and the reconciliation cron) can
+  // tell "we gave this away" from "we took it back".
+  const type = amountUsd > 0 ? "grant" : "adjustment"
+
+  const balance = await applyCreditTransaction({
+    userId: targetUserId,
+    amountMicroUsd,
+    type,
+    description: note ?? `Manual ${type} by admin`,
+    metadata: { adminUserId: auth.userId },
+  })
+
+  await logActivity(auth.userId, "credits_adjusted", {
+    targetUserId,
+    targetUserName: targetUser.name,
+    amountUsd,
+    type,
+    note,
+    balanceAfterUsd: microToUsd(balance),
+  })
+
+  return NextResponse.json({
+    userId: targetUserId,
+    amountUsd,
+    type,
+    balanceUsd: microToUsd(balance),
+  })
+}
+
+/** The target user's balance and recent movements. */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ userId: string }> }
+) {
+  const auth = await requireAdmin()
+  if (isAuthError(auth)) return auth
+
+  const { userId: targetUserId } = await params
+
+  const user = await prisma.user.findUnique({
+    where: { id: targetUserId },
+    select: { creditBalanceMicroUsd: true },
+  })
+  if (!user) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 })
+  }
+
+  const transactions = await listCreditTransactions({ userId: targetUserId })
+
+  return NextResponse.json({
+    balanceUsd: microToUsd(user.creditBalanceMicroUsd),
+    transactions: transactions.map((t) => ({
+      id: t.id,
+      amountUsd: microToUsd(t.amountMicroUsd),
+      balanceAfterUsd: microToUsd(t.balanceAfterMicroUsd),
+      type: t.type,
+      description: t.description,
+      chatId: t.chatId,
+      createdAt: t.createdAt.toISOString(),
+    })),
+  })
+}

--- a/packages/web/app/api/billing/checkout/route.ts
+++ b/packages/web/app/api/billing/checkout/route.ts
@@ -1,0 +1,153 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import { requireAuth, isAuthError, internalError } from "@/lib/db/api-helpers"
+import { prisma } from "@/lib/db/prisma"
+import {
+  appUrl,
+  getCreditPack,
+  getStripe,
+  isBillingEnabled,
+} from "@/lib/server/stripe"
+
+export const runtime = "nodejs"
+
+/**
+ * POST /api/billing/checkout
+ *
+ * Starts a credit top-up. Returns the hosted Checkout URL for the client to
+ * redirect to; it does not credit anything. Credits are granted by the webhook
+ * and nowhere else, because this response can be replayed, bookmarked, or never
+ * reached at all, while the payment still succeeded.
+ *
+ * The body carries a pack id, and — only for the pack Stripe marks as a
+ * customer-chosen amount — an `amountUsd`. The id is resolved against
+ * STRIPE_PRICE_MAP on the server, and the amount is checked against the bounds
+ * on that Stripe price, so what can be bought and for how much is fixed by
+ * Stripe and the environment rather than by whatever the browser sends.
+ */
+export async function POST(request: NextRequest) {
+  if (!isBillingEnabled()) {
+    return NextResponse.json({ error: "Billing is not enabled" }, { status: 404 })
+  }
+
+  const auth = await requireAuth()
+  if (isAuthError(auth)) return auth
+  const { userId } = auth
+
+  let body: { packId?: unknown; amountUsd?: unknown }
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+  }
+
+  const packId = body.packId
+  if (typeof packId !== "string" || !packId) {
+    return NextResponse.json({ error: "packId is required" }, { status: 400 })
+  }
+
+  try {
+    const stripe = getStripe()
+
+    const pack = await getCreditPack(packId)
+    if (!pack) {
+      return NextResponse.json({ error: "Unknown pack" }, { status: 400 })
+    }
+
+    // A chosen amount is only meaningful for a custom-amount price, and only
+    // within the bounds Stripe itself carries for it.
+    let customCents: number | null = null
+    if (body.amountUsd !== undefined) {
+      if (pack.amountUsd !== null) {
+        return NextResponse.json(
+          { error: "This pack has a fixed amount" },
+          { status: 400 }
+        )
+      }
+      const amountUsd = body.amountUsd
+      if (typeof amountUsd !== "number" || !Number.isFinite(amountUsd)) {
+        return NextResponse.json({ error: "amountUsd must be a number" }, { status: 400 })
+      }
+      const cents = Math.round(amountUsd * 100)
+      const minCents = Math.round((pack.minUsd ?? 0) * 100)
+      const maxCents = Math.round((pack.maxUsd ?? 0) * 100)
+      if (cents < minCents || (maxCents > 0 && cents > maxCents)) {
+        return NextResponse.json(
+          { error: `Enter an amount between $${(minCents / 100).toFixed(2)} and $${(maxCents / 100).toFixed(2)}` },
+          { status: 400 }
+        )
+      }
+      customCents = cents
+    } else if (pack.amountUsd === null) {
+      // No amount given for a custom pack — fall back to Stripe's preset so the
+      // request still buys something rather than failing at the redirect.
+      customCents = Math.round((pack.presetUsd ?? pack.minUsd ?? 0) * 100)
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { stripeCustomerId: true, email: true, name: true },
+    })
+    if (!user) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 })
+    }
+
+    // Reuse the customer across top-ups so a person's payment history, receipts
+    // and disputes stay on one Stripe customer instead of scattering across a
+    // new one per purchase.
+    let customerId = user.stripeCustomerId
+    if (!customerId) {
+      const customer = await stripe.customers.create({
+        email: user.email ?? undefined,
+        name: user.name ?? undefined,
+        metadata: { userId },
+      })
+      customerId = customer.id
+      await prisma.user.update({
+        where: { id: userId },
+        data: { stripeCustomerId: customerId },
+      })
+    }
+
+    const session = await stripe.checkout.sessions.create({
+      mode: "payment",
+      customer: customerId,
+      line_items: [
+        customCents === null
+          ? { price: pack.priceId, quantity: 1 }
+          : {
+              // An ad-hoc line against the same product: the amount is already
+              // decided here, so Checkout shows a total to pay rather than an
+              // empty amount field.
+              price_data: {
+                currency: pack.currency,
+                product: pack.productId,
+                unit_amount: customCents,
+              },
+              quantity: 1,
+            },
+      ],
+      // Three places to find the user, because the webhook must never guess.
+      // client_reference_id and metadata cover the session events;
+      // payment_intent_data.metadata carries the id onto the PaymentIntent, so
+      // a refund or dispute months later can still be attributed.
+      client_reference_id: userId,
+      metadata: { userId, packId },
+      payment_intent_data: { metadata: { userId, packId } },
+      success_url: appUrl("/?topup=success&session_id={CHECKOUT_SESSION_ID}"),
+      cancel_url: appUrl("/?topup=cancelled"),
+    })
+
+    if (!session.url) {
+      return NextResponse.json(
+        { error: "Stripe did not return a checkout URL" },
+        { status: 502 }
+      )
+    }
+
+    return NextResponse.json({ url: session.url, sessionId: session.id })
+  } catch (error) {
+    console.error("[billing] checkout session failed:", error)
+    return internalError(error)
+  }
+}

--- a/packages/web/app/api/billing/packs/route.ts
+++ b/packages/web/app/api/billing/packs/route.ts
@@ -1,0 +1,34 @@
+import { requireAuth, isAuthError, internalError } from "@/lib/db/api-helpers"
+import { getCreditPacks, isBillingEnabled, type CreditPack } from "@/lib/server/stripe"
+
+export const runtime = "nodejs"
+
+export interface PacksResponse {
+  /** False when this deployment has no billing configured — hide top-up. */
+  enabled: boolean
+  packs: CreditPack[]
+}
+
+/**
+ * GET /api/billing/packs — what a user can buy, with amounts read from Stripe.
+ *
+ * Behind auth: the pack list is only useful to someone who can buy, and keeping
+ * it authenticated means the price ids are not public.
+ */
+export async function GET(): Promise<Response> {
+  const auth = await requireAuth()
+  if (isAuthError(auth)) return auth
+
+  if (!isBillingEnabled()) {
+    return Response.json({ enabled: false, packs: [] } satisfies PacksResponse)
+  }
+
+  try {
+    return Response.json({
+      enabled: true,
+      packs: await getCreditPacks(),
+    } satisfies PacksResponse)
+  } catch (error) {
+    return internalError(error)
+  }
+}

--- a/packages/web/app/api/stripe/webhook/route.ts
+++ b/packages/web/app/api/stripe/webhook/route.ts
@@ -1,0 +1,399 @@
+import { NextRequest } from "next/server"
+import { Prisma } from "@prisma/client"
+import type Stripe from "stripe"
+
+import { prisma } from "@/lib/db/prisma"
+import { applyCreditTransaction } from "@/lib/db/credits"
+import { microToUsd, stripeAmountToMicro } from "@/lib/server/credits"
+import { getStripe, isBillingEnabled } from "@/lib/server/stripe"
+
+// The Stripe SDK needs node crypto to verify signatures, and this route must
+// never be statically optimised — it exists only to be POSTed to.
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+/**
+ * Stripe webhook — the only place credits are ever granted.
+ *
+ * Idempotency is layered, because Stripe delivers at least once and retries
+ * failures for days:
+ *
+ *  1. `StripeEvent.processedAt` is the fast path. An event we have already
+ *     finished is acknowledged without being re-run. Note the guard is on
+ *     *processed*, not merely *seen* — a row written before a handler threw
+ *     must stay retryable, or a transient database blip would silently drop a
+ *     payment forever.
+ *  2. `CreditTransaction.externalId` is the actual guarantee. Every movement is
+ *     keyed on the Stripe object that caused it — the checkout session for a
+ *     purchase, the refund or dispute id for a reversal — under a unique index.
+ *     Two concurrent deliveries both reach it and exactly one wins.
+ *
+ * The second is what matters. The first is only there to save work.
+ */
+
+function isUniqueViolation(err: unknown): boolean {
+  return err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002"
+}
+
+/**
+ * The user behind a payment, or null.
+ *
+ * Never guessed. An unattributable payment is logged and left alone for a human
+ * to resolve with the admin grant endpoint — crediting the wrong account is
+ * worse than crediting none, and a retry cannot fix a missing id anyway.
+ */
+async function resolveUserFromSession(
+  session: Stripe.Checkout.Session
+): Promise<string | null> {
+  const candidate =
+    session.client_reference_id ??
+    (typeof session.metadata?.userId === "string" ? session.metadata.userId : null)
+
+  if (candidate) {
+    const user = await prisma.user.findUnique({
+      where: { id: candidate },
+      select: { id: true },
+    })
+    if (user) return user.id
+  }
+
+  const customerId =
+    typeof session.customer === "string" ? session.customer : session.customer?.id
+  if (customerId) {
+    const user = await prisma.user.findUnique({
+      where: { stripeCustomerId: customerId },
+      select: { id: true },
+    })
+    if (user) return user.id
+  }
+
+  return null
+}
+
+/**
+ * The user behind a charge, for reversals.
+ *
+ * Reached through the purchase we recorded: the PaymentIntent id is stamped on
+ * the original `purchase` row, so a refund lands on the same account that was
+ * credited, even years later. Falls back to the metadata the checkout route
+ * stamped on the PaymentIntent, then to the customer.
+ */
+async function resolveUserFromCharge(charge: Stripe.Charge): Promise<string | null> {
+  const paymentIntentId =
+    typeof charge.payment_intent === "string"
+      ? charge.payment_intent
+      : charge.payment_intent?.id
+
+  if (paymentIntentId) {
+    const purchase = await prisma.creditTransaction.findFirst({
+      where: { stripePaymentIntentId: paymentIntentId, type: "purchase" },
+      select: { userId: true },
+    })
+    if (purchase) return purchase.userId
+  }
+
+  const metaUserId = charge.metadata?.userId
+  if (typeof metaUserId === "string" && metaUserId) {
+    const user = await prisma.user.findUnique({
+      where: { id: metaUserId },
+      select: { id: true },
+    })
+    if (user) return user.id
+  }
+
+  const customerId =
+    typeof charge.customer === "string" ? charge.customer : charge.customer?.id
+  if (customerId) {
+    const user = await prisma.user.findUnique({
+      where: { stripeCustomerId: customerId },
+      select: { id: true },
+    })
+    if (user) return user.id
+  }
+
+  return null
+}
+
+/**
+ * Apply a balance movement that a duplicate delivery may already have applied.
+ * Returns false when the unique index says it was already done.
+ */
+async function applyOnce(
+  params: Parameters<typeof applyCreditTransaction>[0]
+): Promise<boolean> {
+  try {
+    await applyCreditTransaction(params)
+    return true
+  } catch (err) {
+    if (isUniqueViolation(err)) return false
+    throw err
+  }
+}
+
+/** A completed (or later-settled) Checkout Session becomes credits. */
+async function handleCheckoutCompleted(
+  event: Stripe.Event,
+  session: Stripe.Checkout.Session
+): Promise<void> {
+  // "complete" is not "paid": a delayed-notification method completes the
+  // session and pays days later, arriving again as async_payment_succeeded.
+  if (session.payment_status !== "paid") {
+    console.log(
+      `[stripe] session ${session.id} is ${session.payment_status}; waiting for settlement`
+    )
+    return
+  }
+
+  if ((session.currency ?? "").toLowerCase() !== "usd") {
+    console.error(
+      `[stripe] refusing session ${session.id}: currency ${session.currency}, expected usd`
+    )
+    return
+  }
+
+  // The amount comes from the event, never from anything the client sent.
+  const amount = session.amount_total ?? 0
+  if (amount <= 0) return
+
+  const userId = await resolveUserFromSession(session)
+  if (!userId) {
+    console.error(
+      `[stripe] session ${session.id} paid ${amount} but no user could be resolved — ` +
+        `credit it by hand via /api/admin/users/<id>/credits`
+    )
+    return
+  }
+
+  const paymentIntentId =
+    typeof session.payment_intent === "string"
+      ? session.payment_intent
+      : session.payment_intent?.id
+
+  const micro = stripeAmountToMicro(amount)
+  const applied = await applyOnce({
+    userId,
+    amountMicroUsd: micro,
+    type: "purchase",
+    externalId: session.id,
+    stripeEventId: event.id,
+    stripePaymentIntentId: paymentIntentId ?? null,
+    description: `Top-up of $${microToUsd(micro).toFixed(2)}`,
+  })
+
+  console.log(
+    applied
+      ? `[stripe] credited $${microToUsd(micro).toFixed(2)} to ${userId} (${session.id})`
+      : `[stripe] session ${session.id} was already credited; ignoring redelivery`
+  )
+}
+
+/**
+ * A refunded charge gives the credits back.
+ *
+ * Keyed on the refund id, not the charge id, because a charge can be refunded
+ * in parts: two $5 refunds against one $10 charge arrive as two
+ * `charge.refunded` events on the same charge, and keying on the charge would
+ * dedupe the second away and never reverse it.
+ *
+ * Refunds are listed from the API rather than read off `charge.refunds`, which
+ * is a paginated sublist and is not guaranteed to be expanded on the payload.
+ */
+async function handleChargeRefunded(
+  event: Stripe.Event,
+  charge: Stripe.Charge
+): Promise<void> {
+  const userId = await resolveUserFromCharge(charge)
+  if (!userId) {
+    console.error(
+      `[stripe] charge ${charge.id} was refunded but no user could be resolved`
+    )
+    return
+  }
+
+  const refunds = await getStripe().refunds.list({ charge: charge.id, limit: 100 })
+
+  for (const refund of refunds.data) {
+    if (refund.status !== "succeeded") continue
+    if (refund.amount <= 0) continue
+
+    const micro = stripeAmountToMicro(refund.amount)
+    const applied = await applyOnce({
+      userId,
+      amountMicroUsd: -micro,
+      type: "refund",
+      externalId: refund.id,
+      stripeEventId: event.id,
+      stripePaymentIntentId:
+        typeof charge.payment_intent === "string" ? charge.payment_intent : null,
+      description: `Refund of $${microToUsd(micro).toFixed(2)}`,
+    })
+    if (applied) {
+      console.log(
+        `[stripe] reversed $${microToUsd(micro).toFixed(2)} from ${userId} (${refund.id})`
+      )
+    }
+  }
+}
+
+/**
+ * A dispute takes the money back immediately, so the credits go with it —
+ * even if that leaves the balance negative, which is correct: the platform has
+ * already lost the funds and the usage was already delivered.
+ */
+async function handleDisputeCreated(
+  event: Stripe.Event,
+  dispute: Stripe.Dispute
+): Promise<void> {
+  const chargeId = typeof dispute.charge === "string" ? dispute.charge : dispute.charge.id
+  const charge = await getStripe().charges.retrieve(chargeId)
+
+  const userId = await resolveUserFromCharge(charge)
+  if (!userId) {
+    console.error(`[stripe] dispute ${dispute.id} raised but no user could be resolved`)
+    return
+  }
+
+  const micro = stripeAmountToMicro(dispute.amount)
+  const applied = await applyOnce({
+    userId,
+    amountMicroUsd: -micro,
+    type: "chargeback",
+    externalId: `dispute:${dispute.id}`,
+    stripeEventId: event.id,
+    description: `Chargeback of $${microToUsd(micro).toFixed(2)}`,
+  })
+  if (applied) {
+    console.log(`[stripe] chargeback reversed $${microToUsd(micro).toFixed(2)} from ${userId}`)
+  }
+}
+
+/** A dispute we won gives the credits back; one we lost stays reversed. */
+async function handleDisputeClosed(
+  event: Stripe.Event,
+  dispute: Stripe.Dispute
+): Promise<void> {
+  if (dispute.status !== "won") {
+    console.log(`[stripe] dispute ${dispute.id} closed as ${dispute.status}; no change`)
+    return
+  }
+
+  const chargeId = typeof dispute.charge === "string" ? dispute.charge : dispute.charge.id
+  const charge = await getStripe().charges.retrieve(chargeId)
+
+  const userId = await resolveUserFromCharge(charge)
+  if (!userId) return
+
+  const micro = stripeAmountToMicro(dispute.amount)
+  await applyOnce({
+    userId,
+    amountMicroUsd: micro,
+    type: "adjustment",
+    externalId: `dispute-won:${dispute.id}`,
+    stripeEventId: event.id,
+    description: `Chargeback reversed in our favour`,
+  })
+}
+
+async function handleEvent(event: Stripe.Event): Promise<void> {
+  switch (event.type) {
+    case "checkout.session.completed":
+    case "checkout.session.async_payment_succeeded":
+      await handleCheckoutCompleted(event, event.data.object as Stripe.Checkout.Session)
+      break
+
+    case "checkout.session.async_payment_failed":
+      // Nothing was credited, so there is nothing to reverse.
+      console.log(
+        `[stripe] async payment failed for session ${(event.data.object as Stripe.Checkout.Session).id}`
+      )
+      break
+
+    case "charge.refunded":
+      await handleChargeRefunded(event, event.data.object as Stripe.Charge)
+      break
+
+    case "charge.dispute.created":
+      await handleDisputeCreated(event, event.data.object as Stripe.Dispute)
+      break
+
+    case "charge.dispute.closed":
+      await handleDisputeClosed(event, event.data.object as Stripe.Dispute)
+      break
+
+    default:
+      // Subscribed to something we do not act on. Recorded, not an error.
+      console.log(`[stripe] ignoring ${event.type}`)
+  }
+}
+
+export async function POST(request: NextRequest): Promise<Response> {
+  if (!isBillingEnabled()) {
+    return new Response("Billing is not enabled", { status: 404 })
+  }
+
+  const signature = request.headers.get("stripe-signature")
+  if (!signature) {
+    return new Response("Missing stripe-signature header", { status: 400 })
+  }
+
+  // The raw bytes, not the parsed body: the signature covers the exact payload
+  // Stripe sent, and req.json() would discard it.
+  const raw = await request.text()
+
+  let event: Stripe.Event
+  try {
+    event = getStripe().webhooks.constructEvent(
+      raw,
+      signature,
+      process.env.STRIPE_WEBHOOK_SECRET as string
+    )
+  } catch (err) {
+    // Worth logging every time: a run of these means a misconfigured endpoint,
+    // a secret from the wrong environment, or someone probing.
+    console.error("[stripe] webhook signature verification failed:", err)
+    return new Response("Invalid signature", { status: 400 })
+  }
+
+  const seen = await prisma.stripeEvent.findUnique({
+    where: { id: event.id },
+    select: { processedAt: true },
+  })
+  if (seen?.processedAt) {
+    return new Response("Already processed", { status: 200 })
+  }
+  if (!seen) {
+    try {
+      await prisma.stripeEvent.create({
+        data: {
+          id: event.id,
+          type: event.type,
+          payload: event as unknown as Prisma.InputJsonValue,
+        },
+      })
+    } catch (err) {
+      // Raced by a concurrent delivery of the same event. Harmless: whichever
+      // one is processing it holds the CreditTransaction unique index too.
+      if (!isUniqueViolation(err)) throw err
+      return new Response("In flight", { status: 200 })
+    }
+  }
+
+  try {
+    await handleEvent(event)
+    await prisma.stripeEvent.update({
+      where: { id: event.id },
+      data: { processedAt: new Date(), error: null },
+    })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    console.error(`[stripe] handler failed for ${event.type} ${event.id}:`, err)
+    await prisma.stripeEvent
+      .update({ where: { id: event.id }, data: { error: message.slice(0, 2000) } })
+      .catch(() => {})
+    // 500 so Stripe retries. processedAt is still null, so the retry re-runs
+    // the handler rather than being waved through as a duplicate.
+    return new Response("Handler failed", { status: 500 })
+  }
+
+  return new Response("OK", { status: 200 })
+}

--- a/packages/web/lib/db/activity-log.ts
+++ b/packages/web/lib/db/activity-log.ts
@@ -20,6 +20,10 @@ export type ActivityAction =
   // An LLM provider/model call failed for a turn (auth, balance, rate limit,
   // model unavailable, network, or an otherwise-unclassified model error).
   | "llm_provider_error"
+  // An admin moved a user's purchased credit balance by hand — a grant, or a
+  // correction. Stripe purchases are not logged here; they live in the
+  // CreditTransaction ledger with their Stripe ids attached.
+  | "credits_adjusted"
 
 /**
  * Metadata types for different actions

--- a/packages/web/lib/db/credits.ts
+++ b/packages/web/lib/db/credits.ts
@@ -1,0 +1,143 @@
+/**
+ * Credit balance reads and writes.
+ *
+ * `User.creditBalanceMicroUsd` is authoritative for reads — the send gate hits
+ * it on every message, so it has to be O(1). `CreditTransaction` is the audit
+ * trail beside it, and every movement writes both, in one transaction, or
+ * neither.
+ *
+ * The arithmetic and the units live in lib/server/credits, which stays free of
+ * database imports so it can be unit-tested.
+ */
+
+import { Prisma } from "@prisma/client"
+
+import { prisma } from "./prisma"
+
+/** Why a balance moved. */
+export type CreditTransactionType =
+  | "purchase" // Stripe payment
+  | "debit" // metered usage charged to the balance
+  | "refund" // Stripe refund reversed the purchase
+  | "grant" // manual credit from an admin
+  | "chargeback" // dispute opened against the payment
+  | "adjustment" // manual correction
+
+export interface ApplyCreditParams {
+  userId: string
+  /** Signed micro-dollars: positive credits the user, negative charges them. */
+  amountMicroUsd: bigint
+  type: CreditTransactionType
+  /** Idempotency key (Stripe session / refund / dispute id). Unique. */
+  externalId?: string | null
+  /** The TokenUsage row a `debit` paid for. Unique. */
+  tokenUsageId?: string | null
+  stripeEventId?: string | null
+  stripePaymentIntentId?: string | null
+  chatId?: string | null
+  description?: string | null
+  metadata?: Prisma.InputJsonValue
+}
+
+async function applyInTransaction(
+  params: ApplyCreditParams,
+  tx: Prisma.TransactionClient
+): Promise<bigint> {
+  // Relative update, never read-then-write: two concurrent movements must both
+  // land. The returned row carries the post-increment balance, so the ledger
+  // row can record it without a second read.
+  const user = await tx.user.update({
+    where: { id: params.userId },
+    data: { creditBalanceMicroUsd: { increment: params.amountMicroUsd } },
+    select: { creditBalanceMicroUsd: true },
+  })
+
+  await tx.creditTransaction.create({
+    data: {
+      userId: params.userId,
+      amountMicroUsd: params.amountMicroUsd,
+      balanceAfterMicroUsd: user.creditBalanceMicroUsd,
+      type: params.type,
+      externalId: params.externalId ?? null,
+      tokenUsageId: params.tokenUsageId ?? null,
+      stripeEventId: params.stripeEventId ?? null,
+      stripePaymentIntentId: params.stripePaymentIntentId ?? null,
+      chatId: params.chatId ?? null,
+      description: params.description ?? null,
+      ...(params.metadata !== undefined ? { metadata: params.metadata } : {}),
+    },
+  })
+
+  return user.creditBalanceMicroUsd
+}
+
+/**
+ * Move a user's balance and record why, atomically. Returns the new balance.
+ *
+ * Pass `tx` when the caller already holds a transaction (the metering path
+ * does, and must — its debit has to commit with the usage rows it pays for or
+ * not at all). Without one, this opens its own.
+ *
+ * A duplicate `externalId` or `tokenUsageId` throws a unique-constraint error
+ * rather than being swallowed, which rolls the balance change back with it.
+ * That is deliberate: callers know what a duplicate means for them, and
+ * catching it here would leave an interactive transaction aborted but looking
+ * successful. Postgres refuses every later statement in a transaction where a
+ * constraint has fired, so "catch and carry on" is not available at this level.
+ */
+export async function applyCreditTransaction(
+  params: ApplyCreditParams,
+  tx?: Prisma.TransactionClient
+): Promise<bigint> {
+  if (params.amountMicroUsd === 0n) {
+    return getCreditBalance(params.userId, tx)
+  }
+  if (tx) return applyInTransaction(params, tx)
+  return prisma.$transaction((inner) => applyInTransaction(params, inner))
+}
+
+/** Current balance in micro-dollars. Zero for an unknown user. */
+export async function getCreditBalance(
+  userId: string,
+  tx?: Prisma.TransactionClient
+): Promise<bigint> {
+  const db = tx ?? prisma
+  const user = await db.user.findUnique({
+    where: { id: userId },
+    select: { creditBalanceMicroUsd: true },
+  })
+  return user?.creditBalanceMicroUsd ?? 0n
+}
+
+/** One row of a user's credit history, as the API returns it. */
+export interface CreditTransactionRecord {
+  id: string
+  amountMicroUsd: bigint
+  balanceAfterMicroUsd: bigint
+  type: string
+  description: string | null
+  chatId: string | null
+  createdAt: Date
+}
+
+/** A user's most recent balance movements, newest first. */
+export async function listCreditTransactions(params: {
+  userId: string
+  limit?: number
+}): Promise<CreditTransactionRecord[]> {
+  const { userId, limit = 50 } = params
+  return prisma.creditTransaction.findMany({
+    where: { userId },
+    orderBy: { createdAt: "desc" },
+    take: Math.min(limit, 200),
+    select: {
+      id: true,
+      amountMicroUsd: true,
+      balanceAfterMicroUsd: true,
+      type: true,
+      description: true,
+      chatId: true,
+      createdAt: true,
+    },
+  })
+}

--- a/packages/web/lib/server/credits.test.ts
+++ b/packages/web/lib/server/credits.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Unit tests for the credit unit and its conversions.
+ */
+import { describe, it, expect } from "vitest"
+
+import {
+  MICRO_PER_USD,
+  microToUsd,
+  stripeAmountToMicro,
+  usdToMicro,
+} from "./credits"
+
+describe("stripeAmountToMicro", () => {
+  it("converts Stripe's integer cents exactly", () => {
+    expect(stripeAmountToMicro(1000)).toBe(10_000_000n) // $10.00
+    expect(stripeAmountToMicro(1)).toBe(10_000n) // $0.01
+  })
+
+  it("keeps an amount a float round-trip would spoil", () => {
+    // $10.07 via dollars is 10.07 * 1e6 = 10069999.999999998 before rounding.
+    // Straight from cents there is no float in the path at all.
+    expect(stripeAmountToMicro(1007)).toBe(10_070_000n)
+    expect(stripeAmountToMicro(1007)).toBe(usdToMicro(10.07))
+  })
+
+  it("refuses a non-integer amount rather than rounding money", () => {
+    // Stripe only ever sends integer minor units; anything else means we are
+    // reading the wrong field, and guessing would mis-credit a real payment.
+    expect(stripeAmountToMicro(10.5)).toBe(0n)
+  })
+})
+
+describe("usdToMicro", () => {
+  it("round-trips a dollar amount", () => {
+    expect(usdToMicro(12.34)).toBe(12_340_000n)
+    expect(microToUsd(12_340_000n)).toBeCloseTo(12.34, 10)
+  })
+
+  it("keeps sub-cent costs, which is the whole reason for the unit", () => {
+    // A turn costing a fifth of a cent. Cents would round this to 0 (a free
+    // route around the cap) or to 1 (a 5x overcharge).
+    expect(usdToMicro(0.002)).toBe(2_000n)
+  })
+
+  it("absorbs the float residue the ledger produces", () => {
+    // sumSharedSpend differences floats; a no-op lands here rather than on 0.
+    expect(usdToMicro(4e-16)).toBe(0n)
+  })
+
+  it("is exact for a whole-dollar top-up", () => {
+    expect(usdToMicro(100)).toBe(BigInt(100 * MICRO_PER_USD))
+  })
+
+  it("treats a non-finite cost as zero rather than throwing", () => {
+    // BigInt(NaN) throws, which inside the metering transaction would lose the
+    // whole turn's usage row, not just the debit.
+    expect(usdToMicro(Number.NaN)).toBe(0n)
+    expect(usdToMicro(Number.POSITIVE_INFINITY)).toBe(0n)
+  })
+})

--- a/packages/web/lib/server/credits.ts
+++ b/packages/web/lib/server/credits.ts
@@ -1,0 +1,55 @@
+/**
+ * Purchased credits: the unit, and the conversions at its edges.
+ *
+ * Credits are bought through Stripe, denominated in exactly the same US dollars
+ * of API list value the ledger already stores in `TokenUsage.costUsd` — one
+ * credit is one dollar, priced by tokscale (and by lib/server/claude-pricing
+ * for Claude) with no conversion of any kind in between. That is deliberate: the
+ * number a user buys and the number the meter spends are the same number, so
+ * the balance needs no explaining.
+ *
+ * Free of database imports so the arithmetic can be unit-tested on its own,
+ * mirroring lib/server/usage-cursor. The database side lives in lib/db/credits.
+ */
+
+/**
+ * Micro-dollars per US dollar — the stored unit for balances and ledger rows.
+ *
+ * Not cents: a turn frequently costs less than one (`fmtBalance` renders
+ * `<$0.01`, and `floorCostUsd` exists precisely for those), so rounding each
+ * debit up to a cent overcharges and rounding down to zero recreates the
+ * free-route-around-the-cap bug token-metering guards against. Not a float
+ * either: `snapCostResidue` exists because differencing floats in this ledger
+ * lands on 4e-16 instead of 0, and a balance must not accumulate that.
+ */
+export const MICRO_PER_USD = 1_000_000
+
+/** USD → micro-dollars, rounded to the nearest micro-dollar. */
+export function usdToMicro(usd: number): bigint {
+  if (!Number.isFinite(usd)) return 0n
+  return BigInt(Math.round(usd * MICRO_PER_USD))
+}
+
+/**
+ * Micro-dollars → USD, for display and for JSON responses.
+ *
+ * Balances are far below 2^53 micro-dollars ($9 billion), so the conversion
+ * through `Number` is exact for any value this app will ever hold. It also has
+ * to happen at every API boundary regardless: `JSON.stringify` throws on BigInt.
+ */
+export function microToUsd(micro: bigint): number {
+  return Number(micro) / MICRO_PER_USD
+}
+
+/**
+ * A Stripe amount (integer minor units — cents, for USD) → micro-dollars.
+ *
+ * Deliberately not routed through `usdToMicro`: Stripe already hands us an
+ * exact integer, and dividing it by 100 to get dollars and multiplying back up
+ * would put a float in the middle of the one number in this system that a user
+ * actually paid. 1 cent is 10,000 micro-dollars, and BigInt keeps it exact.
+ */
+export function stripeAmountToMicro(amountInCents: number): bigint {
+  if (!Number.isInteger(amountInCents)) return 0n
+  return BigInt(amountInCents) * 10_000n
+}

--- a/packages/web/lib/server/stripe.test.ts
+++ b/packages/web/lib/server/stripe.test.ts
@@ -1,0 +1,94 @@
+/**
+ * The price map is the security boundary for checkout: the client sends a pack
+ * id, and an amount only for the custom-amount price, so what can be bought is
+ * exactly what this resolves. These tests pin that boundary, and the kill
+ * switch that fails closed.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+
+import { getPriceMap, isBillingEnabled } from "./stripe"
+
+const ENV_KEYS = [
+  "STRIPE_PRICE_MAP",
+  "BILLING_ENABLED",
+  "STRIPE_SECRET_KEY",
+  "STRIPE_WEBHOOK_SECRET",
+] as const
+
+let saved: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>> = {}
+
+beforeEach(() => {
+  saved = {}
+  for (const k of ENV_KEYS) {
+    saved[k] = process.env[k]
+    delete process.env[k]
+  }
+})
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k]
+    else process.env[k] = saved[k]
+  }
+})
+
+describe("getPriceMap", () => {
+  it("resolves a pack the environment sells", () => {
+    process.env.STRIPE_PRICE_MAP = JSON.stringify({ pack_10: "price_abc" })
+    expect(getPriceMap().pack_10).toBe("price_abc")
+  })
+
+  it("refuses a pack id that is not in the map", () => {
+    process.env.STRIPE_PRICE_MAP = JSON.stringify({ pack_10: "price_abc" })
+    expect(getPriceMap().pack_1000000).toBeUndefined()
+  })
+
+  it("refuses anything that is not a Stripe price id", () => {
+    // A map entry pointing at some other object — or at a string a caller
+    // smuggled in — must not become a line item.
+    process.env.STRIPE_PRICE_MAP = JSON.stringify({
+      good: "price_abc",
+      bad: "prod_abc",
+      worse: "sk_live_abc",
+    })
+    const map = getPriceMap()
+    expect(map.good).toBe("price_abc")
+    expect(map.bad).toBeUndefined()
+    expect(map.worse).toBeUndefined()
+  })
+
+  it("sells nothing when the map is missing or malformed", () => {
+    expect(getPriceMap()).toEqual({})
+
+    process.env.STRIPE_PRICE_MAP = "not json"
+    expect(getPriceMap()).toEqual({})
+
+    // An array parses as JSON but is not a map; it must not yield index lookups.
+    process.env.STRIPE_PRICE_MAP = JSON.stringify(["price_abc"])
+    expect(getPriceMap()).toEqual({})
+  })
+})
+
+describe("isBillingEnabled", () => {
+  it("is off unless every piece is configured", () => {
+    expect(isBillingEnabled()).toBe(false)
+
+    process.env.BILLING_ENABLED = "true"
+    expect(isBillingEnabled()).toBe(false)
+
+    process.env.STRIPE_SECRET_KEY = "sk_test_x"
+    expect(isBillingEnabled()).toBe(false)
+
+    process.env.STRIPE_WEBHOOK_SECRET = "whsec_x"
+    expect(isBillingEnabled()).toBe(true)
+  })
+
+  it("stays off when the flag is anything but the literal string", () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_x"
+    process.env.STRIPE_WEBHOOK_SECRET = "whsec_x"
+    for (const value of ["1", "yes", "TRUE", ""]) {
+      process.env.BILLING_ENABLED = value
+      expect(isBillingEnabled()).toBe(false)
+    }
+  })
+})

--- a/packages/web/lib/server/stripe.ts
+++ b/packages/web/lib/server/stripe.ts
@@ -1,0 +1,174 @@
+/**
+ * Stripe client, credit packs, and the billing kill switch.
+ *
+ * The integration is deliberately small: hosted Checkout in `payment` mode, so
+ * Stripe owns the card form, SCA, wallets and receipts, and we own a redirect
+ * out and a webhook back. There is no Stripe app, no Connect account and no
+ * OAuth — the server calls Stripe with a secret key and nothing about a user's
+ * own Stripe account is ever involved.
+ */
+
+import Stripe from "stripe"
+
+/**
+ * The API version this code was written against.
+ *
+ * Pinned here rather than left to the dashboard: unpinned, a version bump on
+ * Stripe's side changes webhook payload shapes without a deploy on ours. It
+ * matches what `stripe@22.x` ships with; bump both together.
+ */
+const STRIPE_API_VERSION = "2026-08-26.dahlia"
+
+let client: Stripe | null = null
+
+/** The shared Stripe client. Throws when no secret key is configured. */
+export function getStripe(): Stripe {
+  const key = process.env.STRIPE_SECRET_KEY
+  if (!key) {
+    throw new Error("STRIPE_SECRET_KEY is not set")
+  }
+  if (!client) {
+    client = new Stripe(key, { apiVersion: STRIPE_API_VERSION as Stripe.LatestApiVersion })
+  }
+  return client
+}
+
+/**
+ * Whether billing is live for this deployment.
+ *
+ * Off by default, and off unless every piece is present, so a half-configured
+ * environment fails closed: the routes 404 and the UI hides top-up rather than
+ * offering a checkout that cannot complete.
+ */
+export function isBillingEnabled(): boolean {
+  return (
+    process.env.BILLING_ENABLED === "true" &&
+    !!process.env.STRIPE_SECRET_KEY &&
+    !!process.env.STRIPE_WEBHOOK_SECRET
+  )
+}
+
+/**
+ * Pack id → Stripe price id, from `STRIPE_PRICE_MAP`.
+ *
+ * The map lives in the environment because price ids differ between test and
+ * live mode — Stripe objects do not cross the two — so hard-coding them would
+ * mean a code change at launch.
+ *
+ * It is also the security boundary for checkout: the client sends a pack id,
+ * never an amount, and only ids in this map can be bought. Trusting a
+ * client-sent amount is how a $100 pack gets bought for a cent.
+ */
+export function getPriceMap(): Record<string, string> {
+  const raw = process.env.STRIPE_PRICE_MAP
+  if (!raw) return {}
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {}
+    const out: Record<string, string> = {}
+    for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof v === "string" && v.startsWith("price_")) out[k] = v
+    }
+    return out
+  } catch {
+    console.error("[stripe] STRIPE_PRICE_MAP is not valid JSON — no packs available")
+    return {}
+  }
+}
+
+/** A purchasable pack, as the UI needs it. */
+export interface CreditPack {
+  id: string
+  priceId: string
+  /** Fixed amount in USD, or null for a customer-chosen amount. */
+  amountUsd: number | null
+  /** Bounds for a customer-chosen amount, in USD. */
+  minUsd?: number
+  maxUsd?: number
+  presetUsd?: number
+  /**
+   * The price's product and currency. Needed only for a customer-chosen
+   * amount, where checkout bills an ad-hoc `price_data` line against this
+   * product rather than sending the user to Stripe to type the amount there.
+   */
+  productId: string
+  currency: string
+}
+
+interface PackCache {
+  packs: CreditPack[]
+  at: number
+}
+let packCache: PackCache | null = null
+const PACK_CACHE_MS = 10 * 60 * 1000
+
+/**
+ * The packs on sale, with amounts read from Stripe rather than duplicated in
+ * the environment — so the price a user is shown is by construction the price
+ * they are charged, and changing a pack means changing it in one place.
+ *
+ * Cached for ten minutes per instance. A price is not something that changes
+ * without a deploy, and checkout itself only needs the id, so a stale read here
+ * can never mis-charge anyone.
+ *
+ * Prices that are recurring are dropped: `mode: "payment"` rejects them, so a
+ * subscription price left in the map would fail at the redirect rather than
+ * here. Better to never offer it, and to say so in the log.
+ */
+export async function getCreditPacks(): Promise<CreditPack[]> {
+  if (packCache && Date.now() - packCache.at < PACK_CACHE_MS) {
+    return packCache.packs
+  }
+
+  const map = getPriceMap()
+  const stripe = getStripe()
+  const packs: CreditPack[] = []
+
+  for (const [id, priceId] of Object.entries(map)) {
+    try {
+      const price = await stripe.prices.retrieve(priceId)
+      if (!price.active) continue
+      if (price.recurring) {
+        console.error(
+          `[stripe] pack "${id}" (${priceId}) is a recurring price; ` +
+            `payment-mode Checkout cannot sell it. Skipping.`
+        )
+        continue
+      }
+      const custom = price.custom_unit_amount
+      packs.push({
+        id,
+        priceId,
+        productId: typeof price.product === "string" ? price.product : price.product.id,
+        currency: price.currency,
+        amountUsd: price.unit_amount != null ? price.unit_amount / 100 : null,
+        ...(custom
+          ? {
+              minUsd: (custom.minimum ?? 0) / 100,
+              maxUsd: (custom.maximum ?? 0) / 100,
+              presetUsd: (custom.preset ?? custom.minimum ?? 0) / 100,
+            }
+          : {}),
+      })
+    } catch (err) {
+      console.error(`[stripe] could not load price for pack "${id}" (${priceId}):`, err)
+    }
+  }
+
+  // Fixed amounts ascending, then any customer-chosen amount last.
+  packs.sort((a, b) => (a.amountUsd ?? Infinity) - (b.amountUsd ?? Infinity))
+
+  packCache = { packs, at: Date.now() }
+  return packs
+}
+
+/** One pack by id, or null when the id is not one this deployment sells. */
+export async function getCreditPack(packId: string): Promise<CreditPack | null> {
+  return (await getCreditPacks()).find((p) => p.id === packId) ?? null
+}
+
+/** Absolute URL for a path on this deployment, for Checkout's redirect URLs. */
+export function appUrl(path: string): string {
+  const base = (process.env.NEXTAUTH_URL ?? "http://localhost:4000").replace(/\/$/, "")
+  return `${base}${path}`
+}

--- a/packages/web/middleware.ts
+++ b/packages/web/middleware.ts
@@ -54,9 +54,21 @@ function maintenanceResponse(request: NextRequest) {
   return res
 }
 
+// Paths that must stay reachable even during maintenance.
+//
+// The Stripe webhook is the only writer of purchased credits, and a 503 would
+// make Stripe queue a payment we have already taken behind the retry schedule.
+// Letting it through costs nothing in the case where maintenance is a database
+// migration — the handler then fails, returns 500, and Stripe retries exactly
+// as it would have — and delivers the credits promptly in every other case.
+const MAINTENANCE_EXEMPT_PATHS = ["/api/stripe/webhook"]
+
 export function middleware(request: NextRequest) {
   // Maintenance gate runs first so nothing slips through.
-  if (isMaintenanceMode()) {
+  if (
+    isMaintenanceMode() &&
+    !MAINTENANCE_EXEMPT_PATHS.includes(request.nextUrl.pathname)
+  ) {
     if (hasBypass(request)) {
       const res = NextResponse.next()
       // Persist the bypass so the operator can navigate freely.

--- a/packages/web/prisma/migrations/20260904130000_add_credits/migration.sql
+++ b/packages/web/prisma/migrations/20260904130000_add_credits/migration.sql
@@ -1,0 +1,58 @@
+-- Purchased credits: a second balance behind the daily plan allowance.
+--
+-- Money is stored in micro-dollars (1e-6 USD) as BIGINT rather than as cents or
+-- a float. Turn costs routinely run under a cent, so cents would either
+-- overcharge (rounding up) or round to zero — the free-route-around-the-cap
+-- case token-metering already guards against — and a float would inherit the
+-- residue snapCostResidue exists to absorb.
+
+ALTER TABLE "User" ADD COLUMN "stripeCustomerId" TEXT;
+ALTER TABLE "User" ADD COLUMN "creditBalanceMicroUsd" BIGINT NOT NULL DEFAULT 0;
+
+CREATE UNIQUE INDEX "User_stripeCustomerId_key" ON "User"("stripeCustomerId");
+
+-- Append-only ledger behind User.creditBalanceMicroUsd.
+CREATE TABLE "CreditTransaction" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "amountMicroUsd" BIGINT NOT NULL,
+    "balanceAfterMicroUsd" BIGINT NOT NULL,
+    "type" TEXT NOT NULL,
+    "externalId" TEXT,
+    "stripeEventId" TEXT,
+    "stripePaymentIntentId" TEXT,
+    "tokenUsageId" TEXT,
+    "chatId" TEXT,
+    "description" TEXT,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "CreditTransaction_pkey" PRIMARY KEY ("id")
+);
+
+-- Both unique indexes are idempotency guards, and both columns are nullable on
+-- purpose: Postgres permits unlimited NULLs under a unique index, so rows that
+-- key on one of them leave the other free.
+CREATE UNIQUE INDEX "CreditTransaction_externalId_key" ON "CreditTransaction"("externalId");
+CREATE UNIQUE INDEX "CreditTransaction_tokenUsageId_key" ON "CreditTransaction"("tokenUsageId");
+CREATE INDEX "CreditTransaction_userId_createdAt_idx" ON "CreditTransaction"("userId", "createdAt");
+CREATE INDEX "CreditTransaction_type_createdAt_idx" ON "CreditTransaction"("type", "createdAt");
+
+ALTER TABLE "CreditTransaction"
+    ADD CONSTRAINT "CreditTransaction_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Every Stripe webhook we have seen, keyed by Stripe's own event id so a
+-- redelivery collides instead of crediting twice.
+CREATE TABLE "StripeEvent" (
+    "id" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "processedAt" TIMESTAMP(3),
+    "error" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "StripeEvent_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "StripeEvent_type_createdAt_idx" ON "StripeEvent"("type", "createdAt");

--- a/packages/web/prisma/schema.prisma
+++ b/packages/web/prisma/schema.prisma
@@ -53,19 +53,37 @@ model User {
   // where `headers` is encrypted at rest (it can carry auth); the rest is plaintext.
   customEndpoints Json?
 
+  // Stripe customer for this user, created lazily on their first top-up and
+  // reused for every later one so the payment history stays on one customer.
+  stripeCustomerId String? @unique
+
+  // Purchased credits, in micro-dollars (1e-6 USD). Spent only once the day's
+  // plan allowance is gone — see lib/server/credits.
+  //
+  // Integer on purpose: turn costs run well under a cent, so cents would either
+  // overcharge or round to zero (the free-route-around-the-cap bug that
+  // token-metering already guards against), and a Float would inherit the
+  // residue that snapCostResidue exists to absorb.
+  //
+  // Goes negative when the turn that emptied it overshot — a cost is only known
+  // after the turn has run. The gate then refuses further shared-pool runs
+  // until a top-up brings it back above zero.
+  creditBalanceMicroUsd BigInt @default(0)
+
   // GitHub App installation id, captured in the install callback. Null until
   // the user installs our GitHub App. Used to mint short-lived installation
   // access tokens at agent-run time so the agent can call GitHub's MCP server
   // with properly-scoped credentials.
   githubAppInstallationId String?
 
-  chats         Chat[]
-  accounts      Account[]
-  sessions      Session[]
-  activityLogs  ActivityLog[]
-  scheduledJobs ScheduledJob[]
-  skills        Skill[]
-  tokenUsages   TokenUsage[]
+  chats              Chat[]
+  accounts           Account[]
+  sessions           Session[]
+  activityLogs       ActivityLog[]
+  scheduledJobs      ScheduledJob[]
+  skills             Skill[]
+  tokenUsages        TokenUsage[]
+  creditTransactions CreditTransaction[]
 }
 
 // =============================================================================
@@ -309,7 +327,7 @@ model CcAuthRun {
 model ActivityLog {
   id        String   @id @default(cuid())
   userId    String
-  action    String // "login" | "logout" | "chat_created" | "chat_deleted" | "message_sent" | "settings_updated" | "admin_promoted" | "admin_demoted"
+  action    String // "login" | "logout" | "chat_created" | "chat_deleted" | "message_sent" | "settings_updated" | "admin_promoted" | "admin_demoted" | "credits_adjusted"
   metadata  Json? // Flexible payload: { chatId, targetUserId, repo, model, etc. }
   createdAt DateTime @default(now())
 
@@ -381,6 +399,73 @@ model TokenUsage {
   @@index([provider, createdAt]) // admin per-provider rollups
   @@index([provider, keyId, createdAt]) // admin per-key rollups
   @@index([sessionId, model, createdAt]) // diff-cursor lookup
+}
+
+// =============================================================================
+// CreditTransaction - append-only ledger behind User.creditBalanceMicroUsd
+// =============================================================================
+// Every movement of a user's purchased balance, signed: positive for a top-up,
+// a manual grant or a reversal-of-a-reversal; negative for usage debits,
+// refunds and chargebacks. The balance on User is authoritative for reads (the
+// gate checks it on every send); this table is the audit trail, and the
+// reconciliation cron asserts the two agree.
+//
+// `balanceAfterMicroUsd` is the balance the moment this row committed, so a
+// disagreement can be traced to a single row without replaying from zero.
+
+model CreditTransaction {
+  id     String @id @default(cuid())
+  userId String
+
+  amountMicroUsd       BigInt
+  balanceAfterMicroUsd BigInt
+
+  // purchase | debit | refund | grant | chargeback | adjustment
+  type String
+
+  // Idempotency key, unique across the table: a Stripe checkout session id for
+  // purchases, a refund/dispute id for reversals. Null for rows whose
+  // uniqueness comes from elsewhere (usage debits key on tokenUsageId).
+  // Postgres allows many NULLs under a unique index, which is what makes that
+  // work.
+  externalId String? @unique
+
+  stripeEventId         String?
+  stripePaymentIntentId String?
+
+  // The TokenUsage row this debit paid for. Unique, so a turn cannot be
+  // charged to credits twice even if the metering path were to run again.
+  tokenUsageId String? @unique
+  chatId       String?
+
+  description String?
+  metadata    Json?
+  createdAt   DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, createdAt])
+  @@index([type, createdAt])
+}
+
+// =============================================================================
+// StripeEvent - every webhook Stripe has delivered, keyed by its own event id
+// =============================================================================
+// Stripe delivers at least once and retries for days, so the handler must be
+// idempotent. Inserting the event id first, in its own transaction, turns a
+// redelivery into a unique-constraint violation the handler can treat as
+// "already done" — the first of the two guards against double-crediting (the
+// second being CreditTransaction.externalId).
+
+model StripeEvent {
+  id          String    @id // Stripe's evt_…
+  type        String
+  payload     Json
+  processedAt DateTime?
+  error       String?   @db.Text
+  createdAt   DateTime  @default(now())
+
+  @@index([type, createdAt])
 }
 
 // =============================================================================


### PR DESCRIPTION
# Credit balance and Stripe top-ups (server side)

**Branch:** `feat/credits-infrastructure` → `main`

Adds a purchasable credit balance and the Stripe path that fills it, deliberately wired to nothing. No send is gated on it, no turn debits it, no account is granted any, and there is no UI.

**Merging this changes behaviour for zero users.** That's the point: it lets the migration, the Stripe account and a real test payment be verified against production before anything depends on them. The switch that makes credits matter is PR 2.

## What's here

**The balance.** `User.creditBalanceMicroUsd` plus an append-only `CreditTransaction` ledger. Units are micro-dollars (1e-6 USD), because turn costs run well under a cent — cents would round a charge to zero, and a float would carry residue a balance must not accumulate. One credit is one dollar of API list value, the same dollars `TokenUsage.costUsd` already stores, so there is no conversion anywhere. The balance is authoritative for reads (the gate hits it on every message, so it has to be O(1)); the ledger is the audit trail beside it. Both move in one transaction or neither.

**Checkout.** Hosted Stripe Checkout in `payment` mode. The amount is billed as an ad-hoc `price_data` line against the custom price's product and re-validated server-side against the bounds Stripe carries on that price, so the browser cannot name its own price.

**The webhook.** Credits are granted here and nowhere else — the checkout response can be replayed, bookmarked, or never reached while the payment still succeeded. Refunds and disputes reverse through the same ledger. It is also exempt from the maintenance gate: a 503 would push a payment already taken behind Stripe's retry schedule.

**An admin endpoint** to move a balance by hand — which is also how this can be exercised before any of it is switched on.

## Stripe setup

Required in the target account:

1. **A product**, and **one price** on it with a **customer-chosen amount** (`custom_unit_amount`), **one-time — not recurring** (recurring prices are skipped). Its min / max / preset become the amount bounds, read from Stripe rather than env.
2. Optionally, fixed prices for preset amounts.
3. **A webhook endpoint** at `/api/stripe/webhook` subscribed to: `checkout.session.completed`, `checkout.session.async_payment_succeeded`, `checkout.session.async_payment_failed`, `charge.refunded`, `charge.dispute.created`, `charge.dispute.closed`. **Without it, payments succeed and no credits are granted.**

Env: `BILLING_ENABLED=true`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET` (per-endpoint), `STRIPE_PRICE_MAP`. Billing fails closed — missing any of these 404s every billing route.

## Deploying

`prebuild` runs `prisma migrate deploy`, applying `20260904130000_add_credits`. It needs `DIRECT_URL` / `POSTGRES_URL_NON_POOLING` on **port 5432** — it refuses to migrate through the 6543 transaction pooler, which can't take the advisory lock `migrate` needs.

The migration is additive: a new table, and a column defaulting to `0`. No existing data is touched, and no existing behaviour reads either.

## Testing it

There is no UI in this PR, so a top-up is exercised by hand:

- `POST /api/billing/checkout` with a session cookie, then follow the returned URL and pay with `4242 4242 4242 4242`
- watch the webhook credit the balance
- or set a balance directly through the admin credits endpoint

## Not in this PR

The Credits tab and top-up dialog, the send gate, the metering debit, the signup grant, and the backfill for existing accounts. All of that is PR 2 (`feat/credits-activation`), which is stacked on this branch.


## Minor

- `STRIPE_PUBLISHABLE_KEY` appears in `.env.example` but is read nowhere in the codebase.
- The ad-hoc Checkout line item takes its label from the Stripe product name — worth eyeballing on a real payment.
