### PR TITLE
feat(admin): let an admin paste Claude credentials directly

### DIFF
--- a/packages/web/app/api/admin/refresh-claude-creds/route.ts
+++ b/packages/web/app/api/admin/refresh-claude-creds/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from "next/server"
 import { requireAdmin, isAuthError } from "@/lib/db/api-helpers"
-import { setCookies, listCcAuthRuns } from "@/lib/claude-credentials"
+import {
+  setCookies,
+  writeCredentials,
+  listCcAuthRuns,
+} from "@/lib/claude-credentials"
 import {
   refreshCredentials,
   refreshResultToResponse,
@@ -65,4 +69,60 @@ export async function POST(request: NextRequest) {
     cookiesUpdated,
   })
   return refreshResultToResponse(result)
+}
+
+/**
+ * PUT /api/admin/refresh-claude-creds
+ *
+ * Stores a credentials blob pasted by hand, for when neither refresh path can
+ * run (expired cookies, ccauth blocked) but a working token is available from
+ * somewhere else — previously this meant editing the row in the database.
+ * Body: { credentials: string } — the contents of ~/.claude/.credentials.json.
+ *
+ * The blob is stored as pasted, so every field it carries (expiresAt, scopes,
+ * subscriptionType, …) reaches the sandbox exactly as Claude Code wrote it.
+ */
+export async function PUT(request: NextRequest) {
+  const auth = await requireAdmin()
+  if (isAuthError(auth)) return auth
+
+  const body = (await request.json().catch(() => ({}))) as {
+    credentials?: unknown
+  }
+  const raw = typeof body.credentials === "string" ? body.credentials.trim() : ""
+
+  let parsed: { claudeAiOauth?: Record<string, unknown> }
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return NextResponse.json(
+      { error: "INVALID_CREDENTIALS", message: "Credentials must be valid JSON." },
+      { status: 400 },
+    )
+  }
+
+  const oauth = parsed?.claudeAiOauth
+  if (
+    !oauth ||
+    typeof oauth.accessToken !== "string" ||
+    typeof oauth.refreshToken !== "string"
+  ) {
+    return NextResponse.json(
+      {
+        error: "INVALID_CREDENTIALS",
+        message:
+          "Expected {\"claudeAiOauth\":{\"accessToken\":\"…\",\"refreshToken\":\"…\"}}.",
+      },
+      { status: 400 },
+    )
+  }
+
+  // Re-stringify rather than storing `raw`: the value is echoed into a shell
+  // command when the sandbox writes .credentials.json, so it must be one line.
+  await writeCredentials(JSON.stringify(parsed))
+
+  return NextResponse.json({
+    saved: true,
+    expiresAt: typeof oauth.expiresAt === "number" ? oauth.expiresAt : undefined,
+  })
 }

--- a/packages/web/components/admin/ClaudeCredentials.tsx
+++ b/packages/web/components/admin/ClaudeCredentials.tsx
@@ -8,9 +8,11 @@ import {
   CheckCircle2,
   AlertCircle,
   History,
+  Save,
 } from "lucide-react"
 import {
   useRefreshClaudeCredsMutation,
+  useSetClaudeCredsMutation,
   useCcAuthRunsQuery,
   type CcAuthRun,
 } from "@/lib/query/hooks"
