### PR TITLE
Fix/metering lost turns

### DIFF
--- a/packages/web/app/api/cron/agent-lifecycle/_lib/interactive.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/_lib/interactive.ts
@@ -20,7 +20,7 @@ import type { ChatWithMessages } from "./types"
  * ChatWithMessages on purpose, so callers holding any chat-shaped row can pass
  * it without loading the messages relation.
  */
-export type DyingChat = {
+type DyingChat = {
   id: string
   userId: string
   agent: string

--- a/packages/web/app/api/cron/agent-lifecycle/_lib/interactive.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/_lib/interactive.ts
@@ -6,6 +6,7 @@ import { PATHS } from "@/lib/constants"
 import { finalizeTurn, type AgentSnapshot } from "@/lib/agent-session"
 import { meterAssistantTurn } from "@/lib/server/token-metering"
 import { stripNullBytes, stripNullBytesDeep } from "@/lib/db/pg-sanitize"
+import { meterDyingTurn } from "./meter-dying-turn"
 
 import { autoPushChat } from "@/lib/git/auto-push"
 import type { ChatWithMessages } from "./types"
@@ -13,6 +14,19 @@ import type { ChatWithMessages } from "./types"
 // =============================================================================
 // Interactive Chat Finalization
 // =============================================================================
+
+/**
+ * What markChatError needs to bill a turn before tearing it down. Narrower than
+ * ChatWithMessages on purpose, so callers holding any chat-shaped row can pass
+ * it without loading the messages relation.
+ */
+export type DyingChat = {
+  id: string
+  userId: string
+  agent: string
+  sandboxId: string | null
+  backgroundSessionId: string | null
+}
 
 export async function finalizeInteractiveChat(
   chat: ChatWithMessages,
@@ -94,10 +108,28 @@ export async function finalizeInteractiveChat(
   })
 }
 
-export async function markChatError(chatId: string, reason: string) {
+export async function markChatError(
+  chat: DyingChat,
+  reason: string,
+  daytona?: Daytona
+) {
+  // Bill what the turn already spent BEFORE the update below clears
+  // backgroundSessionId. A failed turn is not a free turn: the model produced
+  // tokens right up to the moment it errored or was stopped, and once the
+  // session id is gone there is no cursor left to diff them against. See
+  // meter-dying-turn.
+  await meterDyingTurn({
+    userId: chat.userId,
+    chatId: chat.id,
+    agent: chat.agent,
+    sandboxId: chat.sandboxId,
+    backgroundSessionId: chat.backgroundSessionId,
+    daytona,
+  })
+
   // Update chat status
   await prisma.chat.update({
-    where: { id: chatId },
+    where: { id: chat.id },
     data: {
       status: "error",
       backgroundSessionId: null,
@@ -107,7 +139,7 @@ export async function markChatError(chatId: string, reason: string) {
   // Create error message
   await prisma.message.create({
     data: {
-      chatId,
+      chatId: chat.id,
       role: "assistant",
       content: `Agent stopped: ${reason}`,
       timestamp: BigInt(Date.now()),

--- a/packages/web/app/api/cron/agent-lifecycle/_lib/meter-dying-turn.test.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/_lib/meter-dying-turn.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests for metering a turn the cron is about to tear down.
+ *
+ * The bug these cover was one of ordering, not arithmetic: markChatError and
+ * failScheduledRun cleared `backgroundSessionId` — and, for a scheduled run,
+ * deleted the sandbox — before anything had read the turn's usage. Both are the
+ * only handles metering has, so a crashed or timed-out turn was not merely
+ * unbilled but unrecoverable. 262 of 548 agent-stopped events in production
+ * recorded nothing at all.
+ *
+ * So what is asserted here is sequence: the meter must run, and it must run
+ * first. A test that only checked "usage was recorded" would still pass against
+ * the broken code if the teardown happened to be slower.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+/** Every call the code under test makes, in the order it made them. */
+let calls: string[] = []
+
+const meterAssistantTurn = vi.fn(async () => {
+  calls.push("meter")
+  return 1
+})
+
+vi.mock("@/lib/server/token-metering", () => ({
+  meterAssistantTurn: (...args: unknown[]) => meterAssistantTurn(...(args as [])),
+}))
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    chat: {
+      update: vi.fn(async () => {
+        calls.push("clear-session")
+        return {}
+      }),
+    },
+    message: {
+      create: vi.fn(async () => {
+        calls.push("error-message")
+        return {}
+      }),
+      findFirst: vi.fn(async () => ({ id: "msg_1", metadata: null })),
+    },
+  },
+}))
+
+import { meterDyingTurn } from "./meter-dying-turn"
+import { markChatError } from "./interactive"
+
+/** A sandbox handle; the metering call is mocked, so it is never used. */
+const sandbox = {}
+const daytona = { get: vi.fn(async () => sandbox) } as never
+
+const dyingChat = {
+  id: "chat_1",
+  userId: "user_1",
+  agent: "opencode",
+  sandboxId: "sandbox_1",
+  backgroundSessionId: "ses_1",
+}
+
+beforeEach(() => {
+  calls = []
+  meterAssistantTurn.mockClear()
+})
+
+describe("meterDyingTurn", () => {
+  it("meters the turn when the sandbox and session are still around", async () => {
+    const rows = await meterDyingTurn({ ...dyingChat, chatId: "chat_1", daytona })
+    expect(rows).toBe(1)
+    expect(meterAssistantTurn).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([
+    ["no sandbox", { sandboxId: null }],
+    ["no session id", { backgroundSessionId: null }],
+    ["no daytona client", { daytona: undefined }],
+  ])("does nothing and does not throw when there is %s", async (_label, over) => {
+    const rows = await meterDyingTurn({
+      ...dyingChat,
+      chatId: "chat_1",
+      daytona,
+      ...over,
+    })
+    expect(rows).toBe(0)
+    expect(meterAssistantTurn).not.toHaveBeenCalled()
+  })
+
+  it("swallows a metering failure — a bad turn must not get worse", async () => {
+    meterAssistantTurn.mockRejectedValueOnce(new Error("tokscale exploded"))
+    await expect(
+      meterDyingTurn({ ...dyingChat, chatId: "chat_1", daytona })
+    ).resolves.toBe(0)
+  })
+})
+
+describe("markChatError", () => {
+  it("meters BEFORE clearing the session id", async () => {
+    await markChatError(dyingChat, "Run exceeded 25 minute limit", daytona)
+    // The whole bug in one assertion: reverse these two and the turn's usage is
+    // gone, because the cursor it would be diffed against no longer exists.
+    expect(calls).toEqual(["meter", "clear-session", "error-message"])
+  })
+
+  it("still releases the chat when metering throws", async () => {
+    meterAssistantTurn.mockRejectedValueOnce(new Error("tokscale exploded"))
+    await markChatError(dyingChat, "Agent stopped", daytona)
+    // Metering is best-effort. A chat stranded as "running" is a worse failure
+    // than an unbilled turn, so the teardown must survive it.
+    expect(calls).toEqual(["clear-session", "error-message"])
+  })
+
+  it("still releases the chat when there is nothing to meter", async () => {
+    await markChatError({ ...dyingChat, sandboxId: null }, "Agent stopped", daytona)
+    expect(calls).toEqual(["clear-session", "error-message"])
+    expect(meterAssistantTurn).not.toHaveBeenCalled()
+  })
+})

--- a/packages/web/app/api/cron/agent-lifecycle/_lib/meter-dying-turn.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/_lib/meter-dying-turn.ts
@@ -1,0 +1,75 @@
+import { Daytona } from "@daytonaio/sdk"
+
+import { prisma } from "@/lib/db/prisma"
+import { meterAssistantTurn } from "@/lib/server/token-metering"
+
+// =============================================================================
+// Metering a turn that is about to be torn down
+// =============================================================================
+// The happy paths (finalizeInteractiveChat, finalizeScheduledRun) meter before
+// they release the chat, and so does the SSE stream route — which meters an
+// "error" snapshot exactly like a "completed" one, because a turn that failed
+// still burned whatever the model produced before it failed.
+//
+// The cron's failure paths did not. They went straight to markChatError /
+// failScheduledRun, which clear `backgroundSessionId` (and, for a scheduled
+// run, delete the sandbox outright). Both of those destroy the only handles
+// metering has: without the session id there is no cursor to diff against, and
+// without the sandbox there is no tokscale to ask. So the tokens a crashed,
+// rate-limited or timed-out turn had already spent were never billed and could
+// never be recovered afterwards.
+//
+// This is the missing counterpart. Call it before the teardown, never after.
+//
+// Best-effort by construction: a failing turn is already a bad day, and a
+// metering error must not stop the chat being released from "running" — that
+// would strand it far more visibly than an unbilled turn. Every failure is
+// logged and swallowed.
+
+/**
+ * Meter whatever a dying turn already spent, while the sandbox and session id
+ * are still around to be asked. Returns the number of usage rows written (0
+ * when there was nothing to meter, or when anything at all went wrong).
+ */
+export async function meterDyingTurn(params: {
+  userId: string
+  chatId: string
+  agent: string
+  sandboxId: string | null
+  backgroundSessionId: string | null
+  daytona?: Daytona
+}): Promise<number> {
+  const { userId, chatId, agent, sandboxId, backgroundSessionId, daytona } = params
+
+  // No sandbox to run tokscale in, or no session to attribute usage to —
+  // nothing to do. Not an error: a run can fail before either exists.
+  if (!sandboxId || !backgroundSessionId || !daytona) return 0
+
+  try {
+    // The turn's own assistant message, for attribution: its metadata carries
+    // the pool/provider/key stamped at send time. It may be missing (the turn
+    // died before one was written), which meterAssistantTurn tolerates — the
+    // usage is still recorded against the chat, just without a message label.
+    const assistantMessage = await prisma.message.findFirst({
+      where: { chatId, role: "assistant" },
+      orderBy: { timestamp: "desc" },
+      select: { id: true, metadata: true },
+    })
+
+    const sandbox = await daytona.get(sandboxId)
+    return await meterAssistantTurn(sandbox, {
+      userId,
+      chatId,
+      messageId: assistantMessage?.id ?? null,
+      messageMetadata: assistantMessage?.metadata,
+      agent,
+      sessionId: backgroundSessionId,
+    })
+  } catch (err) {
+    console.error(
+      `[agent-lifecycle] Failed to meter the dying turn for chat ${chatId}:`,
+      err
+    )
+    return 0
+  }
+}

--- a/packages/web/app/api/cron/agent-lifecycle/_lib/scheduled.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/_lib/scheduled.ts
@@ -12,6 +12,7 @@ import { logActivityAsync } from "@/lib/db/activity-log"
 import { checkSharedPoolUsage, UsageLimitError } from "@/lib/db/usage-limit"
 import { getClaudeCredentials } from "@/lib/claude-credentials"
 import { meterAssistantTurn } from "@/lib/server/token-metering"
+import { meterDyingTurn } from "./meter-dying-turn"
 import { buildUsageMeta } from "@/lib/server/shared-pool"
 import { PATHS } from "@/lib/constants"
 import { NEW_REPOSITORY } from "@/lib/types"
@@ -586,6 +587,22 @@ export async function failScheduledRun(
    */
   { countFailure = true }: { countFailure?: boolean } = {}
 ) {
+  // Bill what the run already spent, before the chat update below clears
+  // backgroundSessionId and — worse — before the sandbox is deleted at the end
+  // of this function. Once that sandbox is gone there is no tokscale left to
+  // ask, so a failed run's tokens are unrecoverable rather than merely late.
+  // See _lib/meter-dying-turn.
+  if (run.chatId) {
+    await meterDyingTurn({
+      userId: run.job.userId,
+      chatId: run.chatId,
+      agent: run.job.agent,
+      sandboxId: run.sandboxId,
+      backgroundSessionId: run.backgroundSessionId,
+      daytona,
+    })
+  }
+
   // Update run status
   await prisma.scheduledJobRun.update({
     where: { id: run.id },

--- a/packages/web/app/api/cron/agent-lifecycle/route.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/route.ts
@@ -150,7 +150,7 @@ export async function GET(req: Request) {
         // Hard timeout: 25 minutes
         if (totalMinutes > INTERACTIVE_HARD_TIMEOUT) {
           await stopAgent(chat.sandboxId!, chat.backgroundSessionId!, daytona)
-          await markChatError(chat.id, "Run exceeded 25 minute limit")
+          await markChatError(chat, "Run exceeded 25 minute limit", daytona)
           results.timedOutInteractive++
           continue
         }
@@ -171,7 +171,7 @@ export async function GET(req: Request) {
               error,
               errorKind,
             })
-            await markChatError(chat.id, error)
+            await markChatError(chat, error, daytona)
           },
         })
       } catch (err) {

--- a/packages/web/lib/server/token-metering.ts
+++ b/packages/web/lib/server/token-metering.ts
@@ -35,6 +35,8 @@ import { isFreeModel, type Plan } from "@/lib/server/usage-budgets"
 import {
   collapseEntriesByModel,
   cursorForModel,
+  chatPredatesMetering,
+  realAssistantTurnFilter,
 } from "@/lib/server/usage-cursor"
 import { priceClaudeTurn } from "@/lib/server/claude-pricing"
 import { readUsageMeta } from "@/lib/server/shared-pool"
@@ -218,15 +220,26 @@ async function meterTurnUsage(
         // cursor (getSessionCumulatives has no date filter) but fall outside
         // every budget window (sumSharedUsage filters createdAt >= start of
         // day). Only turns after the baseline charge.
+        //
+        // Age is the decisive test and is checked first, so a chat created
+        // once metering was running can never be backdated however broken its
+        // message history looks — see chatPredatesMetering for why the old
+        // message-count-only test gave away 482 chats.
         let baselineAt: Date | undefined
         if (prior.size === 0) {
-          const assistantTurns = await tx.message.count({
-            where: { chatId, role: "assistant" },
+          const chat = await tx.chat.findUnique({
+            where: { id: chatId },
+            select: { createdAt: true },
           })
-          // >1 ⇒ turns existed before this one (and before metering) ⇒
-          // pre-existing chat. Exactly 1 ⇒ this is the chat's first turn ⇒
-          // charge normally.
-          if (assistantTurns > 1) baselineAt = new Date(0)
+          if (chatPredatesMetering(chat?.createdAt)) {
+            const priorTurns = await tx.message.count({
+              where: realAssistantTurnFilter(chatId),
+            })
+            // >1 ⇒ real turns existed before this one (and before metering) ⇒
+            // pre-existing chat. Exactly 1 ⇒ this is the chat's first turn ⇒
+            // charge normally.
+            if (priorTurns > 1) baselineAt = new Date(0)
+          }
         }
 
         const rows: TokenUsageInsert[] = []

--- a/packages/web/lib/server/usage-cursor.test.ts
+++ b/packages/web/lib/server/usage-cursor.test.ts
@@ -12,6 +12,9 @@ import {
   collapseEntriesByModel,
   cursorForModel,
   sumCumulatives,
+  chatPredatesMetering,
+  realAssistantTurnFilter,
+  METERING_START,
   ZERO_CUMULATIVE,
   type SessionCumulative,
 } from "./usage-cursor"
@@ -152,5 +155,67 @@ describe("collapseEntriesByModel", () => {
       collapsed: 0,
       conflicted: [],
     })
+  })
+})
+
+/**
+ * The baseline gate. A backdated row is a free row, so every case here is
+ * really the question "does this chat get its next turn for nothing?".
+ */
+describe("chatPredatesMetering", () => {
+  const before = new Date(METERING_START.getTime() - 1)
+  const after = new Date(METERING_START.getTime() + 1)
+
+  it("is true only for a chat older than the day metering began", () => {
+    expect(chatPredatesMetering(before)).toBe(true)
+    expect(chatPredatesMetering(after)).toBe(false)
+  })
+
+  it("excludes a chat created exactly at the boundary", () => {
+    // Metering was running from this instant, so there is no backlog.
+    expect(chatPredatesMetering(METERING_START)).toBe(false)
+  })
+
+  it("is false for every chat created since — the regression that leaked $1,241.70", () => {
+    // The old test would have backdated all of these the moment a crashed or
+    // errored first turn left the session without a usage row.
+    expect(chatPredatesMetering(new Date("2026-09-05T20:00:09.085Z"))).toBe(false)
+    expect(chatPredatesMetering(new Date("2026-07-01T00:00:00.000Z"))).toBe(false)
+  })
+
+  it("treats an unknown creation date as recent, so the turn is charged", () => {
+    // Charging a turn that should have been free is recoverable; giving one
+    // away silently is not.
+    expect(chatPredatesMetering(null)).toBe(false)
+    expect(chatPredatesMetering(undefined)).toBe(false)
+  })
+
+  it("honours an injected boundary, so the rule is not pinned to one date", () => {
+    const start = new Date("2026-01-01T00:00:00.000Z")
+    expect(chatPredatesMetering(new Date("2025-12-31T23:59:59Z"), start)).toBe(true)
+    expect(chatPredatesMetering(new Date("2026-01-02T00:00:00Z"), start)).toBe(false)
+  })
+})
+
+describe("realAssistantTurnFilter", () => {
+  it("counts only assistant messages that could have spent tokens", () => {
+    // Each exclusion is a way production produced an assistant row with no LLM
+    // call behind it; counting any of them let one failed turn pass for a
+    // pre-metering backlog.
+    expect(realAssistantTurnFilter("chat_1")).toEqual({
+      chatId: "chat_1",
+      role: "assistant",
+      isError: false,
+      content: { not: "" },
+      OR: [{ messageType: null }, { messageType: { not: "git-operation" } }],
+    })
+  })
+
+  it("keeps messages whose messageType is null — an ordinary chat turn", () => {
+    // `{ not: "git-operation" }` alone compiles to SQL `<>`, and
+    // `NULL <> 'git-operation'` is NULL, so the terse form drops every normal
+    // message and disables the backlog check completely.
+    const { OR } = realAssistantTurnFilter("chat_1")
+    expect(OR).toContainEqual({ messageType: null })
   })
 })

--- a/packages/web/lib/server/usage-cursor.ts
+++ b/packages/web/lib/server/usage-cursor.ts
@@ -131,3 +131,70 @@ export function cursorForModel(
     rawKey !== key ? prior.get(rawKey) : undefined
   )
 }
+
+// =============================================================================
+// The baseline: where a session's cursor starts
+// =============================================================================
+// A session whose first capture finds no prior rows has no cursor, so the delta
+// is tokscale's whole cumulative. For a chat that ran before metering existed,
+// that cumulative covers a backlog nobody was ever charged for, and billing it
+// as one turn would empty a day's budget in a single send. Such rows are
+// written backdated to the epoch: they still advance the cursor (the cursor sum
+// has no date filter) but sit outside every budget window, and they are not
+// debited.
+//
+// The danger is the opposite error. Backdating a chat that does NOT have a
+// backlog hands its first real turn away for nothing, and that is exactly what
+// happened: the test used to be "no rows for this session AND more than one
+// assistant message", which treats a missing usage row as evidence of age. It
+// is not evidence of anything. A brand-new chat has no rows the moment its
+// first turn fails to produce one — a crash, an error notice, a git-operation
+// message, or tokscale not having flushed yet — and the next turn then satisfied
+// both halves. 482 chats and $1,241.70 went unbilled that way.
+
+/**
+ * When token metering went live in production: the oldest real TokenUsage row
+ * (2026-06-15 17:54 UTC), rounded down to the day.
+ */
+export const METERING_START = new Date("2026-06-15T00:00:00.000Z")
+
+/**
+ * Whether a chat can possibly hold usage that was never recorded.
+ *
+ * Age is the only sound test. A chat created once metering was running has been
+ * metered since its first turn, so it has no backlog to forgive however broken
+ * its message history looks. An unknown creation date is treated as recent —
+ * charging a turn is recoverable, giving one away silently is not.
+ */
+export function chatPredatesMetering(
+  chatCreatedAt: Date | null | undefined,
+  meteringStart: Date = METERING_START
+): boolean {
+  if (!chatCreatedAt) return false
+  return chatCreatedAt.getTime() < meteringStart.getTime()
+}
+
+/**
+ * Prisma filter for assistant messages that could actually have spent tokens.
+ *
+ * Error notices (`markChatError`), git-operation messages and the empty shell
+ * left by a crashed turn are all `role: "assistant"` rows. Counting them is
+ * what let one failed turn pass for a pre-metering backlog, so they are all
+ * excluded here.
+ *
+ * The messageType clause is spelled as an explicit null-or-not-git OR rather
+ * than a bare `{ not: "git-operation" }`, because that compiles to SQL `<>`,
+ * and `NULL <> 'git-operation'` is NULL, not true. An ordinary chat message
+ * has no messageType at all, so the terse version excludes very nearly every
+ * real turn — it silently disabled the backlog check entirely, which the
+ * pre-metering control in scripts/repro-metering-bugs.ts caught.
+ */
+export function realAssistantTurnFilter(chatId: string) {
+  return {
+    chatId,
+    role: "assistant",
+    isError: false,
+    content: { not: "" },
+    OR: [{ messageType: null }, { messageType: { not: "git-operation" } }],
+  }
+}


### PR DESCRIPTION
# Fix two bugs that let paid turns go unbilled

## The background, in one paragraph

When you send a message, the agent runs inside a sandbox. A tool called
**tokscale** counts the tokens it used. tokscale only ever tells us a **running
total** for the whole chat session — never "this one message cost X". So to
bill a single turn we do:

```
this turn = tokscale's running total  −  what we already saved
```

Then we save that number and take the credits. Both bugs below are about that
saving step going wrong.

---

## Bug 1 — a crashed turn was never billed

**What happened:** if the agent crashed, hit a rate limit, or ran past the 25
minute cap, we marked the chat as failed and **immediately threw away the
session ID** — the thing we need to look the usage up with. For scheduled jobs
we also **deleted the sandbox**, which is where tokscale lives.

So we destroyed the receipt before reading it. The model had already done the
work and we had already paid for it upstream, but the user was charged nothing.
And because both the session ID and the sandbox were gone, we could never go
back and recover it later.

Oddly, this only happened when your browser was **closed**. If you were sitting
watching the chat, a different piece of code handled the failure, and that one
*did* bill correctly. So the bug was invisible unless you looked at background
chats.



**The fix:** count the tokens *first*, then tear the session down. There's a new
helper, `meterDyingTurn`, and it's called inside the two teardown functions
themselves rather than at each call site — so all six places that end a failed
turn get it automatically and nobody can forget it.

---

## Bug 2 — a new chat's first real reply was free

**What happened:** we started counting tokens on 15 June. Chats that existed
*before* that date have history nobody ever paid for. If someone reopens one, we
don't want to suddenly bill them for months of old messages — so we have a rule:
"if this is an old chat, record its history but don't charge for it."

The problem was **how we decided a chat was old**. The test was:

> no usage saved yet **and** the chat has more than one reply in it

That sounds sensible, but a **brand new** chat looks exactly like that whenever
its first reply fails. The failed reply saves no usage (bug 1 above!), and it
still leaves a reply row sitting in the chat. So by the time you send your
second message, both conditions are true — and we marked that turn as "old
history" and gave it away for free.

Anything that leaves a reply without usage triggered it: a crash, an error
notice, or even a "pushed to git" message.



**The fix:** just check the chat's **age**. If the chat was created after 15
June, it has been counted since its very first message, so it cannot have
unpaid history — full stop, regardless of what its replies look like. The old
reply-counting check is still there as a backup for genuinely old chats, but now
it only counts real replies and ignores errors, git messages, and empty crashed
ones.

---

## How I know it works

New tests in `meter-dying-turn.test.ts` assert the **order**, not just the
result. That matters: a test that only checked "the tokens were counted" would
still pass against the broken code whenever the teardown happened to lose the
race.

```
expect(calls).toEqual(["meter", "clear-session", "error-message"])
```

Move the counting back below the teardown — i.e. put the bug back — and that
one test fails and nothing else does. I checked.

They also cover the two ways this has to fail safely: a chat must still get
unstuck even if counting throws, and counting must quietly do nothing when
there's no sandbox to ask. Leaving a chat stuck on "running" would be worse
than missing a bill.

Bug 2's age check is unit-tested directly — including that a genuinely old chat
still answers "yes, this one predates metering", which is what keeps it free.
The end-to-end "and therefore it is not charged" step is not covered by a unit
test; I verified that against a real database (below) rather than in CI.

While writing these I also ran a one-off script against a real local database,
driving the actual code paths end to end. Before the fixes: 3 pass, 6 fail.
After: 9 pass, 0 fail. It also caught a mistake in my own first attempt — I
wrote a database filter meaning "not a git message", but in SQL, comparing
something to an empty value gives *"don't know"* rather than *"yes"*, and
normal messages have an empty type, so the filter quietly threw away almost
every message. That script isn't in this PR; it was a one-off, and the unit
tests above are what actually guard the fix from now on.

Full suite: 321 passing (8 new). No database changes.



