### PR TITLE
feat(web): warn in the composer before credits run out

### DIFF
--- a/packages/web/app/api/user/settings/route.ts
+++ b/packages/web/app/api/user/settings/route.ts
@@ -31,6 +31,15 @@ interface SettingsResponse {
   customEndpoints: CustomEndpoint[]
   /** Whether user is a pro subscriber */
   planIsPro: boolean
+  /**
+   * Purchased credits in USD, or null when the balance doesn't gate this user
+   * (unlimited plan, or own keys everywhere). Carried on this response rather
+   * than fetched separately because getEffectiveCredentialFlags already reads
+   * the balance to set SHARED_BALANCE_EXHAUSTED — the composer's low-credit
+   * warning costs no extra query and can never disagree with the picker's dot.
+   * The Credits tab still uses /api/user/credits, which also returns history.
+   */
+  creditBalanceUsd: number | null
 }
 
 function readSettings(raw: unknown): Settings {
@@ -69,6 +78,7 @@ export async function GET(): Promise<Response> {
       credentialFlags: effective.flags,
       customEndpoints: decryptUserEndpoints(user?.customEndpoints),
       planIsPro: effective.isPro,
+      creditBalanceUsd: effective.creditBalanceUsd,
     }
     return Response.json(response)
   } catch (error) {
@@ -156,6 +166,7 @@ export async function PATCH(req: NextRequest): Promise<Response> {
         newEndpoints ?? (user?.customEndpoints as unknown)
       ),
       planIsPro: effective.isPro,
+      creditBalanceUsd: effective.creditBalanceUsd,
     }
     return Response.json(response)
   } catch (error) {

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -24,6 +24,7 @@ import { useDraftChat } from "@/lib/hooks/useDraftChat"
 import { usePendingMessageReplay } from "@/lib/hooks/usePendingMessageReplay"
 import { usePaletteProps } from "@/lib/hooks/usePaletteProps"
 import { useSendMessage } from "@/lib/hooks/useSendMessage"
+import { useTopUpSettle } from "@/lib/hooks/useTopUpSettle"
 import { useBranching } from "@/lib/hooks/useBranching"
 import { useChatNavigation } from "@/lib/hooks/useChatNavigation"
 import { useRepoSelectHandler } from "@/lib/hooks/useRepoSelectHandler"
@@ -228,6 +229,10 @@ function HomePageContent({ isMobile }: HomePageContentProps) {
     }
   }, [isMobile, sidebar])
 
+  // Set once on landing back from a successful Stripe checkout; see below.
+  const [settlingTopUp, setSettlingTopUp] = useState(false)
+  useTopUpSettle(settlingTopUp)
+
   // Stripe's Checkout success/cancel URLs redirect back to "/" with a `topup`
   // query param. Surface it as a toast, jump to the Credits tab on success so
   // the user lands where the (webhook-credited, so not instant) balance shows
@@ -243,6 +248,11 @@ function HomePageContent({ isMobile }: HomePageContentProps) {
         body: "Your credits will show up in a few seconds.",
       })
       modals.openSettingsSection("credits")
+      // The webhook credits the balance out of band from this redirect, so the
+      // settings query this page just mounted with predates the payment. Poll
+      // it briefly (see useTopUpSettle) rather than leaving a red dot over
+      // credits the user has already bought.
+      setSettlingTopUp(true)
     } else if (topup === "cancelled") {
       useToastStore.getState().addToast({ title: "Checkout cancelled" })
     }

--- a/packages/web/components/chat/AgentModelSelector.tsx
+++ b/packages/web/components/chat/AgentModelSelector.tsx
@@ -5,8 +5,9 @@ import { ChevronDown, Cpu, Lock } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useModals } from "@/lib/contexts"
 import type { Agent, ModelOption, CredentialFlags, Chat } from "@/lib/types"
-import { getAgentModels, agentLabels, getModelLabel, hasCredentialsForModel, agentHasFreeUsage, agentIsReady, agentSharedPoolExhausted, resolveModelForAgent, sharedPoolProviderForModel, formatTokenRate, ALL_AGENTS } from "@/lib/types"
-import { discountDivisorFor } from "@/lib/server/credits"
+import { getAgentModels, agentLabels, getModelLabel, hasCredentialsForModel, agentHasFreeUsage, agentIsReady, agentSharedPoolExhausted, agentUsesSharedPool, resolveModelForAgent, sharedPoolProviderForModel, formatTokenRate, ALL_AGENTS } from "@/lib/types"
+import { creditTier, discountDivisorFor } from "@/lib/server/credits"
+import { fmtCreditAmount } from "@/lib/format"
 import { useSettingsQuery } from "@/lib/query/hooks/useSettingsQuery"
 import { AgentIcon } from "../icons/agent-icons"
 import { MobileSelect } from "../ui/MobileBottomSheet"
@@ -50,16 +51,30 @@ const ELIZA_ENV_OVERRIDE = process.env.NEXT_PUBLIC_ENABLE_ELIZA === "true"
 /**
  * Picker status for an agent's readiness dot:
  *  - "ready"     → green dot (free usage available or the user is set up)
- *  - "exhausted" → yellow dot (its only usage was a shared pool that's now used up)
+ *  - "low"       → yellow dot (shared-pool agent, balance nearly spent)
+ *  - "depleted"  → red dot (shared-pool agent, balance spent — the server will
+ *                  refuse the next send)
  *  - null        → no dot (needs setup)
  * Single source of truth for the dot color and its tooltip/description text.
+ *
+ * Red is driven by `agentSharedPoolExhausted` — the flag the server sets from
+ * the same comparison its send gate makes (lib/db/usage-limit) — rather than by
+ * the balance passed in, so a rounding difference in the float can never leave
+ * the dot green on a send the server is about to refuse. `balanceUsd` decides
+ * only the advisory yellow, which has no server counterpart.
  */
