### PR TITLE
Feat(help-panel): add Windows keyboard shortcut equivalents

### DIFF
--- a/packages/web/components/modals/HelpModal.tsx
+++ b/packages/web/components/modals/HelpModal.tsx
@@ -44,15 +44,15 @@ export function HelpModal({ open, onClose, isMobile = false }: HelpModalProps) {
             <section>
               <h3 className="font-medium mb-1.5">Keyboard shortcuts</h3>
               <ul className="space-y-1 text-muted-foreground">
-                <li><kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">⌘P</kbd> Search chats, repos, and branches</li>
-                <li><kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">⌘K</kbd> Command palette</li>
-                <li><kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">⌘B</kbd> Toggle sidebar</li>
-                <li><kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">⌘J</kbd> Toggle terminal</li>
-                <li><kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">⌘S</kbd> Skills</li>
-                <li><kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">⌘O</kbd> New chat</li>
-                <li><kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">⌘⇧O</kbd> Branch chat</li>
-                <li><kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">⌥↑/↓</kbd> Switch chats</li>
-                <li><kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">⌥Enter</kbd> or <kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">⇧Enter</kbd> Branch and send to a new chat</li>
+                <li><kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">⌘P</kbd> / <kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">Ctrl+P</kbd> Search chats, repos, and branches</li>
+                <li><kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">⌘K</kbd> / <kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">Ctrl+K</kbd> Command palette</li>
+                <li><kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">⌘B</kbd> / <kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">Ctrl+B</kbd> Toggle sidebar</li>
+                <li><kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">⌘J</kbd> / <kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">Ctrl+J</kbd> Toggle terminal</li>
+                <li><kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">⌘S</kbd> / <kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">Ctrl+S</kbd> Skills</li>
+                <li><kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">⌘O</kbd> / <kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">Ctrl+O</kbd> New chat</li>
+                <li><kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">⌘⇧O</kbd> / <kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">Ctrl+Shift+O</kbd> Branch chat</li>
+                <li><kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">⌥↑/↓</kbd> / <kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">Alt+↑/↓</kbd> Switch chats</li>
+                <li><kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">⌥Enter</kbd> / <kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">Alt+Enter</kbd> or <kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">⇧Enter</kbd> / <kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] font-mono">Shift+Enter</kbd> Branch and send to a new chat</li>
               </ul>
             </section>
 


### PR DESCRIPTION
## Feat(help-panel): add Windows keyboard shortcut equivalents

## Summary
Currently, the Help panel only shows Mac-style keyboard shortcuts (⌘P, ⌘K, etc.), which can be confusing for Windows users — especially beginners who don't have a Mac and aren't familiar with these symbols. This PR adds the corresponding Windows shortcuts (Ctrl, Alt, Shift) next to each Mac shortcut so both platforms are clearly represented.

This improves accessibility and inclusivity by making the shortcuts panel understandable regardless of the user's OS.

### Changes
- Added Windows equivalents alongside existing Mac shortcuts for all entries in the Keyboard Shortcuts section:
  - `⌘P` → `Ctrl+P`
  - `⌘K` → `Ctrl+K`
  - `⌘B` → `Ctrl+B`
  - `⌘J` → `Ctrl+J`
  - `⌘S` → `Ctrl+S`
  - `⌘O` → `Ctrl+O`
  - `⌘⇧O` → `Ctrl+Shift+O`
  - `⌥↑/↓` → `Alt+↑/↓`
  - `⏎Enter` → `Alt+Enter`
  - `⇧Enter` → `Shift+Enter`

### Before / After
| Before | After |
|---|---|
| <img width="280" height="201" alt="Screenshot 2026-09-07 185619" src="https://github.com/user-attachments/assets/d33aaf36-8c11-494a-949e-d7f33c9df875" /> | <img width="280" height="191" alt="image" src="https://github.com/user-attachments/assets/f8490ff5-9fba-4d1f-a031-aece69d60b88" /> |

### Testing
- Tested manually across responsive breakpoints, from 1440px (laptop) down to 325px (small phone).
- Layout holds up at all sizes.

### Considerations
- On very small screens (~325px), the "Branch and send to a new chat" row wraps and stacks onto a new line. This wasn't an expected/intended behavior of the change — flagging it here in case it needs a follow-up fix or is deemed acceptable as-is.