### PR TITLE
Fix agent crash wiping prior output on transient snapshot read failures

### DIFF
--- a/packages/web/app/api/agent/stream/route.ts
+++ b/packages/web/app/api/agent/stream/route.ts
@@ -21,6 +21,12 @@ export const maxDuration = 300
 const BACKEND_POLL_INTERVAL = 500
 const HEARTBEAT_INTERVAL = 15000
 const DB_PERSIST_INTERVAL = 5000
+// A snapshot read can fail transiently (sandbox/network blip, a brief race
+// reading the output file — notably possible right as the agent process
+// crashes). Retry silently for a few seconds before giving up, instead of
+// immediately broadcasting/persisting the empty fallback snapshot as if the
+// agent's output were actually gone.
+const MAX_CONSECUTIVE_SNAPSHOT_FAILURES = 10
 
 const jsonResponse = (status: number, body: object) =>
   new Response(JSON.stringify(body), {
@@ -137,12 +143,38 @@ export async function GET(req: Request) {
         // state — the snapshot is re-derived from the file each time, so a
         // new SSE connection (reconnect) automatically reconstructs full state.
         let lastSnap: AgentSnapshot | null = null
+        let consecutiveSnapshotFailures = 0
         while (!isStreamClosed) {
-          lastSnap = await snapshotBackgroundAgent(
+          const snap = await snapshotBackgroundAgent(
             sandbox,
             backgroundSessionId,
-            sessionOpts
+            sessionOpts,
+            lastSnap
           )
+
+          if (snap.transientReadFailure) {
+            consecutiveSnapshotFailures += 1
+            if (consecutiveSnapshotFailures < MAX_CONSECUTIVE_SNAPSHOT_FAILURES) {
+              // Don't broadcast or persist a fabricated state — the snapshot
+              // read just failed, the agent's own output hasn't changed.
+              // Retry on the next tick instead.
+              await new Promise((resolve) =>
+                setTimeout(resolve, BACKEND_POLL_INTERVAL)
+              )
+              continue
+            }
+            // Retries exhausted — surface a real error, but keep whatever
+            // content/toolCalls/contentBlocks we last knew about instead of
+            // the empty fallback snapshot.
+            lastSnap = {
+              ...snap,
+              status: "error",
+              error: snap.error || "Lost connection to the agent session",
+            }
+          } else {
+            consecutiveSnapshotFailures = 0
+            lastSnap = snap
+          }
 
           // Hash the full wire payload so any mutation that would change
           // what we'd send (including in-place tool_end output attachment,

--- a/packages/web/app/api/cron/agent-lifecycle/_lib/monitor.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/_lib/monitor.ts
@@ -33,6 +33,14 @@ export async function monitorAgent(
       repoPath: `${PATHS.SANDBOX_HOME}/project`,
     })
 
+    if (snapshot.transientReadFailure) {
+      // Reading the session failed transiently (network blip, brief file-read
+      // race) — this is not evidence the agent errored, just that we
+      // couldn't read its state this tick. Don't cancel a possibly-healthy
+      // agent or record a spurious failure; just check again next cycle.
+      return
+    }
+
     if (snapshot.status === "completed") {
       await handlers.onComplete(snapshot)
     } else if (snapshot.status === "error") {

--- a/packages/web/lib/agent-session.test.ts
+++ b/packages/web/lib/agent-session.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from "vitest"
+
+// snapshotBackgroundAgent only needs getSession from the SDK; stub it so we
+// can control success/failure without spinning up a real sandbox.
+vi.mock("@background-agents/sdk", () => ({
+  getSession: vi.fn(),
+  createSession: vi.fn(),
+}))
+
+import { getSession } from "@background-agents/sdk"
+import { snapshotBackgroundAgent, type AgentSnapshot } from "./agent-session"
+
+const sandbox = {} as import("@daytonaio/sdk").Sandbox
+
+function runningSnapshot(overrides: Partial<AgentSnapshot> = {}): AgentSnapshot {
+  return {
+    status: "running",
+    content: "partial output written before the read failed",
+    toolCalls: [{ tool: "bash", status: "running" } as unknown as AgentSnapshot["toolCalls"][number]],
+    contentBlocks: [],
+    sessionId: "sess-1",
+    ...overrides,
+  }
+}
+
+describe("snapshotBackgroundAgent", () => {
+  it("preserves the previous snapshot's content when a read fails mid-turn, instead of wiping it", async () => {
+    // Reproduces the bug: a transient failure reading/parsing the session
+    // (sandbox blip, brief file-read race — notably possible right as the
+    // agent process crashes) used to be reported as an empty, errored
+    // snapshot. That fabricated emptiness then got streamed to the client and
+    // persisted as the final message body, wiping a transcript that was
+    // still on disk. It should instead fall back to the last known-good
+    // snapshot and flag the failure so the caller can retry.
+    vi.mocked(getSession).mockRejectedValueOnce(new Error("sandbox unreachable"))
+    const previous = runningSnapshot()
+
+    const snap = await snapshotBackgroundAgent(
+      sandbox,
+      "bg-1",
+      { repoPath: "/repo" },
+      previous
+    )
+
+    expect(snap.transientReadFailure).toBe(true)
+    expect(snap.content).toBe(previous.content)
+    expect(snap.toolCalls).toEqual(previous.toolCalls)
+    expect(snap.status).toBe(previous.status)
+  })
+
+  it("falls back to an empty error snapshot (tagged transientReadFailure) when there is no previous snapshot to preserve", async () => {
+    vi.mocked(getSession).mockRejectedValueOnce(new Error("ECONNRESET"))
+
+    const snap = await snapshotBackgroundAgent(sandbox, "bg-1", { repoPath: "/repo" })
+
+    expect(snap.transientReadFailure).toBe(true)
+    expect(snap.status).toBe("error")
+    expect(snap.content).toBe("")
+  })
+})

--- a/packages/web/lib/agent-session.ts
+++ b/packages/web/lib/agent-session.ts
@@ -213,6 +213,14 @@ export interface AgentSnapshot {
    *  model-not-available) stay undefined. */
   errorKind?: "crash" | "incomplete"
   sessionId?: string
+  /** True only when this snapshot is a fallback produced after
+   *  snapshotBackgroundAgent FAILED to read/parse the session (a transient
+   *  sandbox/network hiccup), rather than a fresh read of the event log. It
+   *  is NOT evidence that the agent crashed or that its output is gone —
+   *  callers should retry a bounded number of times instead of immediately
+   *  broadcasting/persisting this as a real terminal state. See
+   *  snapshotBackgroundAgent's `previous` param. */
+  transientReadFailure?: boolean
 }
 
 /**
@@ -350,11 +358,24 @@ export async function cancelBackgroundAgent(
  * Read cumulative state by re-parsing the entire event log on disk in the
  * sandbox. Use on connect, on reconnect, and for any persistence write
  * where you need the full snapshot. Does not advance the session's cursor.
+ *
+ * @param previous The last snapshot this caller successfully observed for
+ * this session (if any). If the read below throws — a transient hiccup
+ * talking to the sandbox (network blip, a brief race reading the output
+ * file, notably possible right as a process crashes) rather than the agent
+ * log actually reporting a crash — we fall back to `previous` (tagged
+ * `transientReadFailure: true`) instead of fabricating an empty snapshot.
+ * Callers that broadcast/persist snapshots MUST check `transientReadFailure`
+ * and retry rather than treating the fallback as real content loss: without
+ * `previous`, a bare read failure used to return `content: ""` with
+ * `status: "error"`, which streamed as a wire update and got persisted as
+ * the final message body — wiping a transcript that was still on disk.
  */
 export async function snapshotBackgroundAgent(
   sandbox: DaytonaSandbox,
   backgroundSessionId: string,
-  options: AgentSessionOptions
+  options: AgentSessionOptions,
+  previous?: AgentSnapshot | null
 ): Promise<AgentSnapshot> {
   try {
     const bgSession = await getBackgroundSession(
@@ -378,12 +399,16 @@ export async function snapshotBackgroundAgent(
     return summarizeEvents(result.events, running, result.sessionId)
   } catch (err) {
     console.error("[snapshotBackgroundAgent] Error:", err)
+    if (previous) {
+      return { ...previous, transientReadFailure: true }
+    }
     return {
       status: "error",
       content: "",
       toolCalls: [],
       contentBlocks: [],
       error: formatAgentError(err),
+      transientReadFailure: true,
     }
   }
 }


### PR DESCRIPTION
What was happening:
Sometimes when the agent was running and it crashed, all of its output would disappear, even the stuff it had already said/done before the crash. Instead of just stopping and showing an error, it wiped the whole transcript.

Why:
The app checks on the agent every half second by reading its output file. Every once in a while that read itself would fail for a dumb reason (a network hiccup, or bad timing right as the process was dying), nothing to do with the agent's actual output being gone. But the code treated "I failed to read the file" the same as "there is nothing here," so it would send back an empty response and save that empty response over the real one. That's what made the output vanish for good, not just on screen but in the database too.

The fix:
Now if that read fails, it keeps showing/saving whatever it last successfully saw instead of replacing it with nothing. It also gives it a few retries (~5 seconds) before giving up, in case it was just a blip. Only after it truly can't recover does it show an error, and even then, it keeps the earlier output visible instead of erasing it.

How I tested it:

Added tests that simulate this exact failure and confirm the previous output is kept instead of wiped.
Ran the full test suite and typecheck, everything passed.