+type AgentStatusTone = "ready" | "low" | "depleted"
+
 function getAgentStatus(
   agent: Agent,
-  flags: CredentialFlags
-): { tone: "ready" | "exhausted"; label: string } | null {
+  flags: CredentialFlags,
+  balanceUsd: number | null | undefined
+): { tone: AgentStatusTone; label: string } | null {
   if (agentSharedPoolExhausted(agent, flags)) {
-    return { tone: "exhausted", label: "Free usage limit reached" }
+    return { tone: "depleted", label: "Out of credits" }
+  }
+  if (agentUsesSharedPool(agent, flags) && creditTier(balanceUsd) === "low") {
+    return { tone: "low", label: `Credits running low — ${fmtCreditAmount(balanceUsd!)} left` }
   }
   if (agentIsReady(agent, flags)) {
     return {
@@ -68,6 +83,13 @@ function getAgentStatus(
     }
   }
   return null
+}
+
+/** Tailwind background for each dot tone. */
+const DOT_CLASS: Record<AgentStatusTone, string> = {
+  ready: "bg-green-500",
+  low: "bg-yellow-500",
+  depleted: "bg-red-500",
 }
 
 /**
@@ -105,6 +127,9 @@ export function AgentModelSelector({
   // User's custom endpoints — merged into each agent's model list by name.
   const { data: settingsData } = useSettingsQuery()
   const endpoints = settingsData?.customEndpoints
+  // Null for anyone the balance doesn't gate (unlimited plan, own keys
+  // everywhere, logged out) — those users never get a credit-coloured dot.
+  const creditBalanceUsd = settingsData?.creditBalanceUsd ?? null
 
   // Eliza (a deterministic test agent) is hidden from the picker unless the user
   // enables it in the Developer settings, or the env override is set (tests/CI).
@@ -119,6 +144,15 @@ export function AgentModelSelector({
   const [showAgentSheet, setShowAgentSheet] = useState(false)
   const [showModelSheet, setShowModelSheet] = useState(false)
   const [search, setSearch] = useState("")
+
+  // The selected agent's dot, surfaced on the trigger itself — but only when
+  // it's a credit warning. The per-agent dots inside the dropdown are a
+  // comparison aid; a permanent green dot on the closed trigger would just be
+  // chrome, whereas amber/red there is the whole point of the warning (the
+  // dropdown that holds the other dots is shut most of the time).
+  const currentAgentStatus = getAgentStatus(currentAgent, credentialFlags, creditBalanceUsd)
+  const triggerTone =
+    currentAgentStatus && currentAgentStatus.tone !== "ready" ? currentAgentStatus : null
 
   const availableModels = getAgentModels(currentAgent, endpoints)
   const selectedModelConfig = availableModels.find(m => m.value === currentModel)
@@ -290,9 +324,9 @@ export function AgentModelSelector({
     value: agent,
     label: agentLabels[agent],
     icon: <AgentIcon agent={agent} className="h-5 w-5" />,
-    // Surface the agent's status: ready to use (free or configured), or a
-    // used-up free pool with nothing else to fall back on.
-    description: getAgentStatus(agent, credentialFlags)?.label,
+    // Surface the agent's status: ready to use (free or configured), a balance
+    // running low, or a spent one with nothing else to fall back on.
+    description: getAgentStatus(agent, credentialFlags, creditBalanceUsd)?.label,
   }))
 
   // Prepare model options for mobile bottom sheet
@@ -319,6 +353,13 @@ export function AgentModelSelector({
         >
           <AgentIcon agent={currentAgent} className="h-4 w-4" />
           <span className="hidden @[18rem]/row2:inline">{agentLabels[currentAgent]}</span>
+          {triggerTone && (
+            <span
+              className={cn("h-1.5 w-1.5 shrink-0 rounded-full", DOT_CLASS[triggerTone.tone])}
+              title={triggerTone.label}
+              aria-label={triggerTone.label}
+            />
+          )}
           <ChevronDown className="h-4 w-4 hidden @[18rem]/row2:block" />
         </button>
 
@@ -376,12 +417,19 @@ export function AgentModelSelector({
         >
           <AgentIcon agent={currentAgent} className="h-3.5 w-3.5" />
           <span className="hidden @[32rem]:inline">{agentLabels[currentAgent]}</span>
+          {triggerTone && (
+            <span
+              className={cn("h-1.5 w-1.5 shrink-0 rounded-full", DOT_CLASS[triggerTone.tone])}
+              title={triggerTone.label}
+              aria-label={triggerTone.label}
+            />
+          )}
           <ChevronDown className="h-3.5 w-3.5" />
         </button>
         {showAgentDropdown && (
           <div className="absolute bottom-full right-0 mb-1 bg-popover border border-border rounded-md shadow-lg py-1 z-50 w-48">
             {agents.map((agent) => {
-              const status = getAgentStatus(agent, credentialFlags)
+              const status = getAgentStatus(agent, credentialFlags, creditBalanceUsd)
               return (
                 <button
                   key={agent}
@@ -396,11 +444,7 @@ export function AgentModelSelector({
                   <span
                     className={cn(
                       "h-2 w-2 shrink-0 rounded-full",
-                      status?.tone === "exhausted"
-                        ? "bg-yellow-500"
-                        : status?.tone === "ready"
-                          ? "bg-green-500"
-                          : "bg-transparent"
+                      status ? DOT_CLASS[status.tone] : "bg-transparent"
                     )}
                     title={status?.label}
                     aria-label={status?.label}

--- a/packages/web/components/chat/AgentModelSelector.tsx
+++ b/packages/web/components/chat/AgentModelSelector.tsx
@@ -145,15 +145,6 @@ export function AgentModelSelector({
   const [showModelSheet, setShowModelSheet] = useState(false)
   const [search, setSearch] = useState("")
 
-  // The selected agent's dot, surfaced on the trigger itself — but only when
-  // it's a credit warning. The per-agent dots inside the dropdown are a
-  // comparison aid; a permanent green dot on the closed trigger would just be
-  // chrome, whereas amber/red there is the whole point of the warning (the
-  // dropdown that holds the other dots is shut most of the time).
-  const currentAgentStatus = getAgentStatus(currentAgent, credentialFlags, creditBalanceUsd)
-  const triggerTone =
-    currentAgentStatus && currentAgentStatus.tone !== "ready" ? currentAgentStatus : null
-
   const availableModels = getAgentModels(currentAgent, endpoints)
   const selectedModelConfig = availableModels.find(m => m.value === currentModel)
   const hasRequiredCredentials = selectedModelConfig
@@ -353,13 +344,6 @@ export function AgentModelSelector({
         >
           <AgentIcon agent={currentAgent} className="h-4 w-4" />
           <span className="hidden @[18rem]/row2:inline">{agentLabels[currentAgent]}</span>
-          {triggerTone && (
-            <span
-              className={cn("h-1.5 w-1.5 shrink-0 rounded-full", DOT_CLASS[triggerTone.tone])}
-              title={triggerTone.label}
-              aria-label={triggerTone.label}
-            />
-          )}
           <ChevronDown className="h-4 w-4 hidden @[18rem]/row2:block" />
         </button>
 
@@ -417,13 +401,6 @@ export function AgentModelSelector({
         >
           <AgentIcon agent={currentAgent} className="h-3.5 w-3.5" />
           <span className="hidden @[32rem]:inline">{agentLabels[currentAgent]}</span>
-          {triggerTone && (
-            <span
-              className={cn("h-1.5 w-1.5 shrink-0 rounded-full", DOT_CLASS[triggerTone.tone])}
-              title={triggerTone.label}
-              aria-label={triggerTone.label}
-            />
-          )}
           <ChevronDown className="h-3.5 w-3.5" />
         </button>
         {showAgentDropdown && (

--- a/packages/web/components/chat/ChatInput.tsx
+++ b/packages/web/components/chat/ChatInput.tsx
@@ -5,11 +5,13 @@ import { AlertTriangle, ArrowUp, Square, ChevronDown, Github, X, Paperclip, Penc
 import { cn } from "@/lib/utils"
 import { useModals } from "@/lib/contexts"
 import { useSpeechRecognition } from "@/lib/hooks/useSpeechRecognition"
+import { useCreditWarning } from "@/lib/hooks/useCreditWarning"
 import type { Chat, Agent, CredentialFlags, PendingFile } from "@/lib/types"
 import { NEW_REPOSITORY } from "@/lib/types"
 import { basename } from "@/lib/format"
 import { PendingFilesDisplay } from "./PendingFilesDisplay"
 import { AgentModelSelector } from "./AgentModelSelector"
+import { CreditWarningBanner } from "./CreditWarningBanner"
 import { RepoCombobox } from "./RepoCombobox"
 import { BranchCombobox } from "./BranchCombobox"
 import { McpServersCombobox } from "./McpServersCombobox"
@@ -233,6 +235,13 @@ export function ChatInput({
   isMobile,
 }: ChatInputProps) {
   const modals = useModals()
+  // Keyed off the *current* agent+model, so switching to a free model or an
+  // own-key one clears the warning along with the charge it was warning about.
+  const creditWarning = useCreditWarning({
+    agent: currentAgent,
+    model: currentModel,
+    credentialFlags,
+  })
   const [showModeDropdown, setShowModeDropdown] = useState(false)
   const [showModeSheet, setShowModeSheet] = useState(false)
 
@@ -341,6 +350,21 @@ export function ChatInput({
       "w-full mx-auto",
       isMobile ? "max-w-full" : "max-w-[52rem]"
     )}>
+      {/* Low/empty credit warning — above the composer, so it reads as context
+          for the send the user is about to make rather than as a message in the
+          conversation. */}
+      {creditWarning.tier && (
+        <div className="mb-2">
+          <CreditWarningBanner
+            tier={creditWarning.tier}
+            balanceUsd={creditWarning.balanceUsd}
+            onBuyCredits={() => modals.openSettingsSection("credits")}
+            onDismiss={creditWarning.dismiss}
+            isMobile={isMobile}
+          />
+        </div>
+      )}
+
       <div
         onDragOver={onDragOver}
         onDragLeave={onDragLeave}

