### PR TITLE
fix(usage): bill a dying turn under the agent's session id

### DIFF
--- a/packages/web/app/api/cron/agent-lifecycle/_lib/interactive.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/_lib/interactive.ts
@@ -25,7 +25,8 @@ type DyingChat = {
   userId: string
   agent: string
   sandboxId: string | null
-  backgroundSessionId: string | null
+  /** The persisted agent-session resume pointer, used as a fallback id. */
+  sessionId: string | null
 }
 
 export async function finalizeInteractiveChat(
@@ -111,7 +112,13 @@ export async function finalizeInteractiveChat(
 export async function markChatError(
   chat: DyingChat,
   reason: string,
-  daytona?: Daytona
+  daytona?: Daytona,
+  /**
+   * The agent CLI's session id, from whichever snapshot saw the failure. The
+   * chat row cannot supply it: Chat.backgroundSessionId is the Daytona handle,
+   * a different namespace entirely. Without this the turn cannot be billed.
+   */
+  agentSessionId?: string
 ) {
   // Bill what the turn already spent BEFORE the update below clears
   // backgroundSessionId. A failed turn is not a free turn: the model produced
@@ -123,7 +130,8 @@ export async function markChatError(
     chatId: chat.id,
     agent: chat.agent,
     sandboxId: chat.sandboxId,
-    backgroundSessionId: chat.backgroundSessionId,
+    agentSessionId,
+    fallbackSessionId: chat.sessionId,
     daytona,
   })
 

--- a/packages/web/app/api/cron/agent-lifecycle/_lib/meter-dying-turn.test.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/_lib/meter-dying-turn.test.ts
@@ -17,13 +17,18 @@ import { describe, it, expect, vi, beforeEach } from "vitest"
 /** Every call the code under test makes, in the order it made them. */
 let calls: string[] = []
 
-const meterAssistantTurn = vi.fn(async () => {
+/** Args of the last meterAssistantTurn call, so the id passed can be asserted. */
+let meteredWith: { sessionId?: string | null } | undefined
+
+const meterAssistantTurn = vi.fn(async (_sandbox: unknown, params: { sessionId?: string | null }) => {
   calls.push("meter")
+  meteredWith = params
   return 1
 })
 
 vi.mock("@/lib/server/token-metering", () => ({
-  meterAssistantTurn: (...args: unknown[]) => meterAssistantTurn(...(args as [])),
+  meterAssistantTurn: (...args: unknown[]) =>
+    meterAssistantTurn(...(args as Parameters<typeof meterAssistantTurn>)),
 }))
 
 vi.mock("@/lib/db/prisma", () => ({
@@ -51,34 +56,87 @@ import { markChatError } from "./interactive"
 const sandbox = {}
 const daytona = { get: vi.fn(async () => sandbox) } as never
 
+// The two ids are deliberately unalike. Chat.backgroundSessionId is a Daytona
+// handle (a UUID); the agent CLI's session id is what tokscale files usage
+// under ("ses_…"). They never coincide in production, so a test that used one
+// value for both would pass while the code metered a session that does not
+// exist — which is exactly the mistake this file now guards.
+const BACKGROUND_SESSION_ID = "64b0cd9f-807c-42f3-bcf1-000000000000"
+const AGENT_SESSION_ID = "ses_0f954b136ffe7xPfv2"
+
 const dyingChat = {
   id: "chat_1",
   userId: "user_1",
   agent: "opencode",
   sandboxId: "sandbox_1",
-  backgroundSessionId: "ses_1",
+  sessionId: null as string | null,
 }
 
 beforeEach(() => {
   calls = []
+  meteredWith = undefined
   meterAssistantTurn.mockClear()
 })
 
 describe("meterDyingTurn", () => {
   it("meters the turn when the sandbox and session are still around", async () => {
-    const rows = await meterDyingTurn({ ...dyingChat, chatId: "chat_1", daytona })
+    const rows = await meterDyingTurn({
+      ...dyingChat,
+      chatId: "chat_1",
+      agentSessionId: AGENT_SESSION_ID,
+      daytona,
+    })
     expect(rows).toBe(1)
     expect(meterAssistantTurn).toHaveBeenCalledTimes(1)
   })
 
+  it("meters under the AGENT session id, never the Daytona handle", async () => {
+    // tokscale files usage under the CLI's session id and filters on an exact
+    // match, so passing backgroundSessionId matches nothing and silently bills
+    // zero — no error, no row, no clue. Production has never held a usage row
+    // whose sessionId was a backgroundSessionId.
+    await meterDyingTurn({
+      ...dyingChat,
+      chatId: "chat_1",
+      agentSessionId: AGENT_SESSION_ID,
+      daytona,
+    })
+    expect(meteredWith?.sessionId).toBe(AGENT_SESSION_ID)
+    expect(meteredWith?.sessionId).not.toBe(BACKGROUND_SESSION_ID)
+  })
+
+  it("falls back to the chat's resume pointer when the snapshot had no id", async () => {
+    // A resumed turn continues Chat.sessionId, so the CLI reports under it.
+    await meterDyingTurn({
+      ...dyingChat,
+      chatId: "chat_1",
+      agentSessionId: undefined,
+      fallbackSessionId: AGENT_SESSION_ID,
+      daytona,
+    })
+    expect(meteredWith?.sessionId).toBe(AGENT_SESSION_ID)
+  })
+
+  it("prefers the snapshot's id over a stale resume pointer", async () => {
+    await meterDyingTurn({
+      ...dyingChat,
+      chatId: "chat_1",
+      agentSessionId: AGENT_SESSION_ID,
+      fallbackSessionId: "ses_stale_from_an_older_turn",
+      daytona,
+    })
+    expect(meteredWith?.sessionId).toBe(AGENT_SESSION_ID)
+  })
+
   it.each([
     ["no sandbox", { sandboxId: null }],
-    ["no session id", { backgroundSessionId: null }],
+    ["no session id at all", { agentSessionId: null, fallbackSessionId: null }],
     ["no daytona client", { daytona: undefined }],
   ])("does nothing and does not throw when there is %s", async (_label, over) => {
     const rows = await meterDyingTurn({
       ...dyingChat,
       chatId: "chat_1",
+      agentSessionId: AGENT_SESSION_ID,
       daytona,
       ...over,
     })
@@ -89,14 +147,19 @@ describe("meterDyingTurn", () => {
   it("swallows a metering failure — a bad turn must not get worse", async () => {
     meterAssistantTurn.mockRejectedValueOnce(new Error("tokscale exploded"))
     await expect(
-      meterDyingTurn({ ...dyingChat, chatId: "chat_1", daytona })
+      meterDyingTurn({
+        ...dyingChat,
+        chatId: "chat_1",
+        agentSessionId: AGENT_SESSION_ID,
+        daytona,
+      })
     ).resolves.toBe(0)
   })
 })
 
 describe("markChatError", () => {
   it("meters BEFORE clearing the session id", async () => {
-    await markChatError(dyingChat, "Run exceeded 25 minute limit", daytona)
+    await markChatError(dyingChat, "Run exceeded 25 minute limit", daytona, AGENT_SESSION_ID)
     // The whole bug in one assertion: reverse these two and the turn's usage is
     // gone, because the cursor it would be diffed against no longer exists.
     expect(calls).toEqual(["meter", "clear-session", "error-message"])
@@ -104,14 +167,14 @@ describe("markChatError", () => {
 
   it("still releases the chat when metering throws", async () => {
     meterAssistantTurn.mockRejectedValueOnce(new Error("tokscale exploded"))
-    await markChatError(dyingChat, "Agent stopped", daytona)
+    await markChatError(dyingChat, "Agent stopped", daytona, AGENT_SESSION_ID)
     // Metering is best-effort. A chat stranded as "running" is a worse failure
     // than an unbilled turn, so the teardown must survive it.
     expect(calls).toEqual(["clear-session", "error-message"])
   })
 
   it("still releases the chat when there is nothing to meter", async () => {
-    await markChatError({ ...dyingChat, sandboxId: null }, "Agent stopped", daytona)
+    await markChatError({ ...dyingChat, sandboxId: null }, "Agent stopped", daytona, AGENT_SESSION_ID)
     expect(calls).toEqual(["clear-session", "error-message"])
     expect(meterAssistantTurn).not.toHaveBeenCalled()
   })

--- a/packages/web/app/api/cron/agent-lifecycle/_lib/meter-dying-turn.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/_lib/meter-dying-turn.ts
@@ -21,6 +21,13 @@ import { meterAssistantTurn } from "@/lib/server/token-metering"
 //
 // This is the missing counterpart. Call it before the teardown, never after.
 //
+// The id it needs is the AGENT CLI's session id — what tokscale files usage
+// under, and what every other metering call site passes as `snapshot.sessionId`.
+// It is NOT `Chat.backgroundSessionId`, which is the Daytona handle used to
+// talk to the sandbox: the two never coincide (checked against production —
+// no TokenUsage row has ever matched a backgroundSessionId), so passing the
+// wrong one silently meters nothing at all.
+//
 // Best-effort by construction: a failing turn is already a bad day, and a
 // metering error must not stop the chat being released from "running" — that
 // would strand it far more visibly than an unbilled turn. Every failure is
@@ -36,14 +43,26 @@ export async function meterDyingTurn(params: {
   chatId: string
   agent: string
   sandboxId: string | null
-  backgroundSessionId: string | null
+  /**
+   * The agent CLI's session id, from the snapshot that observed the failure.
+   * Not the Daytona backgroundSessionId — see above.
+   */
+  agentSessionId: string | null | undefined
+  /**
+   * `Chat.sessionId`, the persisted resume pointer. Used when the snapshot
+   * could not be read: a resumed turn continues that very session, so the CLI
+   * reports usage under it. Null on a chat's first turn, where only the
+   * snapshot knows the id — hence the ordering.
+   */
+  fallbackSessionId?: string | null
   daytona?: Daytona
 }): Promise<number> {
-  const { userId, chatId, agent, sandboxId, backgroundSessionId, daytona } = params
+  const { userId, chatId, agent, sandboxId, daytona } = params
+  const sessionId = params.agentSessionId || params.fallbackSessionId
 
   // No sandbox to run tokscale in, or no session to attribute usage to —
   // nothing to do. Not an error: a run can fail before either exists.
-  if (!sandboxId || !backgroundSessionId || !daytona) return 0
+  if (!sandboxId || !sessionId || !daytona) return 0
 
   try {
     // The turn's own assistant message, for attribution: its metadata carries
@@ -63,7 +82,7 @@ export async function meterDyingTurn(params: {
       messageId: assistantMessage?.id ?? null,
       messageMetadata: assistantMessage?.metadata,
       agent,
-      sessionId: backgroundSessionId,
+      sessionId,
     })
   } catch (err) {
     console.error(

--- a/packages/web/app/api/cron/agent-lifecycle/_lib/monitor.test.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/_lib/monitor.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for the session id the monitor hands to its failure handlers.
+ *
+ * Two different ids travel through this module and they are easy to confuse:
+ *
+ *   backgroundSessionId  the Daytona handle used to talk to the sandbox
+ *   snapshot.sessionId   the agent CLI's own session, which is what tokscale
+ *                        files token usage under
+ *
+ * Billing a turn needs the second one. tokscale matches on it exactly, so the
+ * first one selects nothing and meters zero — with no error and no row to show
+ * for it. In production the two have never coincided: no TokenUsage row has
+ * ever carried a value that appears as a backgroundSessionId.
+ *
+ * monitorAgent and stopAgent are the only places the agent id is known at
+ * failure time, so what is pinned here is that they surrender it to the caller.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import type { AgentSnapshot } from "@/lib/agent-session"
+
+const BACKGROUND_SESSION_ID = "64b0cd9f-807c-42f3-bcf1-000000000000"
+const AGENT_SESSION_ID = "ses_0f954b136ffe7xPfv2"
+
+let snapshot: AgentSnapshot
+const cancelBackgroundAgent = vi.fn(async () => {})
+const snapshotBackgroundAgent = vi.fn(async () => snapshot)
+
+vi.mock("@/lib/agent-session", () => ({
+  snapshotBackgroundAgent: (...a: unknown[]) => snapshotBackgroundAgent(...(a as [])),
+  cancelBackgroundAgent: (...a: unknown[]) => cancelBackgroundAgent(...(a as [])),
+}))
+
+import { monitorAgent, stopAgent } from "./monitor"
+
+const sandbox = { refreshActivity: vi.fn(async () => {}) }
+const daytona = { get: vi.fn(async () => sandbox) } as never
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  snapshot = {
+    status: "error",
+    content: "partial output",
+    toolCalls: [],
+    contentBlocks: [],
+    error: "Agent stopped without completing",
+    sessionId: AGENT_SESSION_ID,
+  }
+})
+
+describe("monitorAgent", () => {
+  it("hands the failure handler the snapshot, so it can bill the dying turn", async () => {
+    const onError = vi.fn(async () => {})
+    await monitorAgent(BACKGROUND_SESSION_ID, BACKGROUND_SESSION_ID, daytona, {
+      onComplete: vi.fn(async () => {}),
+      onError,
+    })
+
+    const [, , passed] = onError.mock.calls[0] as unknown as [string, unknown, AgentSnapshot]
+    expect(passed.sessionId).toBe(AGENT_SESSION_ID)
+    expect(passed.sessionId).not.toBe(BACKGROUND_SESSION_ID)
+  })
+
+  it("still reports the error text and kind alongside it", async () => {
+    snapshot = { ...snapshot, error: "Rate limit exceeded", errorKind: "crash" }
+    const onError = vi.fn(async () => {})
+    await monitorAgent(BACKGROUND_SESSION_ID, BACKGROUND_SESSION_ID, daytona, {
+      onComplete: vi.fn(async () => {}),
+      onError,
+    })
+    expect(onError.mock.calls[0].slice(0, 2)).toEqual(["Rate limit exceeded", "crash"])
+  })
+
+  it("does not call the failure handler while the agent is still running", async () => {
+    snapshot = { ...snapshot, status: "running", error: undefined }
+    const onError = vi.fn(async () => {})
+    await monitorAgent(BACKGROUND_SESSION_ID, BACKGROUND_SESSION_ID, daytona, {
+      onComplete: vi.fn(async () => {}),
+      onError,
+    })
+    expect(onError).not.toHaveBeenCalled()
+  })
+})
+
+describe("stopAgent", () => {
+  it("returns the agent session id so a hard timeout can still be billed", async () => {
+    // A 25-minute run is the most expensive kind of failure there is; losing
+    // its id means losing the whole turn's usage.
+    await expect(
+      stopAgent("sandbox_1", BACKGROUND_SESSION_ID, daytona)
+    ).resolves.toBe(AGENT_SESSION_ID)
+  })
+
+  it("reads the id BEFORE cancelling — a cancelled session may not report it", async () => {
+    const order: string[] = []
+    snapshotBackgroundAgent.mockImplementationOnce(async () => {
+      order.push("read-id")
+      return snapshot
+    })
+    cancelBackgroundAgent.mockImplementationOnce(async () => {
+      order.push("cancel")
+    })
+    await stopAgent("sandbox_1", BACKGROUND_SESSION_ID, daytona)
+    expect(order).toEqual(["read-id", "cancel"])
+  })
+
+  it("still cancels when the id cannot be read", async () => {
+    snapshotBackgroundAgent.mockRejectedValueOnce(new Error("sandbox unreachable"))
+    await expect(
+      stopAgent("sandbox_1", BACKGROUND_SESSION_ID, daytona)
+    ).resolves.toBeUndefined()
+    // Stopping a runaway agent matters more than billing it.
+    expect(cancelBackgroundAgent).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/web/app/api/cron/agent-lifecycle/_lib/monitor.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/_lib/monitor.ts
@@ -22,7 +22,17 @@ export async function monitorAgent(
   daytona: Daytona,
   handlers: {
     onComplete: (snapshot: AgentSnapshot) => Promise<void>
-    onError: (error: string, errorKind?: AgentSnapshot["errorKind"]) => Promise<void>
+    /**
+     * `snapshot` carries the agent CLI's own session id, which is the id
+     * tokscale reports usage under — NOT the Daytona backgroundSessionId this
+     * function is called with. A failure handler that wants to bill the dying
+     * turn needs the former, and this is the only place it is known.
+     */
+    onError: (
+      error: string,
+      errorKind: AgentSnapshot["errorKind"],
+      snapshot: AgentSnapshot
+    ) => Promise<void>
   }
 ) {
   try {
@@ -43,7 +53,11 @@ export async function monitorAgent(
       await cancelBackgroundAgent(sandbox, backgroundSessionId, {
         repoPath: `${PATHS.SANDBOX_HOME}/project`,
       })
-      await handlers.onError(snapshot.error ?? "Unknown error", snapshot.errorKind)
+      await handlers.onError(
+        snapshot.error ?? "Unknown error",
+        snapshot.errorKind,
+        snapshot
+      )
     }
     // else still running, check again next cycle
   } catch (err) {
@@ -53,18 +67,33 @@ export async function monitorAgent(
 
 /**
  * Forcibly cancel a running background agent (used on hard-timeout).
+ *
+ * Returns the agent CLI's session id, read before the cancel while the session
+ * is still answering, so the caller can bill the turn it just killed. A timed
+ * out run has usually spent more than any other kind of failure, so losing this
+ * id is expensive. Undefined when the snapshot could not be read.
  */
 export async function stopAgent(
   sandboxId: string,
   backgroundSessionId: string,
   daytona: Daytona
-) {
+): Promise<string | undefined> {
   try {
     const sandbox = await daytona.get(sandboxId)
-    await cancelBackgroundAgent(sandbox, backgroundSessionId, {
-      repoPath: `${PATHS.SANDBOX_HOME}/project`,
-    })
+    const options = { repoPath: `${PATHS.SANDBOX_HOME}/project` }
+    // Read first, cancel second: the id is what makes the usage billable, and
+    // a cancelled session may no longer report it.
+    let agentSessionId: string | undefined
+    try {
+      agentSessionId = (await snapshotBackgroundAgent(sandbox, backgroundSessionId, options))
+        .sessionId
+    } catch (err) {
+      console.error(`[agent-lifecycle] Could not read session id before stop:`, err)
+    }
+    await cancelBackgroundAgent(sandbox, backgroundSessionId, options)
+    return agentSessionId
   } catch (err) {
     console.error(`[agent-lifecycle] Failed to stop agent:`, err)
+    return undefined
   }
 }

--- a/packages/web/app/api/cron/agent-lifecycle/_lib/scheduled.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/_lib/scheduled.ts
@@ -585,7 +585,10 @@ export async function failScheduledRun(
    * about the job itself — a spent daily balance, which clears at UTC midnight
    * — so a couple of capped days can't silently disable it.
    */
-  { countFailure = true }: { countFailure?: boolean } = {}
+  { countFailure = true }: { countFailure?: boolean } = {},
+  /** Agent CLI session id from the snapshot that saw the failure — see
+   * _lib/meter-dying-turn for why backgroundSessionId will not do. */
+  agentSessionId?: string
 ) {
   // Bill what the run already spent, before the chat update below clears
   // backgroundSessionId and — worse — before the sandbox is deleted at the end
@@ -598,7 +601,7 @@ export async function failScheduledRun(
       chatId: run.chatId,
       agent: run.job.agent,
       sandboxId: run.sandboxId,
-      backgroundSessionId: run.backgroundSessionId,
+      agentSessionId,
       daytona,
     })
   }

--- a/packages/web/app/api/cron/agent-lifecycle/route.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/route.ts
@@ -149,8 +149,20 @@ export async function GET(req: Request) {
 
         // Hard timeout: 25 minutes
         if (totalMinutes > INTERACTIVE_HARD_TIMEOUT) {
-          await stopAgent(chat.sandboxId!, chat.backgroundSessionId!, daytona)
-          await markChatError(chat, "Run exceeded 25 minute limit", daytona)
+          // stopAgent reads the agent session id before it cancels, which is
+          // the only chance to learn it: a 25-minute run is the most expensive
+          // kind of failure to leave unbilled.
+          const agentSessionId = await stopAgent(
+            chat.sandboxId!,
+            chat.backgroundSessionId!,
+            daytona
+          )
+          await markChatError(
+            chat,
+            "Run exceeded 25 minute limit",
+            daytona,
+            agentSessionId
+          )
           results.timedOutInteractive++
           continue
         }
@@ -161,7 +173,7 @@ export async function GET(req: Request) {
             await finalizeInteractiveChat(chat, snapshot, daytona)
             results.completedInteractive++
           },
-          onError: async (error, errorKind) => {
+          onError: async (error, errorKind, snapshot) => {
             logLlmProviderError({
               userId: chat.userId,
               agent: chat.agent,
@@ -171,7 +183,7 @@ export async function GET(req: Request) {
               error,
               errorKind,
             })
-            await markChatError(chat, error, daytona)
+            await markChatError(chat, error, daytona, snapshot.sessionId)
           },
         })
       } catch (err) {
@@ -195,10 +207,21 @@ export async function GET(req: Request) {
 
         // Hard timeout: 20 minutes
         if (runningMinutes > SCHEDULED_HARD_TIMEOUT) {
+          let agentSessionId: string | undefined
           if (run.sandboxId && run.backgroundSessionId) {
-            await stopAgent(run.sandboxId, run.backgroundSessionId, daytona)
+            agentSessionId = await stopAgent(
+              run.sandboxId,
+              run.backgroundSessionId,
+              daytona
+            )
           }
-          await failScheduledRun(run, "Run timed out after 20 minutes", daytona)
+          await failScheduledRun(
+            run,
+            "Run timed out after 20 minutes",
+            daytona,
+            {},
+            agentSessionId
+          )
           results.timedOutScheduled++
           continue
         }
@@ -209,7 +232,7 @@ export async function GET(req: Request) {
               await finalizeScheduledRun(run, snapshot, daytona)
               results.completedScheduled++
             },
-            onError: async (error, errorKind) => {
+            onError: async (error, errorKind, snapshot) => {
               logLlmProviderError({
                 userId: run.job.userId,
                 agent: run.job.agent,
@@ -219,7 +242,7 @@ export async function GET(req: Request) {
                 error,
                 errorKind,
               })
-              await failScheduledRun(run, error, daytona)
+              await failScheduledRun(run, error, daytona, {}, snapshot.sessionId)
             },
           })
         }


### PR DESCRIPTION
# Bill a dying turn under the agent's session id

The last gap in metering: **a turn killed by a crash, a rate limit or the
25-minute cap is still recorded as costing nothing.**

## The problem

Two session ids travel through the lifecycle cron and they are easy to mistake
for each other:

| id | what it is |
|---|---|
| `backgroundSessionId` | the Daytona handle used to talk to the sandbox |
| `snapshot.sessionId` | the agent CLI's own session — **what tokscale files usage under** |

Metering matches on the second one, exactly. Hand it the first and it selects
nothing and bills zero: no error, no row, nothing to notice. The two are
different namespaces and never coincide — across all 17,744 usage rows in
production, not one is filed under a value that appears as a
`backgroundSessionId`.

The cron's failure handlers only had the Daytona handle. The agent id existed
in exactly two places and neither shared it:

- `monitorAgent` took a snapshot, saw the failure, then dropped the snapshot
  before calling `onError`
- `stopAgent` cancelled the session without ever reading it

So there was no id to bill with, and every failed turn metered zero.

**Standing cost:** 262 agent-stopped turns billed nothing, including 176 runs
that had been going a full 25 minutes.

## The fix

- `monitorAgent` passes the snapshot to `onError`, as it already does for
  `onComplete`
- `stopAgent` reads the id **before** it cancels — the last moment it is
  knowable — and returns it, which is what makes a 25-minute timeout billable
  at all
- `meterDyingTurn` takes the agent id (falling back to `Chat.sessionId` for a
  resumed turn) and no longer accepts the Daytona handle

## Verification

Run against a real Postgres, driving the actual code paths:

| crash path | billed |
|---|---|
| 25-minute hard timeout | 2,400,000 / 2,400,000 tokens ✓ |
| agent crash | 250,000 / 250,000 ✓ |
| provider rate limit | 90,000 / 90,000 ✓ |
| scheduled run timeout | 800,000 / 800,000 ✓ |

Plus a negative control: passing the Daytona handle on purpose records **0
tokens and leaves the balance untouched** — confirming the ids really are
distinct and that the check can detect the mistake rather than passing
regardless.

Teardown is unaffected — a chat still ends `error` with its session cleared
even when metering fails. Billing must never strand a chat as "running".

Unit tests use deliberately unalike ids, so a future mix-up turns a test red
instead of quietly metering nothing.

330 tests passing. No schema changes.
