### PR TITLE
Keep agent-picker dot green when shared pool spent

### DIFF
--- a/packages/common/src/agents.ts
+++ b/packages/common/src/agents.ts
@@ -665,17 +665,21 @@ export function agentSharedPoolExhausted(
 /**
  * Whether picking this agent gives free usage out of the box — either a
  * server-provided shared pool (see agentUsesSharedPool) or always-free models
- * that need no API key. Kilo qualifies via its free auto-router and free model
- * tier, which stay available even when the user adds their own Kilo key. Used to
- * surface the "Free usage available" green dot in the agent picker. Returns
- * false once a metered shared pool is exhausted (see agentSharedPoolExhausted).
+ * that need no API key (see getFreeModelForAgent). Kilo qualifies via its free
+ * auto-router and free model tier; OpenCode qualifies via its no-key models
+ * (opencode/big-pickle, etc.) — both stay available even when the user adds
+ * their own key for that agent, and even once a metered shared pool is
+ * exhausted, since they never draw on it. Used to surface the "Free usage
+ * available" green dot in the agent picker. For agents without an always-free
+ * model, this returns false once their shared pool is exhausted (see
+ * agentSharedPoolExhausted).
  */
 export function agentHasFreeUsage(
   agent: Agent,
   flags: CredentialFlags | null | undefined
 ): boolean {
+  if (getFreeModelForAgent(agent)) return true
   if (agentSharedPoolExhausted(agent, flags)) return false
-  if (agent === "kilo") return true
   return agentUsesSharedPool(agent, flags)
 }
 

--- a/packages/web/components/chat/AgentModelSelector.tsx
+++ b/packages/web/components/chat/AgentModelSelector.tsx
@@ -5,7 +5,7 @@ import { ChevronDown, Cpu, Lock } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useModals } from "@/lib/contexts"
 import type { Agent, ModelOption, CredentialFlags, Chat } from "@/lib/types"
-import { getAgentModels, agentLabels, getModelLabel, hasCredentialsForModel, agentHasFreeUsage, agentIsReady, agentSharedPoolExhausted, agentUsesSharedPool, resolveModelForAgent, sharedPoolProviderForModel, formatTokenRate, ALL_AGENTS } from "@/lib/types"
+import { getAgentModels, getFreeModelForAgent, agentLabels, getModelLabel, hasCredentialsForModel, agentHasFreeUsage, agentIsReady, agentSharedPoolExhausted, agentUsesSharedPool, resolveModelForAgent, sharedPoolProviderForModel, formatTokenRate, ALL_AGENTS } from "@/lib/types"
 import { creditTier, discountDivisorFor } from "@/lib/server/credits"
 import { fmtCreditAmount } from "@/lib/format"
 import { useSettingsQuery } from "@/lib/query/hooks/useSettingsQuery"
@@ -62,6 +62,11 @@ const ELIZA_ENV_OVERRIDE = process.env.NEXT_PUBLIC_ENABLE_ELIZA === "true"
  * the balance passed in, so a rounding difference in the float can never leave
  * the dot green on a send the server is about to refuse. `balanceUsd` decides
  * only the advisory yellow, which has no server counterpart.
+ *
+ * An exhausted shared pool never turns the dot red for an agent that also has
+ * an always-free, no-key model (OpenCode's opencode/big-pickle & co., like
+ * Kilo's free auto-router) — that route never touches the balance, so the
+ * agent stays fully usable and the dot stays green.
  */
 type AgentStatusTone = "ready" | "low" | "depleted"
 
@@ -70,7 +75,7 @@ function getAgentStatus(
   flags: CredentialFlags,
   balanceUsd: number | null | undefined
 ): { tone: AgentStatusTone; label: string } | null {
-  if (agentSharedPoolExhausted(agent, flags)) {
+  if (agentSharedPoolExhausted(agent, flags) && !getFreeModelForAgent(agent)) {
     return { tone: "depleted", label: "Out of credits" }
   }
   if (agentUsesSharedPool(agent, flags) && creditTier(balanceUsd) === "low") {
@@ -178,8 +183,10 @@ export function AgentModelSelector({
 
     // Block switching to any agent whose only route is a shared pool the user
     // has no balance left for. agentSharedPoolExhausted is per-agent, so an
-    // agent the user has their own key for stays selectable at zero balance.
-    if (agentSharedPoolExhausted(agent, credentialFlags)) {
+    // agent the user has their own key for stays selectable at zero balance —
+    // and so does an agent with an always-free, no-key model (OpenCode), whose
+    // free tier never touches the balance.
+    if (agentSharedPoolExhausted(agent, credentialFlags) && !getFreeModelForAgent(agent)) {
       showClaudeLimitDialog()
       return
     }

--- a/packages/web/lib/agent-status.test.ts
+++ b/packages/web/lib/agent-status.test.ts
@@ -265,6 +265,24 @@ describe("free models survive a spent balance", () => {
     expect(hasCredentialsForModel(paid, spentWithSharedOpencode, "opencode")).toBe(false)
     expect(modelRequiresKey("opencode", paid.value)).toBe("opencode")
   })
+
+  // The picker dot (AgentModelSelector.getAgentStatus) paints red only when
+  // agentSharedPoolExhausted is true AND the agent has no always-free model to
+  // fall back to. OpenCode always has one, so its dot must stay green even
+  // though the metered shared pool itself is correctly reported as exhausted.
+  it("keeps agentSharedPoolExhausted true (the metered pool really is closed)", () => {
+    expect(agentSharedPoolExhausted("opencode", spentWithSharedOpencode)).toBe(true)
+  })
+
+  it("still reports free usage and readiness despite the exhausted metered pool", () => {
+    expect(agentHasFreeUsage("opencode", spentWithSharedOpencode)).toBe(true)
+    expect(agentIsReady("opencode", spentWithSharedOpencode)).toBe(true)
+  })
+
+  it("reports free usage even with no credentials at all, since the free tier needs none", () => {
+    expect(agentHasFreeUsage("opencode", {})).toBe(true)
+    expect(agentIsReady("opencode", {})).toBe(true)
+  })
 })
 
 /**


### PR DESCRIPTION
Ensures OpenCode’s agent‑picker dot stays green even when the shared pool is exhausted, preserving the visual indicator regardless of pool status.