--- a/packages/web/components/chat/CreditWarningBanner.tsx
+++ b/packages/web/components/chat/CreditWarningBanner.tsx
@@ -1,0 +1,97 @@
+"use client"
+
+import { TriangleAlert, Wallet, X } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { fmtCreditAmount } from "@/lib/format"
+import type { CreditTier } from "@/lib/server/credits"
+
+interface CreditWarningBannerProps {
+  /** Which warning to show. The caller decides; see lib/credit-warning. */
+  tier: Exclude<CreditTier, "ok">
+  /** Balance in USD. Negative when the turn that emptied it overshot. */
+  balanceUsd: number
+  /** Opens the Credits settings tab. */
+  onBuyCredits: () => void
+  /** Records the dismissal and hides the banner. */
+  onDismiss: () => void
+  isMobile?: boolean
+}
+
+/**
+ * The low/empty credit warning that sits above the composer.
+ *
+ * A banner rather than a popover on purpose: a floating layer over the chat
+ * would cover the messages the user is reading and fight the textarea for
+ * focus, and this warning is never urgent enough to earn that. It is also not a
+ * modal — `LimitReachedDialog` already interrupts the *blocked send*, and this
+ * one's whole job is to arrive before that happens.
+ *
+ * Shape follows ErrorBanner (same border/tint idiom), with the icon and the
+ * wording carrying the state as well as the colour, so it reads the same to
+ * anyone who can't separate amber from red.
+ */
+export function CreditWarningBanner({
+  tier,
+  balanceUsd,
+  onBuyCredits,
+  onDismiss,
+  isMobile,
+}: CreditWarningBannerProps) {
+  const isEmpty = tier === "empty"
+  const overspent = balanceUsd < 0
+
+  return (
+    <div
+      data-testid="credit-warning-banner"
+      role="status"
+      className={cn(
+        "flex items-start gap-2 rounded-md border px-3 py-2",
+        isMobile ? "text-sm" : "text-[13px]",
+        isEmpty
+          ? "border-destructive/30 bg-destructive/10 text-destructive"
+          : "border-yellow-500/30 bg-yellow-500/10 text-yellow-700 dark:text-yellow-400"
+      )}
+    >
+      {isEmpty ? (
+        <TriangleAlert className={cn("shrink-0 mt-0.5", isMobile ? "h-4 w-4" : "h-3.5 w-3.5")} />
+      ) : (
+        <Wallet className={cn("shrink-0 mt-0.5", isMobile ? "h-4 w-4" : "h-3.5 w-3.5")} />
+      )}
+
+      <div className="min-w-0 flex-1">
+        {isEmpty ? (
+          <>
+            <span className="font-medium">Out of credits.</span>{" "}
+            {overspent
+              ? `Your last turn ran ${fmtCreditAmount(balanceUsd)} past your balance — top up to clear it, or wait for tomorrow's daily credits.`
+              : "Top up to keep going, switch to a free model, or wait for tomorrow's daily credits."}
+          </>
+        ) : (
+          <>
+            <span className="font-medium">
+              Credits running low — {fmtCreditAmount(balanceUsd)} left.
+            </span>{" "}
+            Your next turn on a shared model may not finish.
+          </>
+        )}{" "}
+        <button
+          type="button"
+          onClick={onBuyCredits}
+          className="font-medium underline underline-offset-2 hover:no-underline cursor-pointer"
+        >
+          Buy credits
+        </button>
+      </div>
+
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="Dismiss credit warning"
+        title="Dismiss"
+        className="shrink-0 rounded p-0.5 opacity-70 hover:opacity-100 hover:bg-foreground/10 transition-opacity cursor-pointer"
+      >
+        <X className={isMobile ? "h-4 w-4" : "h-3.5 w-3.5"} />
+      </button>
+    </div>
+  )
+}

--- a/packages/web/lib/agent-status.test.ts
+++ b/packages/web/lib/agent-status.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect } from "vitest"
 import {
   agentSharedPoolExhausted,
+  agentUsesSharedPool,
   sharedPoolProviderForModel,
   formatTokenRate,
   agentModels,
@@ -21,6 +22,7 @@ import {
   resolveChatModel,
   type CredentialFlags,
 } from "@background-agents/common"
+import { creditTier } from "./server/credits"
 
 const sharedPoolFresh: CredentialFlags = { CLAUDE_SHARED_POOL_AVAILABLE: true }
 const sharedPoolUsedUp: CredentialFlags = {
@@ -68,6 +70,44 @@ describe("agentSharedPoolExhausted", () => {
       OPENCODE_API_KEY_USER: true,
     }
     expect(agentSharedPoolExhausted("opencode", ownOpencodeKey)).toBe(false)
+  })
+})
+
+describe("the yellow dot: a shared pool the balance is nearly out for", () => {
+  // getAgentStatus paints yellow on `agentUsesSharedPool(agent, flags) &&
+  // creditTier(balance) === "low"`. Red comes from the flag above instead, so
+  // these two together are the whole colour decision — this pins the half that
+  // the balance drives.
+  it("applies to every shared pool, since the balance is pooled", () => {
+    const allShared: CredentialFlags = {
+      CLAUDE_SHARED_POOL_AVAILABLE: true,
+      OPENCODE_API_KEY_SHARED: true,
+      GEMINI_API_KEY_SHARED: true,
+    }
+    expect(creditTier(0.05)).toBe("low")
+    for (const agent of ["claude-code", "opencode", "gemini"] as const) {
+      expect(agentUsesSharedPool(agent, allShared)).toBe(true)
+    }
+  })
+
+  it("does not apply to an agent running on the user's own key", () => {
+    // Their spend never touches the balance, so a low balance says nothing
+    // about their next send and the dot must stay green.
+    const ownOpencodeKey: CredentialFlags = { OPENCODE_API_KEY_USER: true }
+    expect(agentUsesSharedPool("opencode", ownOpencodeKey)).toBe(false)
+    expect(agentIsReady("opencode", { OPENCODE_API_KEY: true })).toBe(true)
+  })
+
+  it("does not apply to an agent with no shared pool at all", () => {
+    expect(agentUsesSharedPool("codex", { CLAUDE_SHARED_POOL_AVAILABLE: true })).toBe(false)
+  })
+
+  it("hands over to red at exactly the balance the server refuses", () => {
+    // The tier flips to "empty" at zero, which is where SHARED_BALANCE_EXHAUSTED
+    // is set too — so there is no balance that is both yellow here and refused
+    // there.
+    expect(creditTier(0.000001)).toBe("low")
+    expect(creditTier(0)).toBe("empty")
   })
 })
 