@@ -51,8 +53,10 @@ function StatusBadge({ status }: { status: string }) {
 
 export function ClaudeCredentials() {
   const [cookies, setCookies] = useState("")
+  const [credentials, setCredentials] = useState("")
   const [outcome, setOutcome] = useState<Outcome | null>(null)
   const mutation = useRefreshClaudeCredsMutation()
+  const saveMutation = useSetClaudeCredsMutation()
   const runsQuery = useCcAuthRunsQuery()
 
   const run = (force: boolean) => {
@@ -79,9 +83,29 @@ export function ClaudeCredentials() {
     )
   }
 
-  const pending = mutation.isPending
-  const pendingForce = pending && mutation.variables?.force === true
-  const pendingNormal = pending && mutation.variables?.force !== true
+  const save = () => {
+    setOutcome(null)
+    saveMutation.mutate(credentials.trim(), {
+      onSuccess: (data) => {
+        setOutcome({
+          ok: true,
+          label: "Credentials saved.",
+          expiresAt: data.expiresAt,
+        })
+        // Don't leave the token sitting in the form once it's stored.
+        setCredentials("")
+      },
+      onError: (err) =>
+        setOutcome({
+          ok: false,
+          message: err instanceof Error ? err.message : String(err),
+        }),
+    })
+  }
+
+  const pending = mutation.isPending || saveMutation.isPending
+  const pendingForce = mutation.isPending && mutation.variables?.force === true
+  const pendingNormal = mutation.isPending && mutation.variables?.force !== true
 
   const runs = runsQuery.data?.runs ?? []
 
@@ -152,11 +176,48 @@ export function ClaudeCredentials() {
           </button>
         </div>
 
-        {pending && (
+        {mutation.isPending && (
           <p className="text-xs text-muted-foreground">
             Running ccauth in Daytona — the first run can take a few minutes…
           </p>
         )}
+
+        <div className="space-y-2 border-t pt-4">
+          <label
+            htmlFor="claude-credentials"
+            className="flex items-center gap-2 text-sm font-medium"
+          >
+            <Save className="h-4 w-4 text-muted-foreground" />
+            Set credentials directly
+          </label>
+          <p className="text-xs text-muted-foreground">
+            For when neither refresh can run: paste the contents of a working{" "}
+            <code>~/.claude/.credentials.json</code> and it&apos;s stored as-is.
+          </p>
+          <textarea
+            id="claude-credentials"
+            value={credentials}
+            onChange={(e) => setCredentials(e.target.value)}
+            placeholder='{"claudeAiOauth":{"accessToken":"sk-ant-oat01-...","refreshToken":"sk-ant-ort01-...","expiresAt":1788716247372,...}}'
+            spellCheck={false}
+            rows={5}
+            className="w-full resize-y rounded-lg border bg-background px-3 py-2 font-mono text-xs shadow-sm outline-none transition-colors focus:border-primary/50 focus:ring-2 focus:ring-primary/20"
+          />
+          <button
+            type="button"
+            onClick={save}
+            disabled={pending || !credentials.trim()}
+            className={cn(
+              "inline-flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium transition-all",
+              "hover:bg-accent disabled:cursor-not-allowed disabled:opacity-60",
+            )}
+          >
+            <Save
+              className={cn("h-4 w-4", saveMutation.isPending && "animate-pulse")}
+            />
+            Save credentials
+          </button>
+        </div>
 
         {outcome && (
           <div

--- a/packages/web/lib/query/hooks/index.ts
+++ b/packages/web/lib/query/hooks/index.ts
@@ -43,3 +43,5 @@ export type {
 } from "./useRefreshClaudeCredsMutation"
 export { useCcAuthRunsQuery } from "./useCcAuthRunsQuery"
 export type { CcAuthRun } from "./useCcAuthRunsQuery"
+export { useSetClaudeCredsMutation } from "./useSetClaudeCredsMutation"
+export type { SetClaudeCredsResult } from "./useSetClaudeCredsMutation"

--- a/packages/web/lib/query/hooks/useSetClaudeCredsMutation.ts
+++ b/packages/web/lib/query/hooks/useSetClaudeCredsMutation.ts
@@ -1,0 +1,29 @@
+"use client"
+
+import { useMutation } from "@tanstack/react-query"
+
+export interface SetClaudeCredsResult {
+  saved: true
+  expiresAt?: number
+}
+
+/** Stores a hand-pasted ~/.claude/.credentials.json as the shared credentials. */
+async function setClaudeCreds(credentials: string): Promise<SetClaudeCredsResult> {
+  const response = await fetch("/api/admin/refresh-claude-creds", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ credentials }),
+  })
+
+  const data = await response.json().catch(() => ({}))
+  if (!response.ok) {
+    throw new Error(
+      data.message || data.error || "Failed to save Claude credentials",
+    )
+  }
+  return data
+}
+
+export function useSetClaudeCredsMutation() {
+  return useMutation({ mutationFn: setClaudeCreds })
+}


### PR DESCRIPTION
## Set Claude credentials directly from the  admin page

  Both credential refresh paths can be down at
  the same time — the stored cookies
  expire and `ccauth` gets blocked by Cloudflare.  When that happens the only fix
  today is editing the credentials row in the
  database by hand.

  This adds a manual escape hatch: paste the
  contents of a working
  `~/.claude/.credentials.json` into the admin
  page and it becomes the shared
  credential.

  ### Changes
  - `PUT /api/admin/refresh-claude-creds` —
  admin-only; parses the blob, requires
    `claudeAiOauth.accessToken` and
  `.refreshToken`, and stores it via
    `writeCredentials`. Re-stringified so it
  stays on one line (the value is echoed
    into a shell command when the sandbox writes
  `.credentials.json`).
  - `useSetClaudeCredsMutation` hook + export.
  - `ClaudeCredentials.tsx` — "Set credentials
  directly" textarea and save button;
    the field is cleared on success so the token
  isn't left in the form. The
    refresh buttons' pending/spinner state is now  keyed to the refresh mutation
    only, so saving doesn't make them look like
  they're running.

  
<img width="799" height="401" alt="image" src="https://github.com/user-attachments/assets/ea2bc747-6618-4d04-8025-4236699458c3" />