--- a/packages/web/lib/credit-warning.test.ts
+++ b/packages/web/lib/credit-warning.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Unit tests for when the composer's credit warning shows and when a dismissed
+ * one comes back.
+ */
+import { describe, it, expect } from "vitest"
+
+import {
+  DISMISS_COOLDOWN_MS,
+  dismissalIsStale,
+  dismissalStorageKey,
+  parseDismissal,
+  warningTierToShow,
+  type CreditWarningDismissal,
+} from "./credit-warning"
+import { LOW_CREDIT_USD } from "./server/credits"
+
+const NOW = 1_700_000_000_000
+
+/** A dismissal of the "low" banner at $0.08, one hour ago. */
+const dismissedLow: CreditWarningDismissal = {
+  tier: "low",
+  dismissedAt: NOW - 60 * 60 * 1000,
+  balanceAtDismiss: 0.08,
+}
+
+describe("warningTierToShow", () => {
+  const base = { drawsSharedPool: true, dismissal: null, now: NOW }
+
+  it("shows nothing on a healthy balance", () => {
+    expect(warningTierToShow({ ...base, balanceUsd: 5 })).toBeNull()
+  })
+
+  it("warns below the threshold and blocks at zero", () => {
+    expect(warningTierToShow({ ...base, balanceUsd: LOW_CREDIT_USD })).toBe("low")
+    expect(warningTierToShow({ ...base, balanceUsd: 0 })).toBe("empty")
+    expect(warningTierToShow({ ...base, balanceUsd: -1.5 })).toBe("empty")
+  })
+
+  it("stays silent for a user the balance doesn't gate", () => {
+    // Unlimited plan / own keys everywhere / logged out all arrive as null.
+    expect(warningTierToShow({ ...base, balanceUsd: null })).toBeNull()
+    expect(warningTierToShow({ ...base, balanceUsd: undefined })).toBeNull()
+  })
+
+  it("stays silent when the next send wouldn't draw the pool", () => {
+    // A free model or the user's own key is not gated by credits, so warning
+    // about the balance there would describe a block that doesn't exist —
+    // even at a balance of zero.
+    expect(
+      warningTierToShow({ ...base, drawsSharedPool: false, balanceUsd: 0.02 })
+    ).toBeNull()
+    expect(warningTierToShow({ ...base, drawsSharedPool: false, balanceUsd: -3 })).toBeNull()
+  })
+
+  it("honours a live dismissal", () => {
+    expect(
+      warningTierToShow({ ...base, balanceUsd: 0.08, dismissal: dismissedLow })
+    ).toBeNull()
+  })
+
+  it("re-shows once the dismissal goes stale", () => {
+    // Escalation: dismissing "low" must not swallow "out of credits".
+    expect(warningTierToShow({ ...base, balanceUsd: 0, dismissal: dismissedLow })).toBe(
+      "empty"
+    )
+  })
+})
+
+describe("dismissalIsStale", () => {
+  const base = { dismissal: dismissedLow, tier: "low" as const, balanceUsd: 0.08, now: NOW }
+
+  it("holds while nothing has changed", () => {
+    expect(dismissalIsStale(base)).toBe(false)
+    // A small drift downward, inside the cooldown and above half, is not news.
+    expect(dismissalIsStale({ ...base, balanceUsd: 0.07 })).toBe(false)
+  })
+
+  it("expires after the cooldown", () => {
+    // Measured from the dismissal, not from `NOW` — the fixture was dismissed
+    // an hour before it.
+    const expiry = dismissedLow.dismissedAt + DISMISS_COOLDOWN_MS
+    expect(dismissalIsStale({ ...base, now: expiry })).toBe(true)
+    expect(dismissalIsStale({ ...base, now: expiry - 1 })).toBe(false)
+  })
+
+  it("re-arms when the tier escalates", () => {
+    expect(dismissalIsStale({ ...base, tier: "empty", balanceUsd: 0 })).toBe(true)
+  })
+
+  it("re-arms after a top-up or the daily refill", () => {
+    // The balance went up, so the next fall into a warning tier is new
+    // information rather than the one they already dismissed.
+    expect(dismissalIsStale({ ...base, balanceUsd: 0.09 })).toBe(true)
+  })
+
+  it("re-arms when the balance halves", () => {
+    expect(dismissalIsStale({ ...base, balanceUsd: 0.04 })).toBe(true)
+    expect(dismissalIsStale({ ...base, balanceUsd: 0.041 })).toBe(false)
+  })
+
+  it("does not let a halving rule fire on a zero-or-negative dismissal", () => {
+    // Dismissed at exactly 0: half of 0 is 0, so an unguarded rule 4 would
+    // call every subsequent render stale and the banner would never stay shut.
+    const atZero: CreditWarningDismissal = { tier: "empty", dismissedAt: NOW, balanceAtDismiss: 0 }
+    expect(
+      dismissalIsStale({ dismissal: atZero, tier: "empty", balanceUsd: 0, now: NOW })
+    ).toBe(false)
+  })
+
+  it("ignores a clock that moved backwards", () => {
+    // A record written by a device ahead of this one must not silence the
+    // banner forever, but it also must not count as elapsed.
+    expect(dismissalIsStale({ ...base, now: NOW - 10 * DISMISS_COOLDOWN_MS })).toBe(false)
+  })
+})
+
+describe("parseDismissal", () => {
+  it("round-trips a real record", () => {
+    expect(parseDismissal({ ...dismissedLow })).toEqual(dismissedLow)
+  })
+
+  it("rejects anything that isn't one, rather than throwing", () => {
+    // A corrupt localStorage entry should cost one extra banner, not the
+    // composer.
+    expect(parseDismissal(null)).toBeNull()
+    expect(parseDismissal("nope")).toBeNull()
+    expect(parseDismissal({ tier: "ok", dismissedAt: NOW, balanceAtDismiss: 1 })).toBeNull()
+    expect(parseDismissal({ tier: "low", dismissedAt: "soon", balanceAtDismiss: 1 })).toBeNull()
+    expect(parseDismissal({ tier: "low", dismissedAt: NOW })).toBeNull()
+    expect(parseDismissal({ tier: "low", dismissedAt: NaN, balanceAtDismiss: 1 })).toBeNull()
+  })
+})
+
+describe("dismissalStorageKey", () => {
+  it("scopes the record to one account", () => {
+    // Two accounts on a shared browser must not inherit each other's silence.
+    expect(dismissalStorageKey("u1")).not.toBe(dismissalStorageKey("u2"))
+  })
+})

--- a/packages/web/lib/credit-warning.ts
+++ b/packages/web/lib/credit-warning.ts
@@ -1,0 +1,155 @@
+/**
+ * When the composer's low-credit warning is shown, and when a dismissed one
+ * comes back.
+ *
+ * The dot in the agent picker is ambient state — it is always accurate and has
+ * no dismissal. This module governs the *interruptive* half: the banner above
+ * the composer. A banner that reappears on every page load is noise a user
+ * learns to click past, and one that never reappears is a warning they see once
+ * and forget, so the rules below try to fire exactly when there is something new
+ * to say.
+ *
+ * Deliberately free of React and of `localStorage` itself: the decision is a
+ * pure function of (tier, balance, stored record, now), which is what makes the
+ * cooldown testable without faking a clock inside a component.
+ */
+
+import { creditTier, type CreditTier } from "@/lib/server/credits"
+
+/** What a dismissal remembers. Stored per user, per device. */
+export interface CreditWarningDismissal {
+  /** The tier that was on screen when the user dismissed it. */
+  tier: Exclude<CreditTier, "ok">
+  /** Epoch ms of the dismissal. */
+  dismissedAt: number
+  /** The balance in USD at that moment — rule 3 and 4 below compare against it. */
+  balanceAtDismiss: number
+}
+
+/**
+ * How long a dismissal silences the same tier.
+ *
+ * Matched to the daily-credit cron rather than picked round: credits refill once
+ * a day (see DAILY_CREDIT_TARGET_USD), so a shorter window would nag a user
+ * repeatedly about a balance that cannot change in their favour until tomorrow,
+ * and a longer one would let a whole refill cycle pass unmentioned.
+ */
+export const DISMISS_COOLDOWN_MS = 24 * 60 * 60 * 1000
+
+/**
+ * Whether a dismissal has stopped applying to the situation the user is now in.
+ *
+ * Any one of these is enough:
+ *
+ *  1. **The tier got worse.** A dismissed "running low" must never swallow "out
+ *     of credits" — it is a different message, and the second one explains why
+ *     sends have started failing.
+ *  2. **The cooldown elapsed.** See {@link DISMISS_COOLDOWN_MS}.
+ *  3. **The balance went up.** A top-up or the daily refill means the next fall
+ *     into a warning tier is genuinely new; a user who tops up and burns through
+ *     it in an hour should hear about it.
+ *  4. **The balance halved.** $0.09 → $0.04 is materially worse than what they
+ *     dismissed, even inside the cooldown.
+ *
+ * The inverse — none of the four — is the only case where the banner stays
+ * hidden.
+ */
+export function dismissalIsStale({
+  dismissal,
+  tier,
+  balanceUsd,
+  now,
+}: {
+  dismissal: CreditWarningDismissal
+  tier: Exclude<CreditTier, "ok">
+  balanceUsd: number
+  now: number
+}): boolean {
+  // 1. Escalation. Only low → empty is a real escalation; empty → low means the
+  // balance recovered, which rule 3 already covers.
+  if (dismissal.tier !== tier) return true
+
+  // 2. Cooldown. `now - dismissedAt` is negative if the clock moved backwards or
+  // the record was written by a device ahead of this one, which reads as "not
+  // elapsed" — the other rules still apply, so a bad clock cannot silence the
+  // banner forever.
+  if (now - dismissal.dismissedAt >= DISMISS_COOLDOWN_MS) return true
+
+  // 3. Refilled or topped up since the dismissal.
+  if (balanceUsd > dismissal.balanceAtDismiss) return true
+
+  // 4. Materially worse. Guarded on a positive balance at dismissal: at or below
+  // zero, halving says nothing (0 → -5 is worse but 0/2 is still 0), and rule 1
+  // has already handled the tier change into `empty`.
+  if (dismissal.balanceAtDismiss > 0 && balanceUsd <= dismissal.balanceAtDismiss / 2) {
+    return true
+  }
+
+  return false
+}
+
+/**
+ * The tier to show in the composer banner, or null to show nothing.
+ *
+ * Null covers all of: a healthy balance, a user the balance doesn't gate
+ * (`balanceUsd` null — unlimited plan, own keys everywhere, logged out), a
+ * send that wouldn't draw the shared pool anyway, and a live dismissal.
+ *
+ * `drawsSharedPool` is what keeps the banner honest about the *current*
+ * selection. Credits gate a run only when it resolves to a shared pool, so
+ * warning a user who is about to send on their own key, or on a free model,
+ * would be telling them their balance blocks something it does not.
+ */
+export function warningTierToShow({
+  balanceUsd,
+  drawsSharedPool,
+  dismissal,
+  now,
+}: {
+  balanceUsd: number | null | undefined
+  drawsSharedPool: boolean
+  dismissal: CreditWarningDismissal | null
+  now: number
+}): Exclude<CreditTier, "ok"> | null {
+  if (!drawsSharedPool) return null
+
+  const tier = creditTier(balanceUsd)
+  if (tier === null || tier === "ok") return null
+
+  // Narrowed by creditTier returning non-null.
+  const balance = balanceUsd as number
+
+  if (dismissal && !dismissalIsStale({ dismissal, tier, balanceUsd: balance, now })) {
+    return null
+  }
+  return tier
+}
+
+/**
+ * Parse a stored dismissal, rejecting anything that isn't one.
+ *
+ * A malformed record reads as "never dismissed" rather than throwing: the
+ * failure mode of showing the banner once more is strictly better than a
+ * corrupt localStorage entry breaking the composer.
+ */
+export function parseDismissal(raw: unknown): CreditWarningDismissal | null {
+  if (!raw || typeof raw !== "object") return null
+  const r = raw as Partial<CreditWarningDismissal>
+  if (r.tier !== "low" && r.tier !== "empty") return null
+  if (typeof r.dismissedAt !== "number" || !Number.isFinite(r.dismissedAt)) return null
+  if (typeof r.balanceAtDismiss !== "number" || !Number.isFinite(r.balanceAtDismiss)) {
+    return null
+  }
+  return { tier: r.tier, dismissedAt: r.dismissedAt, balanceAtDismiss: r.balanceAtDismiss }
+}
+
+/**
+ * The localStorage key for a user's dismissal.
+ *
+ * Keyed by user id so two accounts on one browser don't inherit each other's
+ * dismissals — the balance is per-account, and a shared machine is exactly where
+ * a stale suppression would be most confusing.
+ */
+export function dismissalStorageKey(userId: string): string {
+  return `credit-warning-dismissed:${userId}`
+}

--- a/packages/web/lib/hooks/useCreditWarning.ts
+++ b/packages/web/lib/hooks/useCreditWarning.ts
@@ -1,0 +1,90 @@
+"use client"
+
+import { useCallback, useState } from "react"
+import { useSession } from "next-auth/react"
+import { useSettingsQuery } from "@/lib/query/hooks/useSettingsQuery"
+import { readJSON, writeJSON } from "@/lib/storage"
+import {
+  dismissalStorageKey,
+  parseDismissal,
+  warningTierToShow,
+  type CreditWarningDismissal,
+} from "@/lib/credit-warning"
+import { sharedPoolProviderForModel, type Agent, type CredentialFlags } from "@/lib/types"
+import type { CreditTier } from "@/lib/server/credits"
+
+export interface CreditWarning {
+  /** The banner to render, or null for none. */
+  tier: Exclude<CreditTier, "ok"> | null
+  /** Balance in USD — only meaningful when `tier` is non-null. */
+  balanceUsd: number
+  /** Record the dismissal (per user, this device) and hide the banner. */
+  dismiss: () => void
+}
+
+/**
+ * Whether the composer should be warning about credits right now.
+ *
+ * Balance comes from the settings query, which already carries it (see
+ * getEffectiveCredentialFlags) and is invalidated when a turn completes, so the
+ * banner reflects the spend of the turn the user just watched run.
+ *
+ * The `sharedPoolProviderForModel` check is what ties the warning to the
+ * *current selection* rather than to the account: it is the client mirror of
+ * the server's `resolvePool`, so the banner appears exactly when the next send
+ * would draw the balance down — never on a BYOK key, a custom endpoint, or a
+ * free model, where the balance gates nothing.
+ *
+ * The dismissal record is read into state once per mount rather than on every
+ * render: it only changes when this hook writes it, and re-reading localStorage
+ * during render would make the component's output depend on something React
+ * cannot see change.
+ */
+export function useCreditWarning({
+  agent,
+  model,
+  credentialFlags,
+}: {
+  agent: Agent
+  model: string
+  credentialFlags: CredentialFlags
+}): CreditWarning {
+  const { data: session } = useSession()
+  const userId = session?.user?.id ?? null
+  const { data: settingsData } = useSettingsQuery()
+  const balanceUsd = settingsData?.creditBalanceUsd ?? null
+
+  const [dismissal, setDismissal] = useState<CreditWarningDismissal | null>(() => null)
+  const [loadedFor, setLoadedFor] = useState<string | null>(null)
+
+  // Load (and reload on a user switch) the stored dismissal. Done in render
+  // rather than an effect so the first paint after a login already respects it
+  // — an effect would flash the banner for one frame at a user who dismissed it.
+  if (userId && loadedFor !== userId) {
+    setLoadedFor(userId)
+    setDismissal(parseDismissal(readJSON(dismissalStorageKey(userId), null, "credit warning")))
+  }
+
+  const drawsSharedPool =
+    sharedPoolProviderForModel(agent, model, credentialFlags) !== null
+
+  const tier = warningTierToShow({
+    balanceUsd,
+    drawsSharedPool,
+    dismissal,
+    now: Date.now(),
+  })
+
+  const dismiss = useCallback(() => {
+    if (!tier || typeof balanceUsd !== "number") return
+    const record: CreditWarningDismissal = {
+      tier,
+      dismissedAt: Date.now(),
+      balanceAtDismiss: balanceUsd,
+    }
+    setDismissal(record)
+    if (userId) writeJSON(dismissalStorageKey(userId), record, "credit warning")
+  }, [tier, balanceUsd, userId])
+
+  return { tier, balanceUsd: balanceUsd ?? 0, dismiss }
+}

--- a/packages/web/lib/hooks/useStreaming.ts
+++ b/packages/web/lib/hooks/useStreaming.ts
@@ -184,6 +184,13 @@ export function useStreaming(options: UseStreamingOptions = {}) {
             } : c
           ))
 
+          // The turn just spent credits. The stream route meters the turn
+          // before emitting this event (see app/api/agent/stream/route.ts), so
+          // a refetch now returns the post-turn balance — which is what keeps
+          // the picker's dot and the composer's low-credit banner honest
+          // without polling. Cheap: the settings query is one row.
+          queryClient.invalidateQueries({ queryKey: queryKeys.settings.all })
+
           // Notify about conflict state change
           if (data.conflictState && onConflictStateChangeRef.current) {
             onConflictStateChangeRef.current(data.conflictState)

--- a/packages/web/lib/hooks/useTopUpSettle.ts
+++ b/packages/web/lib/hooks/useTopUpSettle.ts
@@ -1,0 +1,63 @@
+"use client"
+
+import { useEffect } from "react"
+import { useQueryClient } from "@tanstack/react-query"
+import { queryKeys } from "@/lib/query"
+import type { SettingsData } from "@/lib/query/hooks/useSettingsQuery"
+
+/**
+ * How long to keep re-checking, and how often.
+ *
+ * Sized against the gap this exists to cover — Stripe's redirect racing its own
+ * webhook — not against any guarantee. Six checks at 2.5s covers ~15s, which is
+ * comfortably past the "few seconds" the success toast promises. If the webhook
+ * is slower than that, the balance still lands on the next focus refetch or the
+ * next completed turn; this only makes the common case immediate.
+ */
+const SETTLE_ATTEMPTS = 6
+const SETTLE_INTERVAL_MS = 2500
+
+/**
+ * Re-check the credit balance for a few seconds after returning from Stripe.
+ *
+ * The balance is credited by the Stripe webhook, out of band from the redirect
+ * that brings the user back here — so the settings query this page mounts with
+ * almost always predates the payment. Without this the composer keeps a red dot
+ * (and keeps refusing agent switches through `agentSharedPoolExhausted`) over a
+ * balance the user has already paid for, until they happen to tab away and back.
+ *
+ * Stops early the moment the balance rises, so the common case is one or two
+ * extra requests rather than six.
+ */
+export function useTopUpSettle(active: boolean): void {
+  const queryClient = useQueryClient()
+
+  useEffect(() => {
+    if (!active) return
+
+    const readBalance = () =>
+      queryClient.getQueryData<SettingsData>(queryKeys.settings.all)?.creditBalanceUsd ?? null
+
+    const before = readBalance()
+    let attempts = 0
+    let cancelled = false
+
+    const timer = setInterval(async () => {
+      attempts += 1
+      await queryClient.invalidateQueries({ queryKey: queryKeys.settings.all })
+      if (cancelled) return
+
+      const after = readBalance()
+      const credited =
+        typeof before === "number" && typeof after === "number" && after > before
+      if (credited || attempts >= SETTLE_ATTEMPTS) {
+        clearInterval(timer)
+      }
+    }, SETTLE_INTERVAL_MS)
+
+    return () => {
+      cancelled = true
+      clearInterval(timer)
+    }
+  }, [active, queryClient])
+}

--- a/packages/web/lib/query/hooks/useSettingsQuery.ts
+++ b/packages/web/lib/query/hooks/useSettingsQuery.ts
@@ -66,6 +66,15 @@ export function useSettingsQuery() {
     // user who is actually signed in (which would flash the wrong dots).
     enabled: status !== "loading",
     staleTime: 60 * 1000, // 1 minute - settings don't change often
+    // Opt back in to the focus refetch that QueryProvider turns off globally.
+    // This query carries the credit balance, which moves without this tab
+    // doing anything: a turn finished by the agent-lifecycle cron with no
+    // stream attached, the daily refill at UTC midnight, a top-up completed in
+    // another tab. Coming back to the tab is exactly when a stale balance is
+    // most likely and most misleading — a green dot over a balance the server
+    // will refuse. The staleTime above is what keeps it cheap: flicking
+    // between tabs refetches at most once a minute.
+    refetchOnWindowFocus: true,
     // Provide default values while loading
     placeholderData: {
       settings: DEFAULT_SETTINGS,

--- a/packages/web/lib/query/hooks/useSettingsQuery.ts
+++ b/packages/web/lib/query/hooks/useSettingsQuery.ts
@@ -13,6 +13,12 @@ export interface SettingsData {
   credentialFlags: CredentialFlags
   customEndpoints?: CustomEndpoint[]
   planIsPro?: boolean
+  /**
+   * Purchased credits in USD, or null when the balance doesn't gate this user
+   * (unlimited plan, own keys everywhere) — and always null when logged out,
+   * since the anonymous shared-pool endpoint carries no user data.
+   */
+  creditBalanceUsd?: number | null
 }
 
 /**
@@ -45,7 +51,7 @@ export function useSettingsQuery() {
       if (!isAuthenticated) {
         // Logged out: settings stay at defaults; only shared-pool flags are real.
         const { credentialFlags } = await fetchSharedPoolFlags()
-        return { settings: DEFAULT_SETTINGS, credentialFlags }
+        return { settings: DEFAULT_SETTINGS, credentialFlags, creditBalanceUsd: null }
       }
       const response = await fetchSettings()
       return {
@@ -53,6 +59,7 @@ export function useSettingsQuery() {
         credentialFlags: response.credentialFlags,
         customEndpoints: response.customEndpoints,
         planIsPro: response.planIsPro,
+        creditBalanceUsd: response.creditBalanceUsd ?? null,
       }
     },
     // Wait until NextAuth resolves so we don't fetch the anon endpoint for a
@@ -63,6 +70,9 @@ export function useSettingsQuery() {
     placeholderData: {
       settings: DEFAULT_SETTINGS,
       credentialFlags: {},
+      // Null, not 0: the placeholder must not flash "out of credits" at a user
+      // whose balance simply hasn't loaded yet.
+      creditBalanceUsd: null,
     },
   })
 }

--- a/packages/web/lib/query/hooks/useUpdateSettingsMutation.ts
+++ b/packages/web/lib/query/hooks/useUpdateSettingsMutation.ts
@@ -55,6 +55,7 @@ export function useUpdateSettingsMutation() {
         credentialFlags: response.credentialFlags,
         customEndpoints: response.customEndpoints,
         planIsPro: response.planIsPro,
+        creditBalanceUsd: response.creditBalanceUsd ?? null,
       })
     },
     onError: (err, _, context) => {

--- a/packages/web/lib/server/credential-flags.ts
+++ b/packages/web/lib/server/credential-flags.ts
@@ -7,6 +7,7 @@ import { prisma } from "@/lib/db/prisma"
 import { isSharedPoolAvailable } from "@/lib/claude-credentials"
 import { decryptUserCredentials } from "@/lib/db/api-helpers"
 import { getDailyBalance, type Plan } from "@/lib/server/usage-budgets"
+import { microToUsd } from "@/lib/server/credits"
 import { flagsFromCredentials, CREDENTIAL_KEYS, type CredentialFlags } from "@/lib/credentials"
 import { hasSharedOpencodeKey } from "@/lib/server/opencode-pool"
 import { SHARED_POOL_AGENTS } from "@/lib/server/shared-pool"
@@ -18,6 +19,16 @@ export interface EffectiveFlags {
   isPro: boolean
   /** The user's subscription tier. */
   plan: Plan
+  /**
+   * Purchased credits in USD, or null when the balance does not gate this user
+   * at all — the `unlimited` plan, or an account running entirely on its own
+   * keys. Null is the "do not warn about this" signal the UI reads, and is
+   * deliberately distinct from `0`: see creditTier in lib/server/credits.
+   *
+   * Set under exactly the same condition as `SHARED_BALANCE_EXHAUSTED` below,
+   * so the number and the boolean can never describe different users.
+   */
+  creditBalanceUsd: number | null
 }
 
 /**
@@ -121,9 +132,15 @@ export async function getEffectiveCredentialFlags(userId: string): Promise<Effec
   // Readiness for the agent picker: the exact negation of the send gate in
   // lib/db/usage-limit, so the picker never offers a model the server refuses.
   // Unlimited is uncapped there and so is never marked exhausted here.
-  if (usesSharedPool && getDailyBalance(plan) != null) {
+  const gatedOnCredits = usesSharedPool && getDailyBalance(plan) != null
+  if (gatedOnCredits) {
     flags.SHARED_BALANCE_EXHAUSTED = credits <= 0n
   }
 
-  return { flags, isPro, plan }
+  return {
+    flags,
+    isPro,
+    plan,
+    creditBalanceUsd: gatedOnCredits ? microToUsd(credits) : null,
+  }
 }

--- a/packages/web/lib/server/credits.test.ts
+++ b/packages/web/lib/server/credits.test.ts
@@ -6,6 +6,8 @@ import { describe, it, expect } from "vitest"
 
 import {
   chargeableUsd,
+  creditTier,
+  LOW_CREDIT_USD,
   DAILY_CREDIT_TARGET_USD,
   dailyCreditTargetUsd,
   dailyTopUpMicro,
@@ -248,6 +250,45 @@ describe("dailyTopUpMicro", () => {
     for (const plan of ["free", "pro"] as const) {
       const after = 0n + dailyTopUpMicro(0n, plan)
       expect(dailyTopUpMicro(after, plan)).toBe(0n)
+    }
+  })
+})
+
+describe("creditTier", () => {
+  it("classifies the three states the UI paints", () => {
+    expect(creditTier(1)).toBe("ok")
+    expect(creditTier(LOW_CREDIT_USD + 0.001)).toBe("ok")
+    expect(creditTier(LOW_CREDIT_USD)).toBe("low")
+    expect(creditTier(0.01)).toBe("low")
+    expect(creditTier(0)).toBe("empty")
+    expect(creditTier(-4.2)).toBe("empty")
+  })
+
+  it("agrees with the send gate on exactly where zero falls", () => {
+    // checkSharedPoolUsage allows on `credits > 0n` — so a balance of zero is
+    // refused there and must read as `empty` here, not `low`. A disagreement
+    // would paint a yellow dot on a send the server is about to 429.
+    expect(creditTier(0)).toBe("empty")
+    expect(creditTier(0.000001)).toBe("low")
+  })
+
+  it("reports no tier at all for a balance that doesn't gate the user", () => {
+    // Unlimited plans and own-key accounts get null from the API, and a
+    // logged-out visitor gets nothing. None may render as "empty".
+    expect(creditTier(null)).toBeNull()
+    expect(creditTier(undefined)).toBeNull()
+    expect(creditTier(NaN)).toBeNull()
+    expect(creditTier(Infinity)).toBeNull()
+  })
+
+  it("stays below every daily refill target", () => {
+    // The invariant the threshold exists under: a user topped up to their
+    // plan's target must open the app in the clear, or the warning is
+    // permanent and therefore worthless.
+    for (const target of Object.values(DAILY_CREDIT_TARGET_USD)) {
+      if (target === null) continue
+      expect(LOW_CREDIT_USD).toBeLessThan(target)
+      expect(creditTier(target)).toBe("ok")
     }
   })
 })

--- a/packages/web/lib/server/credits.ts
+++ b/packages/web/lib/server/credits.ts
@@ -276,3 +276,51 @@ export function splitTurnCost({
   const fromDaily = Math.min(cost, Math.max(0, dailyLeft))
   return { fromDaily, fromCredits: cost - fromDaily }
 }
+
+/**
+ * The balance at or below which the UI starts warning, in credits.
+ *
+ * Sized against what a turn actually costs rather than as a fraction of any
+ * balance: on the ledger's own per-turn averages (the same ones
+ * {@link SIGNUP_CREDIT_USD} is measured in) a Claude turn is ~$0.125, an
+ * OpenCode one ~$0.042 and a Gemini one ~$0.028. So $0.10 is the point where
+ * the next Claude turn probably will not finish inside the balance — the first
+ * moment a warning is something the user can act on rather than noise.
+ *
+ * The hard constraint is the one above it: this MUST stay below every entry in
+ * {@link DAILY_CREDIT_TARGET_USD} ($0.25 free, $0.50 pro). A threshold at or
+ * over the refill target would leave a freshly topped-up free user permanently
+ * in the warning state, and a warning that is always on is a warning nobody
+ * reads. Raise the daily targets and this is fine; raise this past $0.25 and
+ * the whole free tier lives in amber.
+ */
+export const LOW_CREDIT_USD = 0.1
+
+/**
+ * How the UI describes a balance: healthy, worth warning about, or spent.
+ *
+ * `empty` is the UI's name for the send gate's own condition — `balance <= 0`,
+ * matching `checkSharedPoolUsage` exactly (see lib/db/usage-limit), so the red
+ * dot and the server's refusal can never disagree. `low` is advisory only and
+ * has no counterpart on the server.
+ */
+export type CreditTier = "ok" | "low" | "empty"
+
+/**
+ * Classify a credit balance for display.
+ *
+ * `null` in, `null` out: a balance the caller could not determine, or one that
+ * does not gate the user at all (the `unlimited` plan, or an account running
+ * entirely on its own keys), must not be rendered as any tier — least of all
+ * as `empty`, which a naive `<= 0` on a missing balance would produce.
+ *
+ * A non-finite balance is treated the same way, for the same reason: a NaN that
+ * arrived through a JSON boundary should not tell a paying user they are out of
+ * money.
+ */
+export function creditTier(balanceUsd: number | null | undefined): CreditTier | null {
+  if (typeof balanceUsd !== "number" || !Number.isFinite(balanceUsd)) return null
+  if (balanceUsd <= 0) return "empty"
+  if (balanceUsd <= LOW_CREDIT_USD) return "low"
+  return "ok"
+}

--- a/packages/web/lib/storage.ts
+++ b/packages/web/lib/storage.ts
@@ -83,7 +83,7 @@ const DEFAULT_LOCAL_STATE: LocalState = {
  * Read and JSON-parse a localStorage value. Returns `fallback` when running on
  * the server, when the key is missing, or when the stored value fails to parse.
  */
-function readJSON<T>(key: string, fallback: T, label: string): T {
+export function readJSON<T>(key: string, fallback: T, label: string): T {
   if (typeof window === "undefined") return fallback
   try {
     const stored = localStorage.getItem(key)
@@ -99,7 +99,7 @@ function readJSON<T>(key: string, fallback: T, label: string): T {
  * JSON-serialize and write a value to localStorage. No-ops on the server and
  * swallows quota/serialization errors after logging them.
  */
-function writeJSON(key: string, value: unknown, label: string): void {
+export function writeJSON(key: string, value: unknown, label: string): void {
   if (typeof window === "undefined") return
   try {
     localStorage.setItem(key, JSON.stringify(value))

--- a/packages/web/lib/sync/api.ts
+++ b/packages/web/lib/sync/api.ts
@@ -66,6 +66,12 @@ export interface SettingsResponse {
   credentialFlags: CredentialFlags
   customEndpoints?: CustomEndpoint[]
   planIsPro?: boolean
+  /**
+   * Purchased credits in USD, or null when the balance doesn't gate this user.
+   * Optional so an older deployment's response still parses; a missing value
+   * reads the same as null (no tier, no warning) through creditTier.
+   */
+  creditBalanceUsd?: number | null
 }
 
 // =============================================================================

--- a/packages/web/lib/types.ts
+++ b/packages/web/lib/types.ts
@@ -32,6 +32,7 @@ export {
   formatTokenRate,
   agentHasFreeUsage,
   agentSharedPoolExhausted,
+  agentUsesSharedPool,
   agentIsReady,
 } from "@background-agents/common"
 


### PR DESCRIPTION
## Warn before credits run out

  The agent picker's dot already went yellow at a  spent balance, but only inside a closed
  dropdown and only once the server was already  refusing sends. This splits it into a real
  warning and makes it update live.

  ### Changes

  **Dot colours** — three tones instead of two:
  green above $0.10, **yellow** below it, **red**  at or below zero. Red still comes from
  `SHARED_BALANCE_EXHAUSTED` — the flag the
  server sets from its send gate's own comparison  — so the dot can't disagree with a 429. Only
  the advisory yellow reads the balance.

  **Composer banner** — dismissible, above the
  input, with a link into the Credits tab. Shown
  only when the *selected* agent+model would
  actually draw the shared pool
  (`sharedPoolProviderForModel`, the client
  mirror of the server's `resolvePool`), so it
  never appears over a free model or a BYOK key.

  **Live updates** — the balance now rides on the  settings response (which already read it to
  set `SHARED_BALANCE_EXHAUSTED`, so no extra
  query) and refreshes on:
  - every completed turn — invalidated in the SSE  `complete` handler, which fires *after* the
  stream route meters the turn;
  - window focus — opted in for this one query,
  since it's the only one a different actor
  (metering cron, midnight refill, another tab)
  changes;
  - returning from Stripe — polled for ~15s,
  stopping when the balance rises.

  That last one was a real bug: the webhook
  credits the balance out of band from the
  redirect, so the app kept a red dot — and kept
  refusing agent switches — over credits the user  had just paid for.

  ### Thresholds

  `LOW_CREDIT_USD = $0.10`, sized against the
  ledger's per-turn averages (a Claude turn is
  ~$0.125), so yellow means "your next turn
  probably won't finish". It must stay below
  every `DAILY_CREDIT_TARGET_USD` ($0.25 free /
  $0.50 pro) or a refilled user would live
  permanently in amber — there's a test asserting  that.


<img width="1037" height="206" alt="image" src="https://github.com/user-attachments/assets/6728b0c4-21a6-468a-bdf3-4a6f0e7e492c" />
