### PR TITLE
feat(web): cloud environments (part 1: model, API, and UI)

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -31,3 +31,39 @@ export const SANDBOX_CONFIG = {
   /** Timeout in seconds for starting sandbox */
   START_TIMEOUT_SECONDS: 120,
 } as const
+
+// =============================================================================
+// Network baseline
+// =============================================================================
+
+/**
+ * Domains always reachable from a sandbox, even in "restricted" network mode.
+ *
+ * Without these, restricting an environment breaks things the user never chose:
+ * the git clone, the tokscale install at bring-up, and the agent CLI's own API
+ * calls — all of which originate *inside* the sandbox. The environment editor
+ * shows these as non-removable entries so the behavior is visible rather than
+ * surprising.
+ *
+ * A user on a custom endpoint (User.customEndpoints) needs that host appended
+ * at sandbox-creation time; see resolveDomainAllowList.
+ */
+export const BASELINE_DOMAINS = [
+  // Source control
+  "github.com",
+  "api.github.com",
+  "codeload.github.com",
+  "objects.githubusercontent.com",
+  // Package registries
+  "registry.npmjs.org",
+  "pypi.org",
+  "files.pythonhosted.org",
+  // Agent API hosts
+  "api.anthropic.com",
+  "console.anthropic.com",
+  "api.openai.com",
+  "generativelanguage.googleapis.com",
+  "opencode.ai",
+  "server.smithery.ai",
+  "registry.smithery.ai",
+] as const

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -41,7 +41,7 @@ export const SANDBOX_CONFIG = {
  *
  * Without these, restricting an environment breaks things the user never chose:
  * the git clone, the tokscale install at bring-up, and the agent CLI's own API
- * calls — all of which originate *inside* the sandbox. The environment editor
+ * calls: all of which originate *inside* the sandbox. The environment editor
  * shows these as non-removable entries so the behavior is visible rather than
  * surprising.
  *

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -4,7 +4,7 @@
  */
 
 // Constants
-export { PATHS, SANDBOX_CONFIG } from "./constants"
+export { PATHS, SANDBOX_CONFIG, BASELINE_DOMAINS } from "./constants"
 
 // Types
 export type {

--- a/packages/web/app/api/chats/[chatId]/messages/_lib/agent-env.test.ts
+++ b/packages/web/app/api/chats/[chatId]/messages/_lib/agent-env.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const resolveEnvironmentForChat = vi.fn()
+
+vi.mock("@/lib/environments", () => ({ resolveEnvironmentForChat }))
+vi.mock("@background-agents/common", () => ({
+  getEnvForModel: () => ({ SYSTEM_VAR: "system" }),
+}))
+vi.mock("@/lib/db/prisma", () => ({ prisma: {} }))
+vi.mock("@/lib/types", () => ({ NEW_REPOSITORY: "__new__" }))
+vi.mock("@/lib/db/encryption", () => ({
+  decrypt: (v: string) => v.replace("enc:", ""),
+}))
+
+const { buildAgentEnv } = await import("./agent-env")
+
+const baseParams = {
+  userId: "user_1",
+  payload: { model: "claude-sonnet-4", agent: "claude" },
+  credentials: {},
+  customEndpoints: [],
+} as never as Parameters<typeof buildAgentEnv>[0]
+
+function chat(overrides: Record<string, unknown> = {}) {
+  return { userId: "user_1", repo: "acme/app", environmentId: null, environmentVariables: null, ...overrides }
+}
+
+describe("buildAgentEnv", () => {
+  beforeEach(() => resolveEnvironmentForChat.mockReset())
+
+  it("merges the resolved environment's variables over the system env", async () => {
+    resolveEnvironmentForChat.mockResolvedValue({ variables: { API_KEY: "from-env" } })
+    const env = await buildAgentEnv({ ...baseParams, chat: chat() as never })
+    expect(env).toMatchObject({ SYSTEM_VAR: "system", API_KEY: "from-env" })
+  })
+
+  it("lets chat-level variables override the environment's", async () => {
+    resolveEnvironmentForChat.mockResolvedValue({ variables: { API_KEY: "from-env" } })
+    const env = await buildAgentEnv({
+      ...baseParams,
+      chat: chat({ environmentVariables: { API_KEY: "enc:from-chat" } }) as never,
+    })
+    expect(env.API_KEY).toBe("from-chat")
+  })
+
+  it("lets user variables override system variables", async () => {
+    resolveEnvironmentForChat.mockResolvedValue({ variables: { SYSTEM_VAR: "overridden" } })
+    const env = await buildAgentEnv({ ...baseParams, chat: chat() as never })
+    expect(env.SYSTEM_VAR).toBe("overridden")
+  })
+
+  it("works when the chat resolves to no environment (NEW_REPOSITORY)", async () => {
+    resolveEnvironmentForChat.mockResolvedValue(null)
+    const env = await buildAgentEnv({ ...baseParams, chat: chat({ repo: "__new__" }) as never })
+    expect(env).toEqual({ SYSTEM_VAR: "system" })
+  })
+})

--- a/packages/web/app/api/chats/[chatId]/messages/_lib/agent-env.ts
+++ b/packages/web/app/api/chats/[chatId]/messages/_lib/agent-env.ts
@@ -1,6 +1,5 @@
-import { prisma } from "@/lib/db/prisma"
 import { decrypt } from "@/lib/db/encryption"
-import { NEW_REPOSITORY } from "@/lib/types"
+import { resolveEnvironmentForChat } from "@/lib/environments"
 import { getEnvForModel, type CustomEndpoint } from "@background-agents/common"
 import type { Agent } from "@/lib/agent-session"
 import type { Credentials } from "@/lib/credentials"
@@ -8,8 +7,8 @@ import type { ChatRecord, MessagePayload } from "./types"
 
 /**
  * Build the environment passed to the agent process: the model/agent system env
- * merged with the user's decrypted env vars (repo-level first, then chat-level
- * overriding). User vars take precedence over system vars.
+ * merged with the user's decrypted env vars (environment-level first, then
+ * chat-level overriding). User vars take precedence over system vars.
  */
 export async function buildAgentEnv(params: {
   chat: ChatRecord
@@ -22,26 +21,24 @@ export async function buildAgentEnv(params: {
 
   const systemEnv = getEnvForModel(payload.model, payload.agent as Agent, credentials, customEndpoints)
 
-  // Fetch user-defined environment variables (repo-level then chat-level, chat takes precedence)
+  // Fetch user-defined environment variables (environment-level then chat-level, chat takes precedence)
   const userEnv: Record<string, string> = {}
 
-  // Get repo-level env vars from user
-  if (chat.repo !== NEW_REPOSITORY) {
-    const user = await prisma.user.findUnique({
-      where: { id: userId },
-      select: { repoEnvironmentVariables: true },
-    })
-    const repoEnvVars = (user?.repoEnvironmentVariables as Record<string, Record<string, string>>)?.[chat.repo]
-    if (repoEnvVars) {
-      for (const [key, encryptedValue] of Object.entries(repoEnvVars)) {
-        if (encryptedValue) {
-          userEnv[key] = decrypt(encryptedValue)
-        }
-      }
-    }
+  // Environment-level vars, read fresh every turn so an edit in /environments
+  // takes effect on the next message rather than waiting for the sandbox to be
+  // recreated. (The same values are also passed to daytona.create as sandbox
+  // env for the setup script and the terminal; that copy is create-time only,
+  // which is why this read has to stay.)
+  const environment = await resolveEnvironmentForChat({
+    userId,
+    repo: chat.repo,
+    environmentId: chat.environmentId ?? null,
+  })
+  if (environment) {
+    Object.assign(userEnv, environment.variables)
   }
 
-  // Get chat-level env vars (overrides repo-level)
+  // Get chat-level env vars (overrides environment-level)
   const chatEnvVars = chat.environmentVariables as Record<string, string> | null
   if (chatEnvVars) {
     for (const [key, encryptedValue] of Object.entries(chatEnvVars)) {

--- a/packages/web/app/api/chats/[chatId]/messages/_lib/ensure-sandbox.test.ts
+++ b/packages/web/app/api/chats/[chatId]/messages/_lib/ensure-sandbox.test.ts
@@ -95,6 +95,7 @@ function createArg() {
     newBranch: string
     restoreExistingBranch: boolean
     repo: string
+    environment: unknown
   }
 }
 
@@ -124,6 +125,30 @@ describe("ensureSandboxForChat — first-time creation", () => {
     expect(createArg().restoreExistingBranch).toBe(false)
     expect(chat.sessionId).toBeNull()
     expect(readyUpdate()!.data).toHaveProperty("sessionId", null)
+  })
+
+  it("resolves the chat's environment and forwards it to createSandboxForChat", async () => {
+    const resolvedEnvironment = {
+      id: "env_123",
+      name: "Staging",
+      repo: "octocat/hello",
+      isDefault: false,
+      networkMode: "full",
+      allowedDomains: [],
+      variables: { NPM_TOKEN: "tok" },
+      setupScript: null,
+    }
+    resolveEnvironmentForChat.mockResolvedValue(resolvedEnvironment)
+    const { params } = setup()
+
+    await ensureSandboxForChat(params)
+
+    expect(resolveEnvironmentForChat).toHaveBeenCalledWith({
+      userId: "user-1",
+      repo: "octocat/hello",
+      environmentId: null,
+    })
+    expect(createArg().environment).toBe(resolvedEnvironment)
   })
 })
 

--- a/packages/web/app/api/chats/[chatId]/messages/_lib/ensure-sandbox.test.ts
+++ b/packages/web/app/api/chats/[chatId]/messages/_lib/ensure-sandbox.test.ts
@@ -29,6 +29,14 @@ vi.mock("@/lib/sandbox", () => ({
     installSkillsForRepo(s, u, r),
 }))
 
+// This suite only exercises sandbox-lifecycle branching, not environment
+// resolution (that's covered by lib/environments.test.ts and
+// lib/sandbox-create-params.test.ts), so stub it out to a fixed value.
+const resolveEnvironmentForChat = vi.fn()
+vi.mock("@/lib/environments", () => ({
+  resolveEnvironmentForChat: (args: unknown) => resolveEnvironmentForChat(args),
+}))
+
 import { ensureSandboxForChat, type SandboxState } from "./ensure-sandbox"
 
 const freshSandbox = { id: "sbx-new", state: "started" }
@@ -102,6 +110,7 @@ beforeEach(() => {
   })
   ensureSandboxStarted.mockReset().mockResolvedValue(undefined)
   installSkillsForRepo.mockReset().mockResolvedValue({ installed: 0, total: 0 })
+  resolveEnvironmentForChat.mockReset().mockResolvedValue(null)
 })
 
 describe("ensureSandboxForChat — first-time creation", () => {

--- a/packages/web/app/api/chats/[chatId]/messages/_lib/ensure-sandbox.ts
+++ b/packages/web/app/api/chats/[chatId]/messages/_lib/ensure-sandbox.ts
@@ -2,6 +2,7 @@ import { Daytona } from "@daytonaio/sdk"
 import { randomUUID } from "crypto"
 import { NEW_REPOSITORY } from "@/lib/types"
 import { prisma } from "@/lib/db/prisma"
+import { resolveEnvironmentForChat } from "@/lib/environments"
 import {
   createSandboxForChat,
   ensureSandboxStarted,
@@ -110,6 +111,14 @@ export async function ensureSandboxForChat(params: {
     const restoreExistingBranch = !!branch
     const newBranch = branch ?? payload.newBranch ?? `agent/${randomUUID().slice(0, 8)}`
 
+    // Resolve the chat's environment (pinned, or the repo's default). Null only
+    // for NEW_REPOSITORY chats.
+    const environment = await resolveEnvironmentForChat({
+      userId,
+      repo: chat.repo,
+      environmentId: chat.environmentId ?? null,
+    })
+
     const created = await createSandboxForChat({
       daytona,
       repo: chat.repo,
@@ -118,6 +127,7 @@ export async function ensureSandboxForChat(params: {
       githubToken: githubToken ?? undefined,
       userId,
       restoreExistingBranch,
+      environment,
     })
 
     sandbox = created.sandbox

--- a/packages/web/app/api/chats/[chatId]/route.test.ts
+++ b/packages/web/app/api/chats/[chatId]/route.test.ts
@@ -225,5 +225,27 @@ describe("PATCH /api/chats/[chatId]: environmentId", () => {
       expect(res.status).toBe(200)
       expect(getOrCreateDefaultEnvironment).not.toHaveBeenCalled()
     })
+
+    it("allows a NEW_REPOSITORY chat with a sandbox to publish to a real repo, pinning the new repo's default environment", async () => {
+      getChatWithAuth.mockResolvedValueOnce(
+        existingChat({ sandboxId: "sb_1", repo: "__new__", environmentId: null })
+      )
+      getOrCreateDefaultEnvironment.mockResolvedValueOnce({ id: "env_acme_app_default" })
+      chat.update.mockResolvedValueOnce(
+        updatedChatRow({
+          sandboxId: "sb_1",
+          repo: "acme/app",
+          environmentId: "env_acme_app_default",
+        })
+      )
+
+      const res = await callPatch("chat_1", { repo: "acme/app" })
+      const body = await res.json()
+
+      expect(getOrCreateDefaultEnvironment).toHaveBeenCalledWith("u1", "acme/app")
+      expect(chat.update.mock.calls[0][0].data.environmentId).toBe("env_acme_app_default")
+      expect(res.status).toBe(200)
+      expect(body.repo).toBe("acme/app")
+    })
   })
 })

--- a/packages/web/app/api/chats/[chatId]/route.test.ts
+++ b/packages/web/app/api/chats/[chatId]/route.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// Mock the prisma singleton so route logic can be exercised without a DB.
+const { chat, environment } = vi.hoisted(() => ({
+  chat: {
+    update: vi.fn(),
+    findMany: vi.fn(),
+    updateMany: vi.fn(),
+  },
+  environment: {
+    findFirst: vi.fn(),
+  },
+}))
+vi.mock("@/lib/db/prisma", () => ({ prisma: { chat, environment } }))
+
+const { getChatWithAuth } = vi.hoisted(() => ({
+  getChatWithAuth: vi.fn(),
+}))
+vi.mock("@/lib/db/api-helpers", () => ({
+  requireAuth: vi.fn(async () => ({ userId: "u1" })),
+  isAuthError: vi.fn(() => false),
+  getChatWithAuth,
+  badRequest: vi.fn((message: string) => Response.json({ error: message }, { status: 400 })),
+  notFound: vi.fn((message: string) => Response.json({ error: message }, { status: 404 })),
+  internalError: vi.fn((error: unknown) =>
+    Response.json({ error: String(error) }, { status: 500 })
+  ),
+}))
+
+const { getOrCreateDefaultEnvironment } = vi.hoisted(() => ({
+  getOrCreateDefaultEnvironment: vi.fn(),
+}))
+vi.mock("@/lib/environments", () => ({ getOrCreateDefaultEnvironment }))
+
+import { PATCH } from "./route"
+
+function makeRequest(body: unknown) {
+  return new Request("http://localhost/api/chats/chat_1", {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  }) as unknown as import("next/server").NextRequest
+}
+
+function existingChat(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "chat_1",
+    userId: "u1",
+    repo: "acme/app",
+    baseBranch: "main",
+    branch: null,
+    sandboxId: null,
+    sessionId: null,
+    previewUrlPattern: null,
+    backgroundSessionId: null,
+    agent: "claude-code",
+    model: null,
+    planModeEnabled: false,
+    displayName: null,
+    shareId: null,
+    status: "pending",
+    archived: false,
+    pinned: false,
+    parentChatId: null,
+    needsSync: false,
+    environmentVariables: null,
+    environmentId: "env_old",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    lastActiveAt: new Date(),
+    ...overrides,
+  }
+}
+
+function updatedChatRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    ...existingChat(),
+    ...overrides,
+  }
+}
+
+async function callPatch(chatId: string, body: unknown) {
+  return PATCH(makeRequest(body), { params: Promise.resolve({ chatId }) })
+}
+
+beforeEach(() => {
+  chat.update.mockReset()
+  chat.findMany.mockReset()
+  chat.updateMany.mockReset()
+  environment.findFirst.mockReset()
+  getChatWithAuth.mockReset()
+  getOrCreateDefaultEnvironment.mockReset()
+})
+
+describe("PATCH /api/chats/[chatId]: environmentId", () => {
+  it("accepts an explicit environmentId that belongs to the chat's current repo", async () => {
+    getChatWithAuth.mockResolvedValueOnce(existingChat())
+    environment.findFirst.mockResolvedValueOnce({ id: "env_new" })
+    chat.update.mockResolvedValueOnce(updatedChatRow({ environmentId: "env_new" }))
+
+    const res = await callPatch("chat_1", { environmentId: "env_new" })
+    const body = await res.json()
+
+    expect(environment.findFirst).toHaveBeenCalledWith({
+      where: { id: "env_new", userId: "u1", repo: "acme/app" },
+      select: { id: true },
+    })
+    expect(chat.update.mock.calls[0][0].data.environmentId).toBe("env_new")
+    expect(res.status).toBe(200)
+    expect(body.environmentId).toBe("env_new")
+  })
+
+  it("rejects an environmentId that belongs to a different repo", async () => {
+    getChatWithAuth.mockResolvedValueOnce(existingChat())
+    environment.findFirst.mockResolvedValueOnce(null)
+
+    const res = await callPatch("chat_1", { environmentId: "someone-elses-env" })
+
+    expect(res.status).toBe(400)
+    expect(chat.update).not.toHaveBeenCalled()
+  })
+
+  it("re-resolves the default environment when the repo changes without an explicit environmentId", async () => {
+    getChatWithAuth.mockResolvedValueOnce(existingChat({ repo: "acme/app" }))
+    getOrCreateDefaultEnvironment.mockResolvedValueOnce({ id: "env_acme_other_default" })
+    chat.update.mockResolvedValueOnce(
+      updatedChatRow({ repo: "acme/other", environmentId: "env_acme_other_default" })
+    )
+
+    const res = await callPatch("chat_1", { repo: "acme/other" })
+    const body = await res.json()
+
+    expect(getOrCreateDefaultEnvironment).toHaveBeenCalledWith("u1", "acme/other")
+    expect(chat.update.mock.calls[0][0].data.environmentId).toBe("env_acme_other_default")
+    expect(body.environmentId).toBe("env_acme_other_default")
+  })
+
+  it("clears environmentId when the repo changes to NEW_REPOSITORY without an explicit environmentId", async () => {
+    getChatWithAuth.mockResolvedValueOnce(existingChat({ repo: "acme/app" }))
+    chat.update.mockResolvedValueOnce(updatedChatRow({ repo: "__new__", environmentId: null }))
+
+    const res = await callPatch("chat_1", { repo: "__new__" })
+    const body = await res.json()
+
+    expect(getOrCreateDefaultEnvironment).not.toHaveBeenCalled()
+    expect(chat.update.mock.calls[0][0].data.environmentId).toBeNull()
+    expect(body.environmentId).toBeNull()
+  })
+
+  it("validates an explicit environmentId against the new repo when both are sent in the same PATCH", async () => {
+    getChatWithAuth.mockResolvedValueOnce(existingChat({ repo: "acme/app" }))
+    environment.findFirst.mockResolvedValueOnce({ id: "env_new_repo" })
+    chat.update.mockResolvedValueOnce(
+      updatedChatRow({ repo: "acme/other", environmentId: "env_new_repo" })
+    )
+
+    const res = await callPatch("chat_1", { repo: "acme/other", environmentId: "env_new_repo" })
+
+    expect(environment.findFirst).toHaveBeenCalledWith({
+      where: { id: "env_new_repo", userId: "u1", repo: "acme/other" },
+      select: { id: true },
+    })
+    expect(getOrCreateDefaultEnvironment).not.toHaveBeenCalled()
+    expect(res.status).toBe(200)
+  })
+
+  it("leaves environmentId untouched when neither repo nor environmentId is in the PATCH", async () => {
+    getChatWithAuth.mockResolvedValueOnce(existingChat())
+    chat.update.mockResolvedValueOnce(updatedChatRow({ displayName: "Renamed" }))
+
+    await callPatch("chat_1", { displayName: "Renamed" })
+
+    expect(chat.update.mock.calls[0][0].data.environmentId).toBeUndefined()
+    expect(environment.findFirst).not.toHaveBeenCalled()
+    expect(getOrCreateDefaultEnvironment).not.toHaveBeenCalled()
+  })
+})

--- a/packages/web/app/api/chats/[chatId]/route.test.ts
+++ b/packages/web/app/api/chats/[chatId]/route.test.ts
@@ -173,4 +173,57 @@ describe("PATCH /api/chats/[chatId]: environmentId", () => {
     expect(environment.findFirst).not.toHaveBeenCalled()
     expect(getOrCreateDefaultEnvironment).not.toHaveBeenCalled()
   })
+
+  it("rejects a non-string environmentId (including null) with a 400, not an internal error", async () => {
+    getChatWithAuth.mockResolvedValueOnce(existingChat())
+
+    const res = await callPatch("chat_1", { environmentId: null })
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.error).toContain("environmentId")
+    expect(environment.findFirst).not.toHaveBeenCalled()
+    expect(chat.update).not.toHaveBeenCalled()
+  })
+
+  describe("once the chat has a sandbox", () => {
+    it("rejects an explicit environmentId change with a 400", async () => {
+      getChatWithAuth.mockResolvedValueOnce(existingChat({ sandboxId: "sb_1" }))
+
+      const res = await callPatch("chat_1", { environmentId: "env_new" })
+
+      expect(res.status).toBe(400)
+      expect(environment.findFirst).not.toHaveBeenCalled()
+      expect(chat.update).not.toHaveBeenCalled()
+    })
+
+    it("rejects a repo change that would re-resolve environmentId with a 400", async () => {
+      getChatWithAuth.mockResolvedValueOnce(existingChat({ sandboxId: "sb_1", repo: "acme/app" }))
+
+      const res = await callPatch("chat_1", { repo: "acme/other" })
+
+      expect(res.status).toBe(400)
+      expect(getOrCreateDefaultEnvironment).not.toHaveBeenCalled()
+      expect(chat.update).not.toHaveBeenCalled()
+    })
+
+    it("still allows an unrelated field update (no repo or environmentId in the body)", async () => {
+      getChatWithAuth.mockResolvedValueOnce(existingChat({ sandboxId: "sb_1" }))
+      chat.update.mockResolvedValueOnce(updatedChatRow({ sandboxId: "sb_1", displayName: "Renamed" }))
+
+      const res = await callPatch("chat_1", { displayName: "Renamed" })
+
+      expect(res.status).toBe(200)
+    })
+
+    it("still allows setting repo to its own current value (no-op repo, no environment re-resolution)", async () => {
+      getChatWithAuth.mockResolvedValueOnce(existingChat({ sandboxId: "sb_1", repo: "acme/app" }))
+      chat.update.mockResolvedValueOnce(updatedChatRow({ sandboxId: "sb_1", repo: "acme/app" }))
+
+      const res = await callPatch("chat_1", { repo: "acme/app", baseBranch: "main" })
+
+      expect(res.status).toBe(200)
+      expect(getOrCreateDefaultEnvironment).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/web/app/api/chats/[chatId]/route.ts
+++ b/packages/web/app/api/chats/[chatId]/route.ts
@@ -9,6 +9,8 @@ import {
   internalError,
 } from "@/lib/db/api-helpers"
 import { logActivityAsync } from "@/lib/db/activity-log"
+import { getOrCreateDefaultEnvironment } from "@/lib/environments"
+import { NEW_REPOSITORY } from "@/lib/types"
 
 // =============================================================================
 // Helpers
@@ -72,6 +74,7 @@ interface ChatWithMessagesResponse {
   agent: string
   model: string | null
   planModeEnabled: boolean
+  environmentId: string | null
   displayName: string | null
   shareId: string | null
   status: string
@@ -188,6 +191,7 @@ export async function GET(
       agent: chat.agent,
       model: chat.model,
       planModeEnabled: chat.planModeEnabled,
+      environmentId: chat.environmentId,
       displayName: chat.displayName,
       shareId: chat.shareId,
       status: chat.status,
@@ -242,6 +246,7 @@ interface PatchChatBody {
   branch?: string
   needsSync?: boolean
   lastActiveAt?: number
+  environmentId?: string
   // NOTE: sandboxId, sessionId, previewUrlPattern and backgroundSessionId are
   // intentionally NOT accepted here. They are server-managed — written only by
   // the message/stream flow (ensure-sandbox, persist-turn, persist-snapshot) —
@@ -289,6 +294,30 @@ export async function PATCH(
     if (body.needsSync !== undefined) updateData.needsSync = body.needsSync
     if (body.lastActiveAt !== undefined) updateData.lastActiveAt = new Date(body.lastActiveAt)
 
+    if (body.environmentId !== undefined) {
+      // An explicit environment must belong to this user AND to the repo the
+      // chat will end up on (its new repo if one is also being set in this
+      // same PATCH, otherwise its current one), otherwise a chat could be
+      // pinned to another repo's variables.
+      const targetRepo = body.repo ?? chat.repo
+      const requested = await prisma.environment.findFirst({
+        where: { id: body.environmentId, userId, repo: targetRepo },
+        select: { id: true },
+      })
+      if (!requested) return badRequest("Invalid environmentId")
+      updateData.environmentId = requested.id
+    } else if (body.repo !== undefined && body.repo !== chat.repo) {
+      // Changing repo without an explicit environment invalidates whatever
+      // was pinned for the old repo (an environment id is only ever valid
+      // for the repo it belongs to). Re-resolve exactly like POST /api/chats
+      // does rather than leaving the chat pointed at another repo's
+      // environment and its variables.
+      updateData.environmentId =
+        body.repo === NEW_REPOSITORY
+          ? null
+          : (await getOrCreateDefaultEnvironment(userId, body.repo)).id
+    }
+
     if (Object.keys(updateData).length === 0) {
       return badRequest("No valid fields to update")
     }
@@ -325,6 +354,7 @@ export async function PATCH(
       agent: updatedChat.agent,
       model: updatedChat.model,
       planModeEnabled: updatedChat.planModeEnabled,
+      environmentId: updatedChat.environmentId,
       displayName: updatedChat.displayName,
       shareId: updatedChat.shareId,
       status: updatedChat.status,

--- a/packages/web/app/api/chats/[chatId]/route.ts
+++ b/packages/web/app/api/chats/[chatId]/route.ts
@@ -276,6 +276,25 @@ export async function PATCH(
       return notFound("Chat not found")
     }
 
+    // Once a chat has a sandbox, its environment is fixed: resolveEnvironmentForChat
+    // (agent-env.ts) re-resolves the environment fresh on every turn, but network
+    // mode is baked into the sandbox only at creation time. Letting an explicit
+    // environmentId, or a repo change that re-resolves one, through after the
+    // sandbox exists would inject a different environment's variables into a
+    // sandbox still running under the old one's network mode on the very next
+    // turn, a split-brain state reachable with one PATCH. The client already
+    // disables the picker at this point; this is the server-side half of that.
+    if (
+      chat.sandboxId &&
+      (body.environmentId !== undefined || (body.repo !== undefined && body.repo !== chat.repo))
+    ) {
+      return badRequest("Cannot change repo or environmentId once the chat has a sandbox")
+    }
+
+    if (body.environmentId !== undefined && typeof body.environmentId !== "string") {
+      return badRequest("environmentId must be a string")
+    }
+
     // Build update data
     const updateData: Record<string, unknown> = {}
 

--- a/packages/web/app/api/chats/[chatId]/route.ts
+++ b/packages/web/app/api/chats/[chatId]/route.ts
@@ -284,8 +284,17 @@ export async function PATCH(
     // sandbox still running under the old one's network mode on the very next
     // turn, a split-brain state reachable with one PATCH. The client already
     // disables the picker at this point; this is the server-side half of that.
+    //
+    // Exempt the NEW_REPOSITORY -> real repo transition: a "__new__" chat's
+    // sandbox was created with environment: null (full network, no vars), and
+    // full is the only reachable network mode today, so re-resolving to the
+    // new repo's default on the next turn matches pre-branch behavior exactly.
+    // This exemption needs revisiting if restricted mode ever becomes
+    // enforceable, since a repo's default environment could then carry a
+    // network mode the already-running sandbox never agreed to.
     if (
       chat.sandboxId &&
+      chat.repo !== NEW_REPOSITORY &&
       (body.environmentId !== undefined || (body.repo !== undefined && body.repo !== chat.repo))
     ) {
       return badRequest("Cannot change repo or environmentId once the chat has a sandbox")

--- a/packages/web/app/api/chats/route.ts
+++ b/packages/web/app/api/chats/route.ts
@@ -157,7 +157,7 @@ export async function POST(req: NextRequest): Promise<Response> {
     }
 
     // Pin the chat to an environment. An explicit id must belong to this user
-    // and to the same repo — otherwise a chat could be built from another
+    // and to the same repo: otherwise a chat could be built from another
     // repo's variables. Anything else falls back to the repo's default.
     let environmentId: string | null = null
     if (body.repo !== NEW_REPOSITORY) {

--- a/packages/web/app/api/chats/route.ts
+++ b/packages/web/app/api/chats/route.ts
@@ -16,6 +16,8 @@ import {
   type Agent,
 } from "@background-agents/common"
 import { getEffectiveCredentialFlags } from "@/lib/server/credential-flags"
+import { getOrCreateDefaultEnvironment } from "@/lib/environments"
+import { NEW_REPOSITORY } from "@/lib/types"
 
 // =============================================================================
 // Types
@@ -33,6 +35,7 @@ interface ChatResponse {
   agent: string
   model: string | null
   planModeEnabled: boolean
+  environmentId: string | null
   displayName: string | null
   shareId: string | null
   status: string
@@ -94,6 +97,7 @@ export async function GET(req: NextRequest): Promise<Response> {
       agent: chat.agent,
       model: chat.model,
       planModeEnabled: chat.planModeEnabled,
+      environmentId: chat.environmentId,
       displayName: chat.displayName,
       shareId: chat.shareId,
       status: chat.status,
@@ -126,6 +130,7 @@ interface CreateChatBody {
   model?: string
   status?: string
   planModeEnabled?: boolean
+  environmentId?: string
 }
 
 export async function POST(req: NextRequest): Promise<Response> {
@@ -148,6 +153,23 @@ export async function POST(req: NextRequest): Promise<Response> {
       })
       if (!parentChat || parentChat.userId !== userId) {
         return badRequest("Invalid parentChatId")
+      }
+    }
+
+    // Pin the chat to an environment. An explicit id must belong to this user
+    // and to the same repo — otherwise a chat could be built from another
+    // repo's variables. Anything else falls back to the repo's default.
+    let environmentId: string | null = null
+    if (body.repo !== NEW_REPOSITORY) {
+      if (body.environmentId) {
+        const requested = await prisma.environment.findFirst({
+          where: { id: body.environmentId, userId, repo: body.repo },
+          select: { id: true },
+        })
+        if (!requested) return badRequest("Invalid environmentId")
+        environmentId = requested.id
+      } else {
+        environmentId = (await getOrCreateDefaultEnvironment(userId, body.repo)).id
       }
     }
 
@@ -183,6 +205,7 @@ export async function POST(req: NextRequest): Promise<Response> {
         model: finalModel,
         status: body.status ?? "pending",
         planModeEnabled: body.planModeEnabled ?? false,
+        environmentId,
       },
     })
 
@@ -198,6 +221,7 @@ export async function POST(req: NextRequest): Promise<Response> {
       agent: chat.agent,
       model: chat.model,
       planModeEnabled: chat.planModeEnabled,
+      environmentId: chat.environmentId,
       displayName: chat.displayName,
       shareId: chat.shareId,
       status: chat.status,

--- a/packages/web/app/api/cron/agent-lifecycle/_lib/scheduled.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/_lib/scheduled.ts
@@ -15,6 +15,7 @@ import { meterAssistantTurn } from "@/lib/server/token-metering"
 import { buildUsageMeta } from "@/lib/server/shared-pool"
 import { PATHS } from "@/lib/constants"
 import { NEW_REPOSITORY } from "@/lib/types"
+import { getOrCreateDefaultEnvironment } from "@/lib/environments"
 import { createSandboxForChat, deleteSandboxQuietly } from "@/lib/sandbox"
 import {
   createBackgroundAgentSession,
@@ -152,6 +153,10 @@ export async function startJobExecution(
 
   // 5. Create fresh sandbox. createSandboxForChat detects NEW_REPOSITORY and
   //    skips the clone path, so we don't need the GitHub token in that case.
+  // Scheduled jobs have no per-job environment picker (job.repo is always a
+  // real "owner/repo", never NEW_REPOSITORY), so resolve the repo's default
+  // environment directly rather than through resolveEnvironmentForChat.
+  const environment = await getOrCreateDefaultEnvironment(job.userId, job.repo)
   const branch = `scheduled/${job.id}/${format(new Date(), "yyyyMMdd-HHmmss")}`
   const { sandbox, sandboxId, previewUrlPattern } = await createSandboxForChat({
     daytona,
@@ -160,6 +165,7 @@ export async function startJobExecution(
     newBranch: branch,
     githubToken: account?.access_token ?? undefined,
     userId: job.userId,
+    environment,
   })
 
   // 6. Update chat with sandbox info

--- a/packages/web/app/api/cron/agent-lifecycle/_lib/scheduled.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/_lib/scheduled.ts
@@ -153,10 +153,15 @@ export async function startJobExecution(
 
   // 5. Create fresh sandbox. createSandboxForChat detects NEW_REPOSITORY and
   //    skips the clone path, so we don't need the GitHub token in that case.
-  // Scheduled jobs have no per-job environment picker (job.repo is always a
-  // real "owner/repo", never NEW_REPOSITORY), so resolve the repo's default
-  // environment directly rather than through resolveEnvironmentForChat.
-  const environment = await getOrCreateDefaultEnvironment(job.userId, job.repo)
+  // Scheduled jobs have no per-job environment picker, so resolve the repo's
+  // default environment directly rather than through resolveEnvironmentForChat
+  // (which exists for the pinned-vs-default Chat case). Repo-less jobs
+  // (isRepoLess, job.repo === NEW_REPOSITORY) have no repo to scope an
+  // environment to, so they resolve to none, matching the reasoning in
+  // resolveEnvironmentForChat.
+  const environment = isRepoLess
+    ? null
+    : await getOrCreateDefaultEnvironment(job.userId, job.repo)
   const branch = `scheduled/${job.id}/${format(new Date(), "yyyyMMdd-HHmmss")}`
   const { sandbox, sandboxId, previewUrlPattern } = await createSandboxForChat({
     daytona,

--- a/packages/web/app/api/environments/[id]/route.test.ts
+++ b/packages/web/app/api/environments/[id]/route.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest"
 
 // Mock the prisma singleton so route logic can be exercised without a DB.
 // `vi.hoisted` lets the factory (which is hoisted above imports) see the mocks.
-const { environment } = vi.hoisted(() => ({
+const { environment, transaction } = vi.hoisted(() => ({
   environment: {
     findFirst: vi.fn(),
     update: vi.fn(),
@@ -10,9 +10,10 @@ const { environment } = vi.hoisted(() => ({
     delete: vi.fn(),
     count: vi.fn(),
   },
+  transaction: vi.fn(async (ops: Promise<unknown>[]) => Promise.all(ops)),
 }))
 vi.mock("@/lib/db/prisma", () => ({
-  prisma: { environment, $transaction: vi.fn(async (ops: Promise<unknown>[]) => Promise.all(ops)) },
+  prisma: { environment, $transaction: transaction },
 }))
 
 vi.mock("@/lib/db/api-helpers", () => ({
@@ -25,8 +26,30 @@ vi.mock("@/lib/db/api-helpers", () => ({
   ),
 }))
 
+import { Prisma } from "@prisma/client"
 import { GET, PATCH, DELETE } from "./route"
 import { decryptEnvironmentVariables } from "@/lib/environments"
+
+// Shape copied from a real P2002 forced against the scratch DB via
+// @prisma/adapter-pg (Prisma 7.8.0). See task-6-report.md's smoke-test
+// section for the transcript that produced this.
+function p2002(fields: string[]): Prisma.PrismaClientKnownRequestError {
+  return new Prisma.PrismaClientKnownRequestError("Unique constraint failed on the fields", {
+    code: "P2002",
+    clientVersion: "test",
+    meta: {
+      modelName: "Environment",
+      driverAdapterError: {
+        name: "DriverAdapterError",
+        cause: {
+          originalCode: "23505",
+          kind: "UniqueConstraintViolation",
+          constraint: { fields },
+        },
+      },
+    },
+  })
+}
 
 function makeRequest(body?: unknown) {
   return new Request("http://localhost/api/environments/env_1", {
@@ -63,6 +86,9 @@ beforeEach(() => {
   environment.updateMany.mockReset()
   environment.delete.mockReset()
   environment.count.mockReset()
+  // mockClear (not mockReset): this mock's real job is to actually run its
+  // ops (`Promise.all(ops)`), so clearing must not wipe that implementation.
+  transaction.mockClear()
 })
 
 describe("GET /api/environments/[id]", () => {
@@ -175,6 +201,12 @@ describe("PATCH /api/environments/[id]", () => {
     const res = await PATCH(makeRequest({ isDefault: true }), params())
     const body = await res.json()
 
+    // The two ordered statements must actually run inside prisma.$transaction,
+    // as an array of exactly two operations, not merely be called somewhere.
+    expect(transaction).toHaveBeenCalledTimes(1)
+    const [ops] = transaction.mock.calls[0]
+    expect(ops).toHaveLength(2)
+
     expect(environment.updateMany).toHaveBeenCalledWith({
       where: { userId: "u1", repo: "acme/app", isDefault: true },
       data: { isDefault: false },
@@ -183,6 +215,16 @@ describe("PATCH /api/environments/[id]", () => {
       where: { id: "env_1" },
       data: { isDefault: true },
     })
+
+    // Ordering: the clear (updateMany) must have been INVOKED before the
+    // promotion's set (this update call), not just both present in the
+    // transaction array. invocationCallOrder is a global counter across all
+    // mocks, so comparing it across the two different mock functions is valid
+    // and would catch the array being built in the wrong order.
+    expect(environment.updateMany.mock.invocationCallOrder[0]).toBeLessThan(
+      environment.update.mock.invocationCallOrder[0]
+    )
+
     expect(res.status).toBe(200)
     expect(body.environment.isDefault).toBe(true)
   })
@@ -196,13 +238,37 @@ describe("PATCH /api/environments/[id]", () => {
     expect(environment.updateMany).not.toHaveBeenCalled()
   })
 
-  it("maps a unique-constraint violation to a 400", async () => {
+  it("maps a (userId, repo, name) P2002 to a 400 naming the collision", async () => {
     environment.findFirst.mockResolvedValueOnce(row())
-    environment.update.mockRejectedValueOnce(new Error("Unique constraint failed on the fields"))
+    environment.update.mockRejectedValueOnce(p2002(['"userId"', "repo", "name"]))
 
     const res = await PATCH(makeRequest({ name: "Taken" }), params())
+    const body = await res.json()
 
     expect(res.status).toBe(400)
+    expect(body.error).toContain("environment with that name already exists")
+  })
+
+  it("maps a partial default-per-repo-index P2002 (a concurrent promotion race) to a distinct 400", async () => {
+    environment.findFirst.mockResolvedValueOnce(row({ isDefault: false }))
+    environment.updateMany.mockResolvedValueOnce({ count: 1 })
+    environment.update.mockRejectedValueOnce(p2002(['"userId"', "repo"]))
+
+    const res = await PATCH(makeRequest({ isDefault: true }), params())
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.error).not.toContain("name already exists")
+    expect(body.error.toLowerCase()).toContain("default")
+  })
+
+  it("does not turn a non-P2002 error into a 400", async () => {
+    environment.findFirst.mockResolvedValueOnce(row())
+    environment.update.mockRejectedValueOnce(new Error("connection refused"))
+
+    const res = await PATCH(makeRequest({ name: "Renamed" }), params())
+
+    expect(res.status).toBe(500)
   })
 })
 

--- a/packages/web/app/api/environments/[id]/route.test.ts
+++ b/packages/web/app/api/environments/[id]/route.test.ts
@@ -191,6 +191,23 @@ describe("PATCH /api/environments/[id]", () => {
     })
   })
 
+  it("leaves setupScriptPrevious untouched when setupScript is resent unchanged", async () => {
+    environment.findFirst.mockResolvedValueOnce(
+      row({ setupScript: "echo old", setupScriptPrevious: "echo ancient" })
+    )
+    environment.update.mockResolvedValueOnce(row())
+
+    await PATCH(makeRequest({ setupScript: "echo old", name: "Renamed" }), params())
+
+    expect(environment.update).toHaveBeenCalledWith({
+      where: { id: "env_1" },
+      data: {
+        name: "Renamed",
+        setupScript: "echo old",
+      },
+    })
+  })
+
   it("promotes to default with an ordered clear-then-set transaction, not a single combined update", async () => {
     environment.findFirst.mockResolvedValueOnce(row({ isDefault: false }))
     environment.updateMany.mockResolvedValueOnce({ count: 1 })

--- a/packages/web/app/api/environments/[id]/route.test.ts
+++ b/packages/web/app/api/environments/[id]/route.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// Mock the prisma singleton so route logic can be exercised without a DB.
+// `vi.hoisted` lets the factory (which is hoisted above imports) see the mocks.
+const { environment } = vi.hoisted(() => ({
+  environment: {
+    findFirst: vi.fn(),
+    update: vi.fn(),
+    updateMany: vi.fn(),
+    delete: vi.fn(),
+    count: vi.fn(),
+  },
+}))
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: { environment, $transaction: vi.fn(async (ops: Promise<unknown>[]) => Promise.all(ops)) },
+}))
+
+vi.mock("@/lib/db/api-helpers", () => ({
+  requireAuth: vi.fn(async () => ({ userId: "u1" })),
+  isAuthError: vi.fn(() => false),
+  badRequest: vi.fn((message: string) => Response.json({ error: message }, { status: 400 })),
+  notFound: vi.fn((message: string) => Response.json({ error: message }, { status: 404 })),
+  internalError: vi.fn((error: unknown) =>
+    Response.json({ error: String(error) }, { status: 500 })
+  ),
+}))
+
+import { GET, PATCH, DELETE } from "./route"
+import { decryptEnvironmentVariables } from "@/lib/environments"
+
+function makeRequest(body?: unknown) {
+  return new Request("http://localhost/api/environments/env_1", {
+    method: "PATCH",
+    body: body === undefined ? undefined : JSON.stringify(body),
+  }) as unknown as import("next/server").NextRequest
+}
+
+function params(id = "env_1") {
+  return { params: Promise.resolve({ id }) }
+}
+
+function row(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "env_1",
+    userId: "u1",
+    repo: "acme/app",
+    name: "Default",
+    isDefault: false,
+    networkMode: "full",
+    allowedDomains: [],
+    environmentVariables: null,
+    setupScript: null,
+    setupScriptPrevious: null,
+    setupScriptUpdatedBy: null,
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  environment.findFirst.mockReset()
+  environment.update.mockReset()
+  environment.updateMany.mockReset()
+  environment.delete.mockReset()
+  environment.count.mockReset()
+})
+
+describe("GET /api/environments/[id]", () => {
+  it("scopes the lookup to the caller's userId", async () => {
+    environment.findFirst.mockResolvedValueOnce(row())
+
+    const res = await GET(makeRequest(), params())
+
+    expect(environment.findFirst).toHaveBeenCalledWith({ where: { id: "env_1", userId: "u1" } })
+    expect(res.status).toBe(200)
+  })
+
+  it("404s when the environment belongs to another user or does not exist", async () => {
+    environment.findFirst.mockResolvedValueOnce(null)
+
+    const res = await GET(makeRequest(), params())
+
+    expect(res.status).toBe(404)
+  })
+})
+
+describe("PATCH /api/environments/[id]", () => {
+  it("404s for an environment the caller does not own", async () => {
+    environment.findFirst.mockResolvedValueOnce(null)
+
+    const res = await PATCH(makeRequest({ name: "Renamed" }), params())
+
+    expect(res.status).toBe(404)
+    expect(environment.update).not.toHaveBeenCalled()
+  })
+
+  it("rejects an unrecognized networkMode value with a generic 400", async () => {
+    environment.findFirst.mockResolvedValueOnce(row())
+
+    const res = await PATCH(makeRequest({ networkMode: "bogus" }), params())
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.error).toContain("networkMode must be one of")
+    expect(environment.update).not.toHaveBeenCalled()
+  })
+
+  it("rejects networkMode: restricted with a 400 explaining the SDK gap, not a generic message", async () => {
+    environment.findFirst.mockResolvedValueOnce(row())
+
+    const res = await PATCH(makeRequest({ networkMode: "restricted" }), params())
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.error).toContain("@daytonaio/sdk")
+    expect(body.error).not.toContain("must be one of")
+    expect(environment.update).not.toHaveBeenCalled()
+  })
+
+  it("accepts networkMode: full", async () => {
+    environment.findFirst.mockResolvedValueOnce(row())
+    environment.update.mockResolvedValueOnce(row({ networkMode: "full" }))
+
+    const res = await PATCH(makeRequest({ networkMode: "full" }), params())
+
+    expect(res.status).toBe(200)
+    expect(environment.update).toHaveBeenCalledWith({
+      where: { id: "env_1" },
+      data: { networkMode: "full" },
+    })
+  })
+
+  it("rejects a blank name", async () => {
+    environment.findFirst.mockResolvedValueOnce(row())
+
+    const res = await PATCH(makeRequest({ name: "   " }), params())
+
+    expect(res.status).toBe(400)
+    expect(environment.update).not.toHaveBeenCalled()
+  })
+
+  it("encrypts variables before persisting", async () => {
+    environment.findFirst.mockResolvedValueOnce(row())
+    environment.update.mockResolvedValueOnce(row())
+
+    await PATCH(makeRequest({ variables: { FOO: "bar" } }), params())
+
+    const data = environment.update.mock.calls[0][0].data
+    expect(decryptEnvironmentVariables(data.environmentVariables)).toEqual({ FOO: "bar" })
+  })
+
+  it("stashes the previous setup script and stamps setupScriptUpdatedBy as user", async () => {
+    environment.findFirst.mockResolvedValueOnce(row({ setupScript: "echo old" }))
+    environment.update.mockResolvedValueOnce(row())
+
+    await PATCH(makeRequest({ setupScript: "echo new" }), params())
+
+    expect(environment.update).toHaveBeenCalledWith({
+      where: { id: "env_1" },
+      data: {
+        setupScript: "echo new",
+        setupScriptPrevious: "echo old",
+        setupScriptUpdatedBy: "user",
+      },
+    })
+  })
+
+  it("promotes to default with an ordered clear-then-set transaction, not a single combined update", async () => {
+    environment.findFirst.mockResolvedValueOnce(row({ isDefault: false }))
+    environment.updateMany.mockResolvedValueOnce({ count: 1 })
+    environment.update
+      .mockResolvedValueOnce(undefined) // the transaction's promotion update
+      .mockResolvedValueOnce(row({ isDefault: true })) // the trailing field-patch update
+
+    const res = await PATCH(makeRequest({ isDefault: true }), params())
+    const body = await res.json()
+
+    expect(environment.updateMany).toHaveBeenCalledWith({
+      where: { userId: "u1", repo: "acme/app", isDefault: true },
+      data: { isDefault: false },
+    })
+    expect(environment.update).toHaveBeenNthCalledWith(1, {
+      where: { id: "env_1" },
+      data: { isDefault: true },
+    })
+    expect(res.status).toBe(200)
+    expect(body.environment.isDefault).toBe(true)
+  })
+
+  it("does not run the promotion transaction when the environment is already the default", async () => {
+    environment.findFirst.mockResolvedValueOnce(row({ isDefault: true }))
+    environment.update.mockResolvedValueOnce(row({ isDefault: true }))
+
+    await PATCH(makeRequest({ isDefault: true }), params())
+
+    expect(environment.updateMany).not.toHaveBeenCalled()
+  })
+
+  it("maps a unique-constraint violation to a 400", async () => {
+    environment.findFirst.mockResolvedValueOnce(row())
+    environment.update.mockRejectedValueOnce(new Error("Unique constraint failed on the fields"))
+
+    const res = await PATCH(makeRequest({ name: "Taken" }), params())
+
+    expect(res.status).toBe(400)
+  })
+})
+
+describe("DELETE /api/environments/[id]", () => {
+  it("404s for an environment the caller does not own", async () => {
+    environment.findFirst.mockResolvedValueOnce(null)
+
+    const res = await DELETE(makeRequest(), params())
+
+    expect(res.status).toBe(404)
+    expect(environment.delete).not.toHaveBeenCalled()
+  })
+
+  it("deletes a non-default environment", async () => {
+    environment.findFirst.mockResolvedValueOnce(row({ isDefault: false }))
+    environment.delete.mockResolvedValueOnce(row())
+
+    const res = await DELETE(makeRequest(), params())
+    const body = await res.json()
+
+    expect(environment.delete).toHaveBeenCalledWith({ where: { id: "env_1" } })
+    expect(body).toEqual({ success: true })
+  })
+
+  it("deletes the default when it is the repo's only environment", async () => {
+    environment.findFirst.mockResolvedValueOnce(row({ isDefault: true }))
+    environment.count.mockResolvedValueOnce(0)
+    environment.delete.mockResolvedValueOnce(row())
+
+    const res = await DELETE(makeRequest(), params())
+
+    expect(res.status).toBe(200)
+    expect(environment.delete).toHaveBeenCalledWith({ where: { id: "env_1" } })
+  })
+
+  it("refuses to delete the default while siblings exist", async () => {
+    environment.findFirst.mockResolvedValueOnce(row({ isDefault: true }))
+    environment.count.mockResolvedValueOnce(1)
+
+    const res = await DELETE(makeRequest(), params())
+
+    expect(res.status).toBe(400)
+    expect(environment.delete).not.toHaveBeenCalled()
+  })
+})

--- a/packages/web/app/api/environments/[id]/route.ts
+++ b/packages/web/app/api/environments/[id]/route.ts
@@ -114,8 +114,15 @@ export async function PATCH(
         }),
         ...(body.setupScript !== undefined && {
           setupScript: body.setupScript,
-          setupScriptPrevious: existing.setupScript,
-          setupScriptUpdatedBy: "user",
+          // Only rotate the undo slot when the script actually changed. Saving
+          // an unrelated field (a variable, the name) always resends the
+          // current setupScript unchanged; rotating on every save would
+          // overwrite setupScriptPrevious with the current value and destroy
+          // the single-level undo the Part 2 script-rewriting flow depends on.
+          ...(body.setupScript !== existing.setupScript && {
+            setupScriptPrevious: existing.setupScript,
+            setupScriptUpdatedBy: "user",
+          }),
         }),
       },
     })

--- a/packages/web/app/api/environments/[id]/route.ts
+++ b/packages/web/app/api/environments/[id]/route.ts
@@ -1,0 +1,167 @@
+import { NextRequest } from "next/server"
+import { prisma } from "@/lib/db/prisma"
+import { requireAuth, isAuthError, badRequest, notFound, internalError } from "@/lib/db/api-helpers"
+import {
+  encryptEnvironmentVariables,
+  getOwnedEnvironment,
+  toEnvironmentDTO,
+  NETWORK_MODES,
+} from "@/lib/environments"
+
+interface PatchBody {
+  name?: string
+  networkMode?: string
+  allowedDomains?: string[]
+  variables?: Record<string, string>
+  setupScript?: string | null
+  isDefault?: true
+}
+
+// =============================================================================
+// GET
+// =============================================================================
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<Response> {
+  const authResult = await requireAuth()
+  if (isAuthError(authResult)) return authResult
+  const { userId } = authResult
+
+  try {
+    const { id } = await params
+    const row = await getOwnedEnvironment(userId, id)
+    if (!row) return notFound("Environment not found")
+    return Response.json({ environment: toEnvironmentDTO(row) })
+  } catch (error) {
+    return internalError(error)
+  }
+}
+
+// =============================================================================
+// PATCH - edit fields, or promote to default
+// =============================================================================
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<Response> {
+  const authResult = await requireAuth()
+  if (isAuthError(authResult)) return authResult
+  const { userId } = authResult
+
+  try {
+    const { id } = await params
+    const existing = await getOwnedEnvironment(userId, id)
+    if (!existing) return notFound("Environment not found")
+
+    const body: PatchBody = await req.json()
+
+    if (body.networkMode !== undefined) {
+      if (!(NETWORK_MODES as readonly string[]).includes(body.networkMode)) {
+        return badRequest(`networkMode must be one of: ${NETWORK_MODES.join(", ")}`)
+      }
+
+      // Delete this block once @daytonaio/sdk is upgraded past 0.170.0 to a
+      // version with a domain-allowlist field (0.185.0+) and
+      // buildSandboxCreateParams's matching restricted-mode throw is removed.
+      // The installed SDK has no domainAllowList, only "networkBlockAll" and a
+      // CIDR-only "networkAllowList", neither of which can express an
+      // allowed-hostnames list. Persisting networkMode: "restricted" here
+      // would let a user park an environment in a state where every
+      // subsequent chat on that repo fails at sandbox creation, so it's
+      // refused at the API boundary instead.
+      if (body.networkMode === "restricted") {
+        return badRequest(
+          `Restricted network mode is not enforced yet: the installed @daytonaio/sdk (0.170.0) ` +
+            `has no domain-allowlist field, only "networkBlockAll" and a CIDR-only ` +
+            `"networkAllowList", neither of which can express an allowed-hostnames list. Keep ` +
+            `this environment's network mode set to "full" until the Daytona SDK is upgraded ` +
+            `(0.185.0+) to support domain allowlisting.`
+        )
+      }
+    }
+    if (body.name !== undefined && !body.name.trim()) {
+      return badRequest("name cannot be empty")
+    }
+
+    // Promotion runs as two ordered statements inside a transaction. Postgres
+    // checks the partial unique index per statement, not deferred, so clearing
+    // the old default and setting the new one cannot be a single updateMany.
+    if (body.isDefault === true && !existing.isDefault) {
+      await prisma.$transaction([
+        prisma.environment.updateMany({
+          where: { userId, repo: existing.repo, isDefault: true },
+          data: { isDefault: false },
+        }),
+        prisma.environment.update({ where: { id }, data: { isDefault: true } }),
+      ])
+    }
+
+    const updated = await prisma.environment.update({
+      where: { id },
+      data: {
+        ...(body.name !== undefined && { name: body.name.trim() }),
+        ...(body.networkMode !== undefined && { networkMode: body.networkMode }),
+        ...(body.allowedDomains !== undefined && {
+          allowedDomains: body.allowedDomains.map((d) => d.trim()).filter(Boolean),
+        }),
+        ...(body.variables !== undefined && {
+          environmentVariables: encryptEnvironmentVariables(body.variables),
+        }),
+        ...(body.setupScript !== undefined && {
+          setupScript: body.setupScript,
+          setupScriptPrevious: existing.setupScript,
+          setupScriptUpdatedBy: "user",
+        }),
+      },
+    })
+
+    return Response.json({ environment: toEnvironmentDTO(updated) })
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("Unique constraint")) {
+      return badRequest("An environment with that name already exists for this repo")
+    }
+    return internalError(error)
+  }
+}
+
+// =============================================================================
+// DELETE
+// =============================================================================
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<Response> {
+  const authResult = await requireAuth()
+  if (isAuthError(authResult)) return authResult
+  const { userId } = authResult
+
+  try {
+    const { id } = await params
+    const existing = await getOwnedEnvironment(userId, id)
+    if (!existing) return notFound("Environment not found")
+
+    // Deleting the default is only allowed when it's the repo's last one; in
+    // which case getOrCreateDefaultEnvironment will recreate an empty one on
+    // next need. Otherwise the user promotes another to default first, so the
+    // repo is never left with several environments and no default.
+    if (existing.isDefault) {
+      const siblings = await prisma.environment.count({
+        where: { userId, repo: existing.repo, NOT: { id } },
+      })
+      if (siblings > 0) {
+        return badRequest("Promote another environment to default before deleting this one")
+      }
+    }
+
+    // Chats keep their history; environmentId goes null via SetNull and they
+    // resolve to the repo's default on their next sandbox.
+    await prisma.environment.delete({ where: { id } })
+    return Response.json({ success: true })
+  } catch (error) {
+    return internalError(error)
+  }
+}

--- a/packages/web/app/api/environments/[id]/route.ts
+++ b/packages/web/app/api/environments/[id]/route.ts
@@ -1,8 +1,10 @@
 import { NextRequest } from "next/server"
+import { Prisma } from "@prisma/client"
 import { prisma } from "@/lib/db/prisma"
 import { requireAuth, isAuthError, badRequest, notFound, internalError } from "@/lib/db/api-helpers"
 import {
   encryptEnvironmentVariables,
+  environmentUniqueConstraintMessage,
   getOwnedEnvironment,
   toEnvironmentDTO,
   NETWORK_MODES,
@@ -120,8 +122,13 @@ export async function PATCH(
 
     return Response.json({ environment: toEnvironmentDTO(updated) })
   } catch (error) {
-    if (error instanceof Error && error.message.includes("Unique constraint")) {
-      return badRequest("An environment with that name already exists for this repo")
+    // Two concurrent default-promotions in the same repo can interleave such
+    // that the loser hits the partial default-per-repo index even though this
+    // request never touched name; environmentUniqueConstraintMessage tells
+    // that apart from an actual (userId, repo, name) collision. Anything that
+    // isn't a P2002 is a real error and must not become a 400.
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+      return badRequest(environmentUniqueConstraintMessage(error))
     }
     return internalError(error)
   }

--- a/packages/web/app/api/environments/[id]/usage/route.test.ts
+++ b/packages/web/app/api/environments/[id]/usage/route.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// Mock the prisma singleton so route logic can be exercised without a DB.
+// `vi.hoisted` lets the factory (which is hoisted above imports) see the mocks.
+const { environment, chat } = vi.hoisted(() => ({
+  environment: { findFirst: vi.fn() },
+  chat: { count: vi.fn() },
+}))
+vi.mock("@/lib/db/prisma", () => ({ prisma: { environment, chat } }))
+
+vi.mock("@/lib/db/api-helpers", () => ({
+  requireAuth: vi.fn(async () => ({ userId: "u1" })),
+  isAuthError: vi.fn(() => false),
+  notFound: vi.fn((message: string) => Response.json({ error: message }, { status: 404 })),
+  internalError: vi.fn((error: unknown) =>
+    Response.json({ error: String(error) }, { status: 500 })
+  ),
+}))
+
+import { GET } from "./route"
+
+function makeRequest() {
+  return new Request("http://localhost/api/environments/env_1/usage") as unknown as import(
+    "next/server"
+  ).NextRequest
+}
+
+function params(id = "env_1") {
+  return { params: Promise.resolve({ id }) }
+}
+
+beforeEach(() => {
+  environment.findFirst.mockReset()
+  chat.count.mockReset()
+})
+
+describe("GET /api/environments/[id]/usage", () => {
+  it("404s for an environment the caller does not own", async () => {
+    environment.findFirst.mockResolvedValueOnce(null)
+
+    const res = await GET(makeRequest(), params())
+
+    expect(res.status).toBe(404)
+    expect(chat.count).not.toHaveBeenCalled()
+  })
+
+  it("counts the caller's chats pinned to this environment", async () => {
+    environment.findFirst.mockResolvedValueOnce({ id: "env_1" })
+    chat.count.mockResolvedValueOnce(3)
+
+    const res = await GET(makeRequest(), params())
+    const body = await res.json()
+
+    expect(chat.count).toHaveBeenCalledWith({ where: { userId: "u1", environmentId: "env_1" } })
+    expect(body).toEqual({ chatCount: 3 })
+  })
+})

--- a/packages/web/app/api/environments/[id]/usage/route.ts
+++ b/packages/web/app/api/environments/[id]/usage/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest } from "next/server"
+import { prisma } from "@/lib/db/prisma"
+import { requireAuth, isAuthError, notFound, internalError } from "@/lib/db/api-helpers"
+import { getOwnedEnvironment } from "@/lib/environments"
+
+/**
+ * How many of the user's chats are pinned to this environment. Drives the
+ * delete confirmation copy ("3 chats use this environment and will fall back
+ * to Default"), so a deletion is never silent about its blast radius.
+ */
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<Response> {
+  const authResult = await requireAuth()
+  if (isAuthError(authResult)) return authResult
+  const { userId } = authResult
+
+  try {
+    const { id } = await params
+    const exists = await getOwnedEnvironment(userId, id)
+    if (!exists) return notFound("Environment not found")
+
+    const chatCount = await prisma.chat.count({ where: { userId, environmentId: id } })
+    return Response.json({ chatCount })
+  } catch (error) {
+    return internalError(error)
+  }
+}

--- a/packages/web/app/api/environments/route.test.ts
+++ b/packages/web/app/api/environments/route.test.ts
@@ -76,7 +76,7 @@ beforeEach(() => {
 })
 
 describe("GET /api/environments", () => {
-  it("lists the caller's environments, decrypted", async () => {
+  it("omits variables by default, returning only a count", async () => {
     const encrypted = encryptEnvironmentVariables({ FOO: "bar" })
     environment.findMany.mockResolvedValueOnce([row({ environmentVariables: encrypted })])
 
@@ -88,8 +88,20 @@ describe("GET /api/environments", () => {
       orderBy: [{ repo: "asc" }, { isDefault: "desc" }, { name: "asc" }],
     })
     expect(body.environments).toHaveLength(1)
-    expect(body.environments[0].variables).toEqual({ FOO: "bar" })
+    expect(body.environments[0].variables).toBeUndefined()
+    expect(body.environments[0].variableCount).toBe(1)
     expect(body.environments[0].updatedAt).toBe(row().updatedAt.getTime())
+  })
+
+  it("includes decrypted variables when the caller asks for them via ?include=variables", async () => {
+    const encrypted = encryptEnvironmentVariables({ FOO: "bar" })
+    environment.findMany.mockResolvedValueOnce([row({ environmentVariables: encrypted })])
+
+    const res = await GET(makeRequest("http://localhost/api/environments?include=variables"))
+    const body = await res.json()
+
+    expect(body.environments[0].variables).toEqual({ FOO: "bar" })
+    expect(body.environments[0].variableCount).toBe(1)
   })
 
   it("filters by repo when a repo query param is given", async () => {

--- a/packages/web/app/api/environments/route.test.ts
+++ b/packages/web/app/api/environments/route.test.ts
@@ -22,11 +22,33 @@ vi.mock("@/lib/db/api-helpers", () => ({
   ),
 }))
 
+import { Prisma } from "@prisma/client"
 import { GET, POST } from "./route"
 import { encryptEnvironmentVariables } from "@/lib/environments"
 
 function makeRequest(url: string, init?: RequestInit) {
   return new Request(url, init) as unknown as import("next/server").NextRequest
+}
+
+// Shape copied from a real P2002 forced against the scratch DB via
+// @prisma/adapter-pg (Prisma 7.8.0). See task-6-report.md's smoke-test
+// section for the transcript that produced this.
+function p2002(fields: string[]): Prisma.PrismaClientKnownRequestError {
+  return new Prisma.PrismaClientKnownRequestError("Unique constraint failed on the fields", {
+    code: "P2002",
+    clientVersion: "test",
+    meta: {
+      modelName: "Environment",
+      driverAdapterError: {
+        name: "DriverAdapterError",
+        cause: {
+          originalCode: "23505",
+          kind: "UniqueConstraintViolation",
+          constraint: { fields },
+        },
+      },
+    },
+  })
 }
 
 function row(overrides: Partial<Record<string, unknown>> = {}) {
@@ -191,15 +213,44 @@ describe("POST /api/environments", () => {
     expect(data.setupScript).toBe("echo hi")
   })
 
-  it("maps a unique-constraint violation on (userId, repo, name) to a 400", async () => {
+  it("maps a (userId, repo, name) P2002 to a 400 naming the collision", async () => {
     environment.count.mockResolvedValueOnce(0)
-    environment.create.mockRejectedValueOnce(new Error("Unique constraint failed on the fields"))
+    environment.create.mockRejectedValueOnce(p2002(['"userId"', "repo", "name"]))
+
+    const res = await POST(makeRequest("http://localhost/api/environments", {
+      method: "POST",
+      body: JSON.stringify({ repo: "acme/app", name: "Default" }),
+    }))
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.error).toContain("environment with that name already exists")
+  })
+
+  it("maps a partial default-per-repo-index P2002 (a concurrent first-create race) to a distinct 400", async () => {
+    environment.count.mockResolvedValueOnce(0)
+    environment.create.mockRejectedValueOnce(p2002(['"userId"', "repo"]))
+
+    const res = await POST(makeRequest("http://localhost/api/environments", {
+      method: "POST",
+      body: JSON.stringify({ repo: "acme/app", name: "Default" }),
+    }))
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.error).not.toContain("name already exists")
+    expect(body.error.toLowerCase()).toContain("default")
+  })
+
+  it("does not turn a non-P2002 error into a 400", async () => {
+    environment.count.mockResolvedValueOnce(0)
+    environment.create.mockRejectedValueOnce(new Error("connection refused"))
 
     const res = await POST(makeRequest("http://localhost/api/environments", {
       method: "POST",
       body: JSON.stringify({ repo: "acme/app", name: "Default" }),
     }))
 
-    expect(res.status).toBe(400)
+    expect(res.status).toBe(500)
   })
 })

--- a/packages/web/app/api/environments/route.test.ts
+++ b/packages/web/app/api/environments/route.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// Mock the prisma singleton so route logic can be exercised without a DB.
+// `vi.hoisted` lets the factory (which is hoisted above imports) see the mocks.
+const { environment } = vi.hoisted(() => ({
+  environment: {
+    findFirst: vi.fn(),
+    findMany: vi.fn(),
+    count: vi.fn(),
+    create: vi.fn(),
+  },
+}))
+vi.mock("@/lib/db/prisma", () => ({ prisma: { environment } }))
+
+vi.mock("@/lib/db/api-helpers", () => ({
+  requireAuth: vi.fn(async () => ({ userId: "u1" })),
+  isAuthError: vi.fn(() => false),
+  badRequest: vi.fn((message: string) => Response.json({ error: message }, { status: 400 })),
+  notFound: vi.fn((message: string) => Response.json({ error: message }, { status: 404 })),
+  internalError: vi.fn((error: unknown) =>
+    Response.json({ error: String(error) }, { status: 500 })
+  ),
+}))
+
+import { GET, POST } from "./route"
+import { encryptEnvironmentVariables } from "@/lib/environments"
+
+function makeRequest(url: string, init?: RequestInit) {
+  return new Request(url, init) as unknown as import("next/server").NextRequest
+}
+
+function row(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "env_1",
+    userId: "u1",
+    repo: "acme/app",
+    name: "Default",
+    isDefault: true,
+    networkMode: "full",
+    allowedDomains: [],
+    environmentVariables: null,
+    setupScript: null,
+    setupScriptUpdatedBy: null,
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  environment.findFirst.mockReset()
+  environment.findMany.mockReset()
+  environment.count.mockReset()
+  environment.create.mockReset()
+})
+
+describe("GET /api/environments", () => {
+  it("lists the caller's environments, decrypted", async () => {
+    const encrypted = encryptEnvironmentVariables({ FOO: "bar" })
+    environment.findMany.mockResolvedValueOnce([row({ environmentVariables: encrypted })])
+
+    const res = await GET(makeRequest("http://localhost/api/environments"))
+    const body = await res.json()
+
+    expect(environment.findMany).toHaveBeenCalledWith({
+      where: { userId: "u1" },
+      orderBy: [{ repo: "asc" }, { isDefault: "desc" }, { name: "asc" }],
+    })
+    expect(body.environments).toHaveLength(1)
+    expect(body.environments[0].variables).toEqual({ FOO: "bar" })
+    expect(body.environments[0].updatedAt).toBe(row().updatedAt.getTime())
+  })
+
+  it("filters by repo when a repo query param is given", async () => {
+    environment.findMany.mockResolvedValueOnce([])
+
+    await GET(makeRequest("http://localhost/api/environments?repo=acme/app"))
+
+    expect(environment.findMany).toHaveBeenCalledWith({
+      where: { userId: "u1", repo: "acme/app" },
+      orderBy: [{ repo: "asc" }, { isDefault: "desc" }, { name: "asc" }],
+    })
+  })
+})
+
+describe("POST /api/environments", () => {
+  it("rejects a missing repo", async () => {
+    const res = await POST(makeRequest("http://localhost/api/environments", {
+      method: "POST",
+      body: JSON.stringify({ name: "Staging" }),
+    }))
+    expect(res.status).toBe(400)
+  })
+
+  it("rejects a blank name", async () => {
+    const res = await POST(makeRequest("http://localhost/api/environments", {
+      method: "POST",
+      body: JSON.stringify({ repo: "acme/app", name: "   " }),
+    }))
+    expect(res.status).toBe(400)
+  })
+
+  it("marks the first environment for a repo as default", async () => {
+    environment.count.mockResolvedValueOnce(0)
+    environment.create.mockResolvedValueOnce(row({ isDefault: true }))
+
+    const res = await POST(makeRequest("http://localhost/api/environments", {
+      method: "POST",
+      body: JSON.stringify({ repo: "acme/app", name: "Default" }),
+    }))
+    const body = await res.json()
+
+    expect(res.status).toBe(201)
+    expect(environment.create.mock.calls[0][0].data.isDefault).toBe(true)
+    expect(body.environment.isDefault).toBe(true)
+  })
+
+  it("does not default a later environment for a repo that already has one", async () => {
+    environment.count.mockResolvedValueOnce(1)
+    environment.create.mockResolvedValueOnce(row({ id: "env_2", isDefault: false, name: "Staging" }))
+
+    const res = await POST(makeRequest("http://localhost/api/environments", {
+      method: "POST",
+      body: JSON.stringify({ repo: "acme/app", name: "Staging" }),
+    }))
+    const body = await res.json()
+
+    expect(environment.create.mock.calls[0][0].data.isDefault).toBe(false)
+    expect(body.environment.isDefault).toBe(false)
+  })
+
+  it("404s when duplicating an environment the caller does not own", async () => {
+    environment.findFirst.mockResolvedValueOnce(null)
+
+    const res = await POST(makeRequest("http://localhost/api/environments", {
+      method: "POST",
+      body: JSON.stringify({ repo: "acme/app", name: "Copy", duplicateOf: "someone-elses-env" }),
+    }))
+
+    expect(res.status).toBe(404)
+    expect(environment.create).not.toHaveBeenCalled()
+  })
+
+  it("rejects duplicating an environment into a different repo", async () => {
+    environment.findFirst.mockResolvedValueOnce(row({ repo: "acme/app" }))
+
+    const res = await POST(makeRequest("http://localhost/api/environments", {
+      method: "POST",
+      body: JSON.stringify({ repo: "acme/other", name: "Copy", duplicateOf: "env_1" }),
+    }))
+
+    expect(res.status).toBe(400)
+    expect(environment.create).not.toHaveBeenCalled()
+  })
+
+  it("rejects duplicating a restricted-network-mode source with a 400 explaining the SDK gap", async () => {
+    environment.findFirst.mockResolvedValueOnce(row({ networkMode: "restricted" }))
+
+    const res = await POST(makeRequest("http://localhost/api/environments", {
+      method: "POST",
+      body: JSON.stringify({ repo: "acme/app", name: "Copy", duplicateOf: "env_1" }),
+    }))
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.error).toContain("@daytonaio/sdk")
+    expect(environment.create).not.toHaveBeenCalled()
+  })
+
+  it("copies ciphertext verbatim on duplication, without decrypting", async () => {
+    const encrypted = encryptEnvironmentVariables({ FOO: "bar" })
+    environment.findFirst.mockResolvedValueOnce(
+      row({
+        id: "env_1",
+        networkMode: "full",
+        allowedDomains: ["example.com"],
+        environmentVariables: encrypted,
+        setupScript: "echo hi",
+      })
+    )
+    environment.count.mockResolvedValueOnce(1)
+    environment.create.mockResolvedValueOnce(row({ id: "env_2" }))
+
+    await POST(makeRequest("http://localhost/api/environments", {
+      method: "POST",
+      body: JSON.stringify({ repo: "acme/app", name: "Copy", duplicateOf: "env_1" }),
+    }))
+
+    const data = environment.create.mock.calls[0][0].data
+    expect(data.environmentVariables).toBe(encrypted)
+    expect(data.allowedDomains).toEqual(["example.com"])
+    expect(data.setupScript).toBe("echo hi")
+  })
+
+  it("maps a unique-constraint violation on (userId, repo, name) to a 400", async () => {
+    environment.count.mockResolvedValueOnce(0)
+    environment.create.mockRejectedValueOnce(new Error("Unique constraint failed on the fields"))
+
+    const res = await POST(makeRequest("http://localhost/api/environments", {
+      method: "POST",
+      body: JSON.stringify({ repo: "acme/app", name: "Default" }),
+    }))
+
+    expect(res.status).toBe(400)
+  })
+})

--- a/packages/web/app/api/environments/route.ts
+++ b/packages/web/app/api/environments/route.ts
@@ -1,0 +1,105 @@
+import { NextRequest } from "next/server"
+import { prisma } from "@/lib/db/prisma"
+import {
+  requireAuth,
+  isAuthError,
+  badRequest,
+  notFound,
+  internalError,
+} from "@/lib/db/api-helpers"
+import { toEnvironmentDTO, type EnvironmentDTO } from "@/lib/environments"
+
+export type { EnvironmentDTO }
+
+interface CreateBody {
+  repo: string
+  name: string
+  /** When set, copy network settings, variables, and setup script from this id. */
+  duplicateOf?: string
+}
+
+// =============================================================================
+// GET - list the user's environments, optionally filtered by repo
+// =============================================================================
+
+export async function GET(req: NextRequest): Promise<Response> {
+  const authResult = await requireAuth()
+  if (isAuthError(authResult)) return authResult
+  const { userId } = authResult
+
+  try {
+    const repo = new URL(req.url).searchParams.get("repo")
+    const rows = await prisma.environment.findMany({
+      where: { userId, ...(repo && { repo }) },
+      orderBy: [{ repo: "asc" }, { isDefault: "desc" }, { name: "asc" }],
+    })
+    return Response.json({ environments: rows.map(toEnvironmentDTO) })
+  } catch (error) {
+    return internalError(error)
+  }
+}
+
+// =============================================================================
+// POST - create, optionally by duplicating an existing environment
+// =============================================================================
+
+export async function POST(req: NextRequest): Promise<Response> {
+  const authResult = await requireAuth()
+  if (isAuthError(authResult)) return authResult
+  const { userId } = authResult
+
+  try {
+    const body: CreateBody = await req.json()
+    if (!body.repo || typeof body.repo !== "string") return badRequest("repo is required")
+    if (!body.name?.trim()) return badRequest("name is required")
+
+    let source: Awaited<ReturnType<typeof prisma.environment.findFirst>> = null
+    if (body.duplicateOf) {
+      source = await prisma.environment.findFirst({
+        where: { id: body.duplicateOf, userId },
+      })
+      if (!source) return notFound("Environment not found")
+      if (source.repo !== body.repo) return badRequest("Cannot duplicate across repos")
+
+      // Duplication copies networkMode verbatim below, so a restricted source
+      // would otherwise let a "restricted" row appear via a path that never
+      // showed the PATCH rejection message. Delete alongside the matching
+      // check in PATCH once @daytonaio/sdk is upgraded past 0.170.0 to a
+      // version with a domain-allowlist field.
+      if (source.networkMode === "restricted") {
+        return badRequest(
+          `Cannot duplicate: restricted network mode is not enforced yet. The installed ` +
+            `@daytonaio/sdk (0.170.0) has no domain-allowlist field, only "networkBlockAll" and ` +
+            `a CIDR-only "networkAllowList", neither of which can express an allowed-hostnames ` +
+            `list. Set the source environment's network mode to "full" before duplicating it, or ` +
+            `wait for the Daytona SDK upgrade (0.185.0+).`
+        )
+      }
+    }
+
+    // First environment for a repo becomes its default; later ones do not.
+    const existingCount = await prisma.environment.count({ where: { userId, repo: body.repo } })
+
+    const created = await prisma.environment.create({
+      data: {
+        userId,
+        repo: body.repo,
+        name: body.name.trim(),
+        isDefault: existingCount === 0,
+        networkMode: source?.networkMode ?? "full",
+        allowedDomains: source?.allowedDomains ?? [],
+        // Ciphertext copied verbatim: no decrypt/re-encrypt round trip, so
+        // values never exist in plaintext on this path.
+        environmentVariables: source?.environmentVariables ?? undefined,
+        setupScript: source?.setupScript ?? null,
+      },
+    })
+
+    return Response.json({ environment: toEnvironmentDTO(created) }, { status: 201 })
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("Unique constraint")) {
+      return badRequest("An environment with that name already exists for this repo")
+    }
+    return internalError(error)
+  }
+}

--- a/packages/web/app/api/environments/route.ts
+++ b/packages/web/app/api/environments/route.ts
@@ -33,12 +33,21 @@ export async function GET(req: NextRequest): Promise<Response> {
   const { userId } = authResult
 
   try {
-    const repo = new URL(req.url).searchParams.get("repo")
+    const { searchParams } = new URL(req.url)
+    const repo = searchParams.get("repo")
+    // Full variables are plaintext once decrypted, so this endpoint omits them
+    // by default: every render that lists environments (the combobox, the
+    // environments list) needs only names, defaults and a count, not secrets
+    // sitting in the SPA's memory on every load. Only a caller that actually
+    // edits variables (the environments editor) asks for them explicitly.
+    const includeVariables = searchParams.get("include") === "variables"
     const rows = await prisma.environment.findMany({
       where: { userId, ...(repo && { repo }) },
       orderBy: [{ repo: "asc" }, { isDefault: "desc" }, { name: "asc" }],
     })
-    return Response.json({ environments: rows.map(toEnvironmentDTO) })
+    return Response.json({
+      environments: rows.map((row) => toEnvironmentDTO(row, { includeVariables })),
+    })
   } catch (error) {
     return internalError(error)
   }

--- a/packages/web/app/api/environments/route.ts
+++ b/packages/web/app/api/environments/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from "next/server"
+import { Prisma } from "@prisma/client"
 import { prisma } from "@/lib/db/prisma"
 import {
   requireAuth,
@@ -7,7 +8,11 @@ import {
   notFound,
   internalError,
 } from "@/lib/db/api-helpers"
-import { toEnvironmentDTO, type EnvironmentDTO } from "@/lib/environments"
+import {
+  toEnvironmentDTO,
+  environmentUniqueConstraintMessage,
+  type EnvironmentDTO,
+} from "@/lib/environments"
 
 export type { EnvironmentDTO }
 
@@ -97,8 +102,13 @@ export async function POST(req: NextRequest): Promise<Response> {
 
     return Response.json({ environment: toEnvironmentDTO(created) }, { status: 201 })
   } catch (error) {
-    if (error instanceof Error && error.message.includes("Unique constraint")) {
-      return badRequest("An environment with that name already exists for this repo")
+    // Environment has two unique constraints that both throw P2002: the named
+    // (userId, repo, name) one and the partial default-per-repo index that
+    // the isDefault: existingCount === 0 create above can race against.
+    // environmentUniqueConstraintMessage tells them apart; anything that
+    // isn't a P2002 is a real error and must not become a 400.
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+      return badRequest(environmentUniqueConstraintMessage(error))
     }
     return internalError(error)
   }

--- a/packages/web/app/api/test/auth/route.ts
+++ b/packages/web/app/api/test/auth/route.ts
@@ -3,13 +3,19 @@
  *
  * Creates a test user and returns a valid session token.
  * ONLY enabled when ENABLE_TEST_AUTH=true (should only be set in test environments)
+ *
+ * An optional `?user=<tag>` query param picks a distinct, stable test user
+ * (`test-<tag>@playwright.local`) instead of the default `test@playwright.local`.
+ * IDOR-style specs use this to get a second real user id to test ownership
+ * scoping against, rather than asserting against the same user twice.
  */
 
+import { NextRequest } from "next/server"
 import { prisma } from "@/lib/db/prisma"
 import { encode } from "next-auth/jwt"
 import { internalError } from "@/lib/db/api-helpers"
 
-export async function POST() {
+export async function POST(req: NextRequest) {
   // Safety check: only allow in test mode
   if (process.env.ENABLE_TEST_AUTH !== "true") {
     return Response.json(
@@ -19,14 +25,19 @@ export async function POST() {
   }
 
   try {
+    const rawTag = new URL(req.url).searchParams.get("user")
+    if (rawTag && !/^[a-z0-9-]{1,32}$/.test(rawTag)) {
+      return Response.json({ error: "Invalid user tag" }, { status: 400 })
+    }
+    const tag = rawTag
+    const email = tag ? `test-${tag}@playwright.local` : "test@playwright.local"
+    const name = tag ? `Playwright Test User ${tag.toUpperCase()}` : "Playwright Test User"
+
     // Create or find test user
     const user = await prisma.user.upsert({
-      where: { email: "test@playwright.local" },
+      where: { email },
       update: {},
-      create: {
-        email: "test@playwright.local",
-        name: "Playwright Test User",
-      },
+      create: { email, name },
     })
 
     // Generate session token
@@ -51,6 +62,6 @@ export async function POST() {
 }
 
 // Also support GET for easier testing
-export async function GET() {
-  return POST()
+export async function GET(req: NextRequest) {
+  return POST(req)
 }

--- a/packages/web/app/api/user/repo-env/route.test.ts
+++ b/packages/web/app/api/user/repo-env/route.test.ts
@@ -22,7 +22,6 @@ vi.mock("@/lib/db/api-helpers", () => ({
 }))
 
 import { GET, PATCH } from "./route"
-import { buildRepoEnvVarsResponse } from "./route"
 import { encryptEnvironmentVariables, decryptEnvironmentVariables } from "@/lib/environments"
 
 beforeEach(() => {
@@ -32,26 +31,12 @@ beforeEach(() => {
   environment.update.mockReset()
 })
 
-describe("buildRepoEnvVarsResponse", () => {
-  it("shapes the response from default environments only, decrypted", () => {
-    const encrypted = encryptEnvironmentVariables({ FOO: "bar" })
-    const result = buildRepoEnvVarsResponse([
-      { repo: "acme/app", environmentVariables: encrypted },
-      { repo: "acme/other", environmentVariables: null },
-    ])
-
-    expect(result).toEqual({
-      "acme/app": { FOO: "bar" },
-      "acme/other": {},
-    })
-  })
-})
-
 describe("GET /api/user/repo-env", () => {
-  it("returns repoEnvironmentVariables shaped from default environments", async () => {
+  it("returns repoEnvironmentVariables shaped from default environments only, decrypted", async () => {
     const encrypted = encryptEnvironmentVariables({ FOO: "bar" })
     environment.findMany.mockResolvedValueOnce([
       { repo: "acme/app", environmentVariables: encrypted },
+      { repo: "acme/other", environmentVariables: null },
     ])
 
     const res = await GET()
@@ -62,7 +47,10 @@ describe("GET /api/user/repo-env", () => {
       select: { repo: true, environmentVariables: true },
     })
     expect(body).toEqual({
-      repoEnvironmentVariables: { "acme/app": { FOO: "bar" } },
+      repoEnvironmentVariables: {
+        "acme/app": { FOO: "bar" },
+        "acme/other": {},
+      },
     })
   })
 })

--- a/packages/web/app/api/user/repo-env/route.test.ts
+++ b/packages/web/app/api/user/repo-env/route.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// Mock the prisma singleton so route logic can be exercised without a DB.
+// `vi.hoisted` lets the factory (which is hoisted above imports) see the mocks.
+const { environment } = vi.hoisted(() => ({
+  environment: {
+    findFirst: vi.fn(),
+    findMany: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+  },
+}))
+vi.mock("@/lib/db/prisma", () => ({ prisma: { environment } }))
+
+vi.mock("@/lib/db/api-helpers", () => ({
+  requireAuth: vi.fn(async () => ({ userId: "u1" })),
+  isAuthError: vi.fn(() => false),
+  badRequest: vi.fn((message: string) => Response.json({ error: message }, { status: 400 })),
+  internalError: vi.fn((error: unknown) =>
+    Response.json({ error: String(error) }, { status: 500 })
+  ),
+}))
+
+import { GET, PATCH } from "./route"
+import { buildRepoEnvVarsResponse } from "./route"
+import { encryptEnvironmentVariables, decryptEnvironmentVariables } from "@/lib/environments"
+
+beforeEach(() => {
+  environment.findFirst.mockReset()
+  environment.findMany.mockReset()
+  environment.create.mockReset()
+  environment.update.mockReset()
+})
+
+describe("buildRepoEnvVarsResponse", () => {
+  it("shapes the response from default environments only, decrypted", () => {
+    const encrypted = encryptEnvironmentVariables({ FOO: "bar" })
+    const result = buildRepoEnvVarsResponse([
+      { repo: "acme/app", environmentVariables: encrypted },
+      { repo: "acme/other", environmentVariables: null },
+    ])
+
+    expect(result).toEqual({
+      "acme/app": { FOO: "bar" },
+      "acme/other": {},
+    })
+  })
+})
+
+describe("GET /api/user/repo-env", () => {
+  it("returns repoEnvironmentVariables shaped from default environments", async () => {
+    const encrypted = encryptEnvironmentVariables({ FOO: "bar" })
+    environment.findMany.mockResolvedValueOnce([
+      { repo: "acme/app", environmentVariables: encrypted },
+    ])
+
+    const res = await GET()
+    const body = await res.json()
+
+    expect(environment.findMany).toHaveBeenCalledWith({
+      where: { userId: "u1", isDefault: true },
+      select: { repo: true, environmentVariables: true },
+    })
+    expect(body).toEqual({
+      repoEnvironmentVariables: { "acme/app": { FOO: "bar" } },
+    })
+  })
+})
+
+describe("PATCH /api/user/repo-env", () => {
+  function makeRequest(body: unknown) {
+    return new Request("http://localhost/api/user/repo-env", {
+      method: "PATCH",
+      body: JSON.stringify(body),
+    }) as unknown as import("next/server").NextRequest
+  }
+
+  it("rejects a missing repo", async () => {
+    const res = await PATCH(makeRequest({ environmentVariables: {} }))
+    expect(res.status).toBe(400)
+  })
+
+  it("rejects invalid environmentVariables", async () => {
+    const res = await PATCH(makeRequest({ repo: "acme/app" }))
+    expect(res.status).toBe(400)
+  })
+
+  it("round-trips values through encrypt/decrypt against the repo's default environment", async () => {
+    environment.findFirst.mockResolvedValueOnce({
+      id: "env1",
+      name: "Default",
+      repo: "acme/app",
+      isDefault: true,
+      networkMode: "full",
+      allowedDomains: [],
+      environmentVariables: null,
+      setupScript: null,
+    })
+    environment.update.mockResolvedValueOnce({})
+
+    const res = await PATCH(
+      makeRequest({ repo: "acme/app", environmentVariables: { FOO: "bar" } })
+    )
+
+    expect(res.status).toBe(200)
+    expect(environment.update).toHaveBeenCalledTimes(1)
+    const call = environment.update.mock.calls[0][0]
+    expect(call.where).toEqual({ id: "env1" })
+    const written = call.data.environmentVariables as Record<string, string>
+    expect(decryptEnvironmentVariables(written)).toEqual({ FOO: "bar" })
+  })
+
+  it("clears the default environment's variables without deleting the row", async () => {
+    environment.findFirst.mockResolvedValueOnce({
+      id: "env1",
+      name: "Default",
+      repo: "acme/app",
+      isDefault: true,
+      networkMode: "full",
+      allowedDomains: [],
+      environmentVariables: { FOO: "encrypted" },
+      setupScript: null,
+    })
+    environment.update.mockResolvedValueOnce({})
+
+    const res = await PATCH(
+      makeRequest({ repo: "acme/app", environmentVariables: {} })
+    )
+
+    expect(res.status).toBe(200)
+    expect(environment.update).toHaveBeenCalledWith({
+      where: { id: "env1" },
+      data: { environmentVariables: {} },
+    })
+  })
+})

--- a/packages/web/app/api/user/repo-env/route.ts
+++ b/packages/web/app/api/user/repo-env/route.ts
@@ -83,7 +83,7 @@ export async function PATCH(req: NextRequest): Promise<Response> {
     const encrypted = encryptEnvironmentVariables(body.environmentVariables)
 
     // An empty environmentVariables clears the values but must not delete the
-    // Environment row — that would take its name, network mode, and setup
+    // Environment row: that would take its name, network mode, and setup
     // script with it.
     await prisma.environment.update({
       where: { id: defaultEnv.id },

--- a/packages/web/app/api/user/repo-env/route.ts
+++ b/packages/web/app/api/user/repo-env/route.ts
@@ -26,24 +26,6 @@ interface PatchRepoEnvVarsBody {
 }
 
 // =============================================================================
-// Shaping helper (pure, unit-tested)
-// =============================================================================
-
-/**
- * Builds the GET response shape from every default Environment a user has,
- * keyed by repo, with variables decrypted.
- */
-export function buildRepoEnvVarsResponse(
-  defaultEnvironments: { repo: string; environmentVariables: unknown }[]
-): Record<string, Record<string, string>> {
-  const out: Record<string, Record<string, string>> = {}
-  for (const env of defaultEnvironments) {
-    out[env.repo] = decryptEnvironmentVariables(env.environmentVariables)
-  }
-  return out
-}
-
-// =============================================================================
 // GET - Fetch all repository environment variables for the user (decrypted)
 // =============================================================================
 //
@@ -64,9 +46,12 @@ export async function GET(): Promise<Response> {
       select: { repo: true, environmentVariables: true },
     })
 
-    const response: RepoEnvVarsResponse = {
-      repoEnvironmentVariables: buildRepoEnvVarsResponse(defaultEnvironments),
+    const repoEnvironmentVariables: Record<string, Record<string, string>> = {}
+    for (const env of defaultEnvironments) {
+      repoEnvironmentVariables[env.repo] = decryptEnvironmentVariables(env.environmentVariables)
     }
+
+    const response: RepoEnvVarsResponse = { repoEnvironmentVariables }
 
     return Response.json(response)
   } catch (error) {

--- a/packages/web/app/api/user/repo-env/route.ts
+++ b/packages/web/app/api/user/repo-env/route.ts
@@ -6,7 +6,11 @@ import {
   badRequest,
   internalError,
 } from "@/lib/db/api-helpers"
-import { encrypt, decrypt } from "@/lib/db/encryption"
+import {
+  decryptEnvironmentVariables,
+  encryptEnvironmentVariables,
+  getOrCreateDefaultEnvironment,
+} from "@/lib/environments"
 
 // =============================================================================
 // Types
@@ -22,8 +26,32 @@ interface PatchRepoEnvVarsBody {
 }
 
 // =============================================================================
+// Shaping helper (pure, unit-tested)
+// =============================================================================
+
+/**
+ * Builds the GET response shape from every default Environment a user has,
+ * keyed by repo, with variables decrypted.
+ */
+export function buildRepoEnvVarsResponse(
+  defaultEnvironments: { repo: string; environmentVariables: unknown }[]
+): Record<string, Record<string, string>> {
+  const out: Record<string, Record<string, string>> = {}
+  for (const env of defaultEnvironments) {
+    out[env.repo] = decryptEnvironmentVariables(env.environmentVariables)
+  }
+  return out
+}
+
+// =============================================================================
 // GET - Fetch all repository environment variables for the user (decrypted)
 // =============================================================================
+//
+// This endpoint predates per-repo Environment rows; it now reads/writes the
+// repo's *default* Environment rather than the legacy
+// User.repoEnvironmentVariables JSON column, which nothing else reads
+// anymore. The wire contract is unchanged so existing clients
+// (useSandboxActions.ts + the env vars modal) keep working untouched.
 
 export async function GET(): Promise<Response> {
   const authResult = await requireAuth()
@@ -31,26 +59,13 @@ export async function GET(): Promise<Response> {
   const { userId } = authResult
 
   try {
-    const user = await prisma.user.findUnique({
-      where: { id: userId },
-      select: { repoEnvironmentVariables: true },
+    const defaultEnvironments = await prisma.environment.findMany({
+      where: { userId, isDefault: true },
+      select: { repo: true, environmentVariables: true },
     })
 
-    // Decrypt all repo environment variables
-    const encrypted = (user?.repoEnvironmentVariables as Record<string, Record<string, string>>) || {}
-    const decrypted: Record<string, Record<string, string>> = {}
-
-    for (const [repo, envVars] of Object.entries(encrypted)) {
-      decrypted[repo] = {}
-      for (const [key, value] of Object.entries(envVars)) {
-        if (value) {
-          decrypted[repo][key] = decrypt(value)
-        }
-      }
-    }
-
     const response: RepoEnvVarsResponse = {
-      repoEnvironmentVariables: decrypted,
+      repoEnvironmentVariables: buildRepoEnvVarsResponse(defaultEnvironments),
     }
 
     return Response.json(response)
@@ -79,34 +94,15 @@ export async function PATCH(req: NextRequest): Promise<Response> {
       return badRequest("Invalid environmentVariables")
     }
 
-    // Get current repo env vars
-    const user = await prisma.user.findUnique({
-      where: { id: userId },
-      select: { repoEnvironmentVariables: true },
-    })
+    const defaultEnv = await getOrCreateDefaultEnvironment(userId, body.repo)
+    const encrypted = encryptEnvironmentVariables(body.environmentVariables)
 
-    const allRepoEnvVars = (user?.repoEnvironmentVariables as Record<string, Record<string, string>>) || {}
-
-    // Encrypt all values for this repo
-    const encrypted: Record<string, string> = {}
-    for (const [key, value] of Object.entries(body.environmentVariables)) {
-      if (typeof key === "string" && typeof value === "string" && key.trim()) {
-        encrypted[key.trim()] = encrypt(value)
-      }
-    }
-
-    // Update or remove the repo entry
-    if (Object.keys(encrypted).length > 0) {
-      allRepoEnvVars[body.repo] = encrypted
-    } else {
-      delete allRepoEnvVars[body.repo]
-    }
-
-    await prisma.user.update({
-      where: { id: userId },
-      data: {
-        repoEnvironmentVariables: allRepoEnvVars,
-      },
+    // An empty environmentVariables clears the values but must not delete the
+    // Environment row — that would take its name, network mode, and setup
+    // script with it.
+    await prisma.environment.update({
+      where: { id: defaultEnv.id },
+      data: { environmentVariables: encrypted },
     })
 
     return Response.json({ success: true })

--- a/packages/web/app/environments/[id]/page.tsx
+++ b/packages/web/app/environments/[id]/page.tsx
@@ -1,0 +1,10 @@
+/**
+ * Single environment page route
+ *
+ * Thin wrapper that renders the main app page, which handles URL routing
+ * internally. Mirrors app/jobs/page.tsx.
+ */
+
+import HomePage from "../../page"
+
+export default HomePage

--- a/packages/web/app/environments/page.tsx
+++ b/packages/web/app/environments/page.tsx
@@ -1,0 +1,10 @@
+/**
+ * Environments list page route
+ *
+ * Thin wrapper that renders the main app page, which handles URL routing
+ * internally. Mirrors app/jobs/page.tsx.
+ */
+
+import HomePage from "../page"
+
+export default HomePage

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -10,6 +10,7 @@ import { PreviewView } from "@/components/PreviewView"
 import { AppModals } from "@/components/AppModals"
 import { useGitDialogs } from "@/components/modals/git-dialogs"
 import { ScheduledJobsView } from "@/components/scheduled-jobs/ScheduledJobsView"
+import { EnvironmentsView } from "@/components/environments/EnvironmentsView"
 import type { SlashCommandType } from "@/components/SlashCommandMenu"
 import { PaletteProvider, usePalette } from "@/components/search-palette"
 import { basename } from "@/lib/format"
@@ -99,6 +100,16 @@ function HomePageContent({ isMobile }: HomePageContentProps) {
   // Derived route state for page title (uses Next.js pathname for SSR compatibility)
   const isJobsRoute = pathname?.startsWith("/jobs") ?? false
   const isNewChatRoute = pathname === "/chat/new"
+
+  // Environments route state. Unlike jobs (which drives its selected-id state
+  // through the sidebar context, updated via pushState handlers and the
+  // popstate-driven useUrlSync), environments derives its id straight from the
+  // pathname: there's no equivalent name-caching need since EnvironmentsView
+  // already has the full EnvironmentDTO list loaded to look the name up from.
+  const isEnvironmentsRoute = pathname?.startsWith("/environments") ?? false
+  const urlEnvironmentId = isEnvironmentsRoute
+    ? (pathname?.split("/")[2] ?? null) || null
+    : null
 
   // For jobs, we derive the ID from sidebar state since we use pushState for navigation
   // The sidebar.selectedScheduledJob is updated by handleNavigateToJob
@@ -380,6 +391,9 @@ function HomePageContent({ isMobile }: HomePageContentProps) {
 
   // Dynamic page title based on current view
   const pageTitle = useMemo(() => {
+    if (isEnvironmentsRoute) {
+      return "Environments"
+    }
     if (isJobsRoute) {
       return sidebar.selectedScheduledJob?.name ?? "Scheduled Agents"
     }
@@ -390,9 +404,37 @@ function HomePageContent({ isMobile }: HomePageContentProps) {
       return "New Chat"
     }
     return null
-  }, [isJobsRoute, isNewChatRoute, isDraftMode, displayCurrentChat?.displayName, sidebar.selectedScheduledJob?.name])
+  }, [
+    isEnvironmentsRoute,
+    isJobsRoute,
+    isNewChatRoute,
+    isDraftMode,
+    displayCurrentChat?.displayName,
+    sidebar.selectedScheduledJob?.name,
+  ])
+
+  // Keep sidebar.viewMode following the URL when a hard load or browser
+  // navigation lands directly on /environments (or a specific environment).
+  // Every other viewMode transition already goes through an explicit handler
+  // (handleSelectChat, handleOpenScheduledJobs, useUrlSync's popstate sync);
+  // environments isn't wired into that popstate-driven route table, so this
+  // effect is the one path that keeps it in sync with the URL.
+  useEffect(() => {
+    if (isEnvironmentsRoute) sidebar.setViewMode("environments")
+  }, [isEnvironmentsRoute, sidebar])
 
   usePageTitle(pageTitle)
+
+  // Sidebar entry point for the environments list. Mirrors
+  // useChatNavigation's handleOpenScheduledJobs: switch view mode, drop any
+  // selected chat/job, and push the URL without a Next.js navigation (so the
+  // page doesn't remount).
+  const handleOpenEnvironments = useCallback(() => {
+    sidebar.setViewMode("environments")
+    sidebar.setSelectedScheduledJob(null)
+    selectChat(null)
+    window.history.pushState(null, "", "/environments")
+  }, [sidebar, selectChat])
 
   // "User clicked send" flow — owns handleSendMessage and the isSendingMessage
   // flag (with its auto-reset effects).
@@ -641,6 +683,15 @@ function HomePageContent({ isMobile }: HomePageContentProps) {
         }
         scheduledJobsActive={sidebar.viewMode === "scheduled-jobs"}
         selectedScheduledJob={sidebar.viewMode === "scheduled-jobs" ? sidebar.selectedScheduledJob : null}
+        onOpenEnvironments={
+          isMobile
+            ? () => {
+                handleOpenEnvironments()
+                sidebar.setMobileSidebarOpen(false)
+              }
+            : handleOpenEnvironments
+        }
+        environmentsActive={sidebar.viewMode === "environments"}
         isLoadingChats={!isHydrated || (isLoading && displayChats.length === 0)}
       />
 
@@ -660,7 +711,14 @@ function HomePageContent({ isMobile }: HomePageContentProps) {
 
         <div className="flex-1 flex min-h-0">
             <div className="flex-1 flex flex-col min-w-0">
-              {sidebar.viewMode === "scheduled-jobs" ? (
+              {sidebar.viewMode === "environments" ? (
+                <EnvironmentsView
+                  urlEnvironmentId={urlEnvironmentId}
+                  onNavigate={(id) => {
+                    window.history.pushState(null, "", id ? `/environments/${id}` : "/environments")
+                  }}
+                />
+              ) : sidebar.viewMode === "scheduled-jobs" ? (
                 <ScheduledJobsView
                   onOpenForm={() => modals.setScheduledJobFormOpen(true)}
                   refreshKey={scheduledJobsRefreshKey}

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -101,21 +101,28 @@ function HomePageContent({ isMobile }: HomePageContentProps) {
   const isJobsRoute = pathname?.startsWith("/jobs") ?? false
   const isNewChatRoute = pathname === "/chat/new"
 
-  // Environments route state. Unlike jobs (which drives its selected-id state
-  // through the sidebar context, updated via pushState handlers and the
-  // popstate-driven useUrlSync), environments derives its id straight from the
-  // pathname: there's no equivalent name-caching need since EnvironmentsView
-  // already has the full EnvironmentDTO list loaded to look the name up from.
+  // isEnvironmentsRoute is derived from pathname purely for the page title
+  // (matching isJobsRoute's role above): it must NOT drive view switching.
+  // usePathname() does not reliably update on the raw window.history.pushState
+  // calls this app uses for in-app navigation (confirmed: after pushState-ing
+  // away from /environments, pathname stayed "/environments" indefinitely, not
+  // just for one render), so an effect keyed on it got permanently stuck
+  // showing the environments view after visiting it once. The actual view
+  // switch instead goes through sidebar.viewMode, kept correct by
+  // useChatNavigation's handlers (handleOpenEnvironments,
+  // handleNavigateToEnvironment) and useUrlSync's popstate-driven route table:
+  // the same mechanism jobs already uses.
   const isEnvironmentsRoute = pathname?.startsWith("/environments") ?? false
-  const urlEnvironmentId = isEnvironmentsRoute
-    ? (pathname?.split("/")[2] ?? null) || null
-    : null
 
-  // For jobs, we derive the ID from sidebar state since we use pushState for navigation
-  // The sidebar.selectedScheduledJob is updated by handleNavigateToJob
-  // Use ?? null to ensure urlJobId is always string | null (never undefined)
-  // This keeps ScheduledJobsView in URL-controlled mode so row clicks work
+  // For jobs and environments, the ID is derived from sidebar state (kept in
+  // sync by the navigate handlers and useUrlSync), not from pathname: pushState
+  // navigation doesn't reliably update usePathname(), so anything driving a
+  // view off pathname directly can get stuck. See isEnvironmentsRoute above.
+  // Use ?? null so these are always string | null (never undefined); this
+  // keeps ScheduledJobsView/EnvironmentsView in URL-controlled mode so row
+  // clicks work.
   const urlJobId = sidebar.selectedScheduledJob?.id ?? null
+  const urlEnvironmentId = sidebar.selectedEnvironmentId
 
   const {
     chats,
@@ -319,6 +326,7 @@ function HomePageContent({ isMobile }: HomePageContentProps) {
       startNewChat(NEW_REPOSITORY, "main", undefined, true, "pending", agent),
     setViewMode: sidebar.setViewMode,
     setSelectedScheduledJob: sidebar.setSelectedScheduledJob,
+    setSelectedEnvironmentId: sidebar.setSelectedEnvironmentId,
   })
 
   // =============================================================================
@@ -361,6 +369,8 @@ function HomePageContent({ isMobile }: HomePageContentProps) {
     handleRepoFilterChange,
     handleOpenScheduledJobs,
     handleNavigateToJob,
+    handleOpenEnvironments,
+    handleNavigateToEnvironment,
     handleNavigateChat,
     handleRequestMergeChats,
     handleRequestRebaseChat,
@@ -413,28 +423,7 @@ function HomePageContent({ isMobile }: HomePageContentProps) {
     sidebar.selectedScheduledJob?.name,
   ])
 
-  // Keep sidebar.viewMode following the URL when a hard load or browser
-  // navigation lands directly on /environments (or a specific environment).
-  // Every other viewMode transition already goes through an explicit handler
-  // (handleSelectChat, handleOpenScheduledJobs, useUrlSync's popstate sync);
-  // environments isn't wired into that popstate-driven route table, so this
-  // effect is the one path that keeps it in sync with the URL.
-  useEffect(() => {
-    if (isEnvironmentsRoute) sidebar.setViewMode("environments")
-  }, [isEnvironmentsRoute, sidebar])
-
   usePageTitle(pageTitle)
-
-  // Sidebar entry point for the environments list. Mirrors
-  // useChatNavigation's handleOpenScheduledJobs: switch view mode, drop any
-  // selected chat/job, and push the URL without a Next.js navigation (so the
-  // page doesn't remount).
-  const handleOpenEnvironments = useCallback(() => {
-    sidebar.setViewMode("environments")
-    sidebar.setSelectedScheduledJob(null)
-    selectChat(null)
-    window.history.pushState(null, "", "/environments")
-  }, [sidebar, selectChat])
 
   // "User clicked send" flow — owns handleSendMessage and the isSendingMessage
   // flag (with its auto-reset effects).
@@ -714,9 +703,7 @@ function HomePageContent({ isMobile }: HomePageContentProps) {
               {sidebar.viewMode === "environments" ? (
                 <EnvironmentsView
                   urlEnvironmentId={urlEnvironmentId}
-                  onNavigate={(id) => {
-                    window.history.pushState(null, "", id ? `/environments/${id}` : "/environments")
-                  }}
+                  onNavigate={handleNavigateToEnvironment}
                 />
               ) : sidebar.viewMode === "scheduled-jobs" ? (
                 <ScheduledJobsView

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -103,21 +103,28 @@ function HomePageContent({ isMobile }: HomePageContentProps) {
 
   // isEnvironmentsRoute is derived from pathname purely for the page title
   // (matching isJobsRoute's role above): it must NOT drive view switching.
-  // usePathname() does not reliably update on the raw window.history.pushState
-  // calls this app uses for in-app navigation (confirmed: after pushState-ing
-  // away from /environments, pathname stayed "/environments" indefinitely, not
-  // just for one render), so an effect keyed on it got permanently stuck
-  // showing the environments view after visiting it once. The actual view
-  // switch instead goes through sidebar.viewMode, kept correct by
-  // useChatNavigation's handlers (handleOpenEnvironments,
-  // handleNavigateToEnvironment) and useUrlSync's popstate-driven route table:
-  // the same mechanism jobs already uses.
+  // An earlier version of this code used an effect keyed on isEnvironmentsRoute
+  // to set sidebar.viewMode, and that got permanently stuck showing the
+  // environments view after leaving it via the sidebar. The cause was not
+  // pathname going stale (Next's router does patch pushState and update it);
+  // it was that SidebarContext's value object was rebuilt unmemoized on every
+  // render, so the effect's `[isEnvironmentsRoute, sidebar]` dependency array
+  // changed identity constantly and the effect re-ran on renders that had
+  // nothing to do with the route. handleOpenScheduledJobs's pushState triggers
+  // exactly such a render (its own setViewMode call) before the pathname
+  // update from that pushState lands, and the effect re-firing in that window
+  // stomped setViewMode("chat"/"scheduled-jobs") back to "environments" with
+  // no corresponding reset in the other direction. The fix was twofold: fold
+  // environments into the same ROUTES/matchRoute table useUrlSync already uses
+  // for jobs (view switching now goes through sidebar.viewMode, kept correct
+  // by useChatNavigation's handlers and useUrlSync's popstate sync, the same
+  // mechanism jobs already uses) and memoize SidebarContext's value so no
+  // other effect keyed on the whole context object can suffer the same bug.
   const isEnvironmentsRoute = pathname?.startsWith("/environments") ?? false
 
   // For jobs and environments, the ID is derived from sidebar state (kept in
-  // sync by the navigate handlers and useUrlSync), not from pathname: pushState
-  // navigation doesn't reliably update usePathname(), so anything driving a
-  // view off pathname directly can get stuck. See isEnvironmentsRoute above.
+  // sync by the navigate handlers and useUrlSync), the same way
+  // isEnvironmentsRoute above is derived from pathname for display only.
   // Use ?? null so these are always string | null (never undefined); this
   // keeps ScheduledJobsView/EnvironmentsView in URL-controlled mode so row
   // clicks work.

--- a/packages/web/components/MobileHeader.tsx
+++ b/packages/web/components/MobileHeader.tsx
@@ -1,13 +1,13 @@
 "use client"
 
 import { useRef, useEffect } from "react"
-import { Menu, MoreVertical, ChevronDown, Pencil, Github, Trash2, Clock, Command } from "lucide-react"
+import { Menu, MoreVertical, ChevronDown, Pencil, Github, Trash2, Clock, Command, Boxes } from "lucide-react"
 import { useModals, useSidebar } from "@/lib/contexts"
 import type { Chat } from "@/lib/types"
 
 interface MobileHeaderProps {
   chat: Chat | null
-  viewMode: "chat" | "scheduled-jobs"
+  viewMode: "chat" | "scheduled-jobs" | "environments"
   githubBranchUrl: string | null
   onOpenMenu: () => void
   onOpenInGitHub: () => void
@@ -51,11 +51,16 @@ export function MobileHeader({
         <Menu className="h-5 w-5" />
       </button>
 
-      {/* Title - different for scheduled jobs vs chat */}
+      {/* Title - different for scheduled jobs / environments vs chat */}
       {viewMode === "scheduled-jobs" ? (
         <div className="flex-1 min-w-0 flex items-center gap-2 px-2 py-1 -ml-2">
           <Clock className="h-4 w-4 text-muted-foreground" />
           <span className="text-base font-semibold">Scheduled Agents</span>
+        </div>
+      ) : viewMode === "environments" ? (
+        <div className="flex-1 min-w-0 flex items-center gap-2 px-2 py-1 -ml-2">
+          <Boxes className="h-4 w-4 text-muted-foreground" />
+          <span className="text-base font-semibold">Environments</span>
         </div>
       ) : (
         <div className="relative flex-1 min-w-0" ref={mobileTitleMenuRef}>

--- a/packages/web/components/Sidebar.tsx
+++ b/packages/web/components/Sidebar.tsx
@@ -4,7 +4,7 @@ import { useState, useRef, useCallback, useEffect, useMemo } from "react"
 import { useRouter } from "next/navigation"
 import { useSession, signOut } from "next-auth/react"
 import { signInWithGitHub } from "@/lib/auth-utils"
-import { Plus, PanelLeft, X, Loader2, Clock, Search, BarChart3, Settings, HelpCircle, LogOut, BookOpen } from "lucide-react"
+import { Plus, PanelLeft, X, Loader2, Clock, Search, BarChart3, Settings, HelpCircle, LogOut, BookOpen, Boxes } from "lucide-react"
 import { usePalette } from "@/components/search-palette/PaletteProvider"
 import { cn } from "@/lib/utils"
 import { useClickOutside } from "@/lib/hooks/useClickOutside"
@@ -72,6 +72,10 @@ interface SidebarProps {
   scheduledJobsActive?: boolean
   /** Currently selected scheduled job (shown as indented item) */
   selectedScheduledJob?: { id: string; name: string } | null
+  /** Open the environments view */
+  onOpenEnvironments?: () => void
+  /** Whether the environments view is active */
+  environmentsActive?: boolean
   /** Whether chats are still being loaded from storage/server */
   isLoadingChats?: boolean
 }
@@ -105,6 +109,8 @@ export function Sidebar({
   onOpenScheduledJobs,
   scheduledJobsActive = false,
   selectedScheduledJob,
+  onOpenEnvironments,
+  environmentsActive = false,
   isLoadingChats = false,
 }: SidebarProps) {
   const modals = useModals()
@@ -412,6 +418,26 @@ export function Sidebar({
               <span className="text-base text-foreground">Scheduled Agents</span>
             </button>
 
+            {/* Environments Button */}
+            <button
+              onClick={() => {
+                if (onOpenEnvironments) {
+                  onOpenEnvironments()
+                } else {
+                  router.push("/environments")
+                }
+              }}
+              className={cn(
+                "flex items-center gap-3 w-full px-3 py-3 rounded-lg transition-colors touch-target",
+                environmentsActive
+                  ? "bg-accent text-accent-foreground"
+                  : "hover:bg-accent/50 active:bg-accent"
+              )}
+            >
+              <Boxes className={cn("h-5 w-5", environmentsActive ? "text-foreground" : "text-muted-foreground")} />
+              <span className="text-base text-foreground">Environments</span>
+            </button>
+
             {/* Docs Link */}
             <a
               href={DOCS_URL}
@@ -653,6 +679,26 @@ export function Sidebar({
         >
           <Clock className={cn("h-4 w-4", scheduledJobsActive && !selectedScheduledJob ? "text-foreground" : "text-muted-foreground")} />
           {!collapsed && <span className="text-sm text-foreground">Scheduled Agents</span>}
+        </button>
+
+        {/* Environments Button */}
+        <button
+          onClick={() => {
+            if (onOpenEnvironments) {
+              onOpenEnvironments()
+            } else {
+              router.push("/environments")
+            }
+          }}
+          title={collapsed ? "Environments" : undefined}
+          className={cn(
+            "flex items-center gap-2 rounded-md transition-colors cursor-pointer",
+            collapsed ? "p-1.5" : "w-full px-2 py-[7px]",
+            environmentsActive ? "bg-accent text-accent-foreground" : "hover:bg-accent/50"
+          )}
+        >
+          <Boxes className={cn("h-4 w-4", environmentsActive ? "text-foreground" : "text-muted-foreground")} />
+          {!collapsed && <span className="text-sm text-foreground">Environments</span>}
         </button>
 
         {/* Docs Link */}

--- a/packages/web/components/chat/ChatInput.tsx
+++ b/packages/web/components/chat/ChatInput.tsx
@@ -13,6 +13,7 @@ import { PendingFilesDisplay } from "./PendingFilesDisplay"
 import { AgentModelSelector } from "./AgentModelSelector"
 import { CreditWarningBanner } from "./CreditWarningBanner"
 import { RepoCombobox } from "./RepoCombobox"
+import { EnvironmentCombobox } from "./EnvironmentCombobox"
 import { BranchCombobox } from "./BranchCombobox"
 import { McpServersCombobox } from "./McpServersCombobox"
 import { SlashCommandMenu, type SlashCommandType } from "../SlashCommandMenu"
@@ -599,6 +600,15 @@ export function ChatInput({
                 </span>
               </a>
             )}
+
+            {/* Environment picker: the environment the chat's sandbox is/will be built from */}
+            <EnvironmentCombobox
+              repo={isNewRepo ? null : chat.repo}
+              value={chat.environmentId ?? null}
+              onChange={(environmentId) => onUpdateChat?.({ environmentId })}
+              disabled={!canSelectExistingRepo}
+              isMobile={isMobile}
+            />
 
             {/* MCP servers picker */}
             {showMcpButton && (

--- a/packages/web/components/chat/EnvironmentCombobox.test.ts
+++ b/packages/web/components/chat/EnvironmentCombobox.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest"
+import { resolveEnvironmentPicker } from "./EnvironmentCombobox"
+import type { EnvironmentDTO } from "@/lib/environments"
+
+function env(overrides: Partial<EnvironmentDTO> = {}): EnvironmentDTO {
+  return {
+    id: "env_1",
+    repo: "acme/app",
+    name: "Default",
+    isDefault: true,
+    networkMode: "full",
+    allowedDomains: [],
+    variables: {},
+    hasSetupScript: false,
+    setupScript: null,
+    setupScriptUpdatedBy: null,
+    updatedAt: 0,
+    ...overrides,
+  }
+}
+
+describe("resolveEnvironmentPicker", () => {
+  it("hides the picker when there are no environments and no value", () => {
+    const result = resolveEnvironmentPicker([], null)
+    expect(result.visible).toBe(false)
+    expect(result.selected).toBeUndefined()
+  })
+
+  it("hides the picker for a single environment before any value is pinned", () => {
+    const environments = [env()]
+    const result = resolveEnvironmentPicker(environments, null)
+    expect(result.visible).toBe(false)
+  })
+
+  it("shows a single environment once a value is pinned, selecting it", () => {
+    const environments = [env({ id: "env_1" })]
+    const result = resolveEnvironmentPicker(environments, "env_1")
+    expect(result.visible).toBe(true)
+    expect(result.selected?.id).toBe("env_1")
+  })
+
+  it("shows the picker for two or more environments even with no value, selecting the default", () => {
+    const environments = [
+      env({ id: "env_1", isDefault: true, name: "Default" }),
+      env({ id: "env_2", isDefault: false, name: "Staging" }),
+    ]
+    const result = resolveEnvironmentPicker(environments, null)
+    expect(result.visible).toBe(true)
+    expect(result.selected?.id).toBe("env_1")
+  })
+
+  it("falls back to the default when the value doesn't match any environment", () => {
+    const environments = [
+      env({ id: "env_1", isDefault: true, name: "Default" }),
+      env({ id: "env_2", isDefault: false, name: "Staging" }),
+    ]
+    const result = resolveEnvironmentPicker(environments, "env_deleted")
+    expect(result.visible).toBe(true)
+    expect(result.selected?.id).toBe("env_1")
+  })
+
+  it("selects the pinned non-default environment when it matches", () => {
+    const environments = [
+      env({ id: "env_1", isDefault: true, name: "Default" }),
+      env({ id: "env_2", isDefault: false, name: "Staging" }),
+    ]
+    const result = resolveEnvironmentPicker(environments, "env_2")
+    expect(result.visible).toBe(true)
+    expect(result.selected?.id).toBe("env_2")
+  })
+})

--- a/packages/web/components/chat/EnvironmentCombobox.test.ts
+++ b/packages/web/components/chat/EnvironmentCombobox.test.ts
@@ -11,6 +11,7 @@ function env(overrides: Partial<EnvironmentDTO> = {}): EnvironmentDTO {
     networkMode: "full",
     allowedDomains: [],
     variables: {},
+    variableCount: 0,
     hasSetupScript: false,
     setupScript: null,
     setupScriptUpdatedBy: null,

--- a/packages/web/components/chat/EnvironmentCombobox.tsx
+++ b/packages/web/components/chat/EnvironmentCombobox.tsx
@@ -1,0 +1,148 @@
+"use client"
+
+import { useState } from "react"
+import { Boxes, ChevronDown } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { isRealRepo } from "@/lib/types"
+// Type-only: EnvironmentDTO's module imports @/lib/db/prisma. A plain value
+// import here would pull Prisma into the browser bundle.
+import type { EnvironmentDTO } from "@/lib/environments"
+import { useEnvironmentsQuery } from "@/lib/query/hooks/useEnvironmentsQuery"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command"
+
+interface EnvironmentComboboxProps {
+  /** Repo full_name the chat is on, NEW_REPOSITORY, or null (no repo yet). */
+  repo: string | null
+  /** The chat's currently pinned environment id, or null. */
+  value: string | null
+  /** Called with the id of the environment the user picked. */
+  onChange: (environmentId: string) => void
+  /** True once the chat has a sandbox (or has messages): the environment is
+   *  fixed from then on, the same rule the repo picker follows. */
+  disabled?: boolean
+  isMobile?: boolean
+  showLabel?: boolean
+}
+
+/**
+ * Whether the picker should render at all, and which environment it should
+ * show as selected, given the repo's environments and the chat's current
+ * value.
+ *
+ * A repo with fewer than two environments has nothing to choose between: the
+ * sole environment is already applied server-side, so showing a one-item
+ * dropdown before any value is pinned would just be noise. Once a value IS
+ * pinned (the chat exists and has been resolved to a concrete environment),
+ * the control stays visible even with one option: at that point it is no
+ * longer a choice, it's a statement of which environment this chat actually
+ * uses, and hiding it would let a user believe a chat has none.
+ */
+export function resolveEnvironmentPicker(
+  environments: EnvironmentDTO[],
+  value: string | null
+): { visible: boolean; selected: EnvironmentDTO | undefined } {
+  if (environments.length < 2 && !value) {
+    return { visible: false, selected: undefined }
+  }
+  const selected =
+    environments.find((e) => e.id === value) ?? environments.find((e) => e.isDefault)
+  return { visible: true, selected }
+}
+
+export function EnvironmentCombobox({
+  repo,
+  value,
+  onChange,
+  disabled = false,
+  isMobile = false,
+  showLabel = false,
+}: EnvironmentComboboxProps) {
+  const [open, setOpen] = useState(false)
+  const queryRepo = repo && isRealRepo(repo) ? repo : undefined
+  const { data: environments = [] } = useEnvironmentsQuery(queryRepo)
+
+  // NEW_REPOSITORY chats (and chats with no repo yet) have no repo to scope
+  // an environment to.
+  if (!isRealRepo(repo)) return null
+
+  const { visible, selected } = resolveEnvironmentPicker(environments, value)
+  if (!visible) return null
+
+  const displayLabel = selected?.name ?? "Environment"
+
+  const handleSelect = (environmentId: string) => {
+    onChange(environmentId)
+    setOpen(false)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          disabled={disabled}
+          aria-label="Environment"
+          className={cn(
+            "flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors cursor-pointer text-sm",
+            disabled && "opacity-50 cursor-not-allowed"
+          )}
+          title={
+            disabled
+              ? `${displayLabel} (fixed once a chat has started)`
+              : displayLabel
+          }
+        >
+          <Boxes className={cn(isMobile ? "h-4 w-4" : "h-3.5 w-3.5")} />
+          <span className={cn(
+            showLabel ? "inline" : (isMobile ? "hidden @[16rem]/row1:inline" : "hidden @[32rem]:inline")
+          )}>
+            {displayLabel}
+          </span>
+          <ChevronDown className={cn(isMobile ? "h-4 w-4 hidden @[16rem]/row1:block" : "h-3.5 w-3.5")} />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-56 p-0"
+        align="start"
+        side="bottom"
+        sideOffset={8}
+      >
+        <Command>
+          <CommandList>
+            <CommandEmpty>No environments</CommandEmpty>
+            <CommandGroup>
+              {environments.map((env) => (
+                <CommandItem
+                  key={env.id}
+                  value={env.id}
+                  onSelect={() => handleSelect(env.id)}
+                  className={cn(
+                    "flex items-center gap-2 cursor-pointer",
+                    selected?.id === env.id && "bg-accent"
+                  )}
+                >
+                  <Boxes className="h-4 w-4 text-muted-foreground shrink-0" />
+                  <span className="flex-1 truncate">{env.name}</span>
+                  {env.isDefault && (
+                    <span className="text-xs text-muted-foreground">default</span>
+                  )}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/packages/web/components/environments/EnvironmentEditor.tsx
+++ b/packages/web/components/environments/EnvironmentEditor.tsx
@@ -131,15 +131,25 @@ export function EnvironmentEditor({ environment, onBack, onDeleted, onDuplicated
   }
 
   const askDelete = async () => {
+    // Await the usage count before opening the dialog. ConfirmDialog has no
+    // disabled/loading affordance and auto-focuses its confirm button on
+    // open, so opening it first and filling in the count afterward would
+    // leave a window where an enabled, auto-focused Delete (reachable by a
+    // single click or a single Enter keypress) fires before the count the
+    // whole dialog exists to show has arrived. The Delete button in the
+    // header is disabled for this same window so a second click can't start
+    // an overlapping fetch, but that alone doesn't protect the dialog itself
+    // once it's open, which is why the dialog must not open until we know
+    // what to tell the user.
     setError(null)
     setUsage({ status: "loading" })
-    setConfirmDelete(true)
     try {
       const chatCount = await fetchEnvironmentUsage(environment.id)
       setUsage({ status: "known", chatCount })
     } catch {
       setUsage({ status: "unknown" })
     }
+    setConfirmDelete(true)
   }
 
   const confirmDeleteNow = async () => {

--- a/packages/web/components/environments/EnvironmentEditor.tsx
+++ b/packages/web/components/environments/EnvironmentEditor.tsx
@@ -77,27 +77,44 @@ function EnvVarRow({
   )
 }
 
+/**
+ * Usage-count fetch result for the delete confirmation.
+ * - "idle": haven't asked yet (initial state; the Delete button must NOT be
+ *   disabled here, or it could never be clicked to start a fetch at all).
+ * - "loading": the /usage request is in flight; the Delete button is
+ *   disabled so a fast double-click can't open two overlapping fetches.
+ * - "unknown": the /usage request failed, distinct from a genuine 0, since
+ *   the whole point of this number is telling the user what a destructive
+ *   action will affect.
+ */
+type UsageState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "known"; chatCount: number }
+  | { status: "unknown" }
+
 export function EnvironmentEditor({ environment, onBack, onDeleted, onDuplicated }: EnvironmentEditorProps) {
+  // No re-seed effect: EnvironmentsView keys this component by environment.id,
+  // so switching environments mounts a fresh instance (fresh useState calls)
+  // instead of reusing one whose state would need reconciling against props.
+  // That also means a mutation's query-invalidation refetch (new environment
+  // object, same id) never silently overwrites unsaved edits mid-session.
   const [name, setName] = useState(environment.name)
   const [variables, setVariables] = useState<EnvVar[]>(recordToEnvVars(environment.variables))
   const [newVarId, setNewVarId] = useState<string | null>(null)
   const [setupScript, setSetupScript] = useState(environment.setupScript ?? "")
   const [error, setError] = useState<string | null>(null)
   const [confirmDelete, setConfirmDelete] = useState(false)
-  const [deleteChatCount, setDeleteChatCount] = useState(0)
+  const [usage, setUsage] = useState<UsageState>({ status: "idle" })
+  const [confirmPromote, setConfirmPromote] = useState(false)
 
+  // Separate mutation instances for save vs. promote so their `isPending`
+  // flags don't cross-contaminate each other's button (promoting default
+  // shouldn't make the Save button read "Saving", and vice versa).
   const update = useUpdateEnvironmentMutation()
+  const promote = useUpdateEnvironmentMutation()
   const remove = useDeleteEnvironmentMutation()
   const create = useCreateEnvironmentMutation()
-
-  // Re-seed local state when a different environment is selected.
-  useEffect(() => {
-    setName(environment.name)
-    setVariables(recordToEnvVars(environment.variables))
-    setNewVarId(null)
-    setSetupScript(environment.setupScript ?? "")
-    setError(null)
-  }, [environment])
 
   const save = async () => {
     setError(null)
@@ -115,9 +132,14 @@ export function EnvironmentEditor({ environment, onBack, onDeleted, onDuplicated
 
   const askDelete = async () => {
     setError(null)
-    const chatCount = await fetchEnvironmentUsage(environment.id).catch(() => 0)
-    setDeleteChatCount(chatCount)
+    setUsage({ status: "loading" })
     setConfirmDelete(true)
+    try {
+      const chatCount = await fetchEnvironmentUsage(environment.id)
+      setUsage({ status: "known", chatCount })
+    } catch {
+      setUsage({ status: "unknown" })
+    }
   }
 
   const confirmDeleteNow = async () => {
@@ -129,6 +151,19 @@ export function EnvironmentEditor({ environment, onBack, onDeleted, onDuplicated
       // so a failure (e.g. "promote another environment to default first")
       // has to surface on the main editor, not inside the closed dialog.
       setError(err instanceof Error ? err.message : "Failed to delete")
+    }
+  }
+
+  const confirmPromoteNow = async () => {
+    setError(null)
+    try {
+      await promote.mutateAsync({ id: environment.id, isDefault: true })
+    } catch (err) {
+      // Same reasoning as confirmDeleteNow: ConfirmDialog closes itself
+      // immediately regardless of the async result, so a failed promotion
+      // (e.g. the P2002 race the API reports a specific message for) has to
+      // surface on the main editor rather than vanish with the dialog.
+      setError(err instanceof Error ? err.message : "Failed to make default")
     }
   }
 
@@ -165,8 +200,8 @@ export function EnvironmentEditor({ environment, onBack, onDeleted, onDuplicated
         <div className="ml-auto flex items-center gap-2 shrink-0">
           {!environment.isDefault && (
             <button
-              onClick={() => update.mutate({ id: environment.id, isDefault: true })}
-              disabled={update.isPending}
+              onClick={() => setConfirmPromote(true)}
+              disabled={promote.isPending}
               className="inline-flex items-center gap-1 px-2 py-1 text-sm rounded-md border border-border hover:bg-accent transition-colors cursor-pointer disabled:opacity-50"
             >
               <Star className="w-3.5 h-3.5" /> Make default
@@ -181,7 +216,8 @@ export function EnvironmentEditor({ environment, onBack, onDeleted, onDuplicated
           </button>
           <button
             onClick={askDelete}
-            className="inline-flex items-center gap-1 px-2 py-1 text-sm rounded-md border border-border hover:bg-accent text-destructive transition-colors cursor-pointer"
+            disabled={usage.status === "loading"}
+            className="inline-flex items-center gap-1 px-2 py-1 text-sm rounded-md border border-border hover:bg-accent text-destructive transition-colors cursor-pointer disabled:opacity-50"
           >
             <Trash2 className="w-3.5 h-3.5" /> Delete
           </button>
@@ -284,13 +320,26 @@ export function EnvironmentEditor({ environment, onBack, onDeleted, onDuplicated
         onClose={() => setConfirmDelete(false)}
         title={`Delete "${environment.name}"?`}
         description={
-          deleteChatCount > 0
-            ? `${deleteChatCount} ${deleteChatCount === 1 ? "chat uses" : "chats use"} this environment and will fall back to the repo's default on their next sandbox.`
-            : "No chats use this environment."
+          usage.status === "idle" || usage.status === "loading"
+            ? "Checking how many chats use this environment..."
+            : usage.status === "unknown"
+              ? "Could not determine how many chats use this environment. Deleting it will still move any that do to the repo's default on their next sandbox."
+              : usage.chatCount > 0
+                ? `${usage.chatCount} ${usage.chatCount === 1 ? "chat uses" : "chats use"} this environment and will fall back to the repo's default on their next sandbox.`
+                : "No chats use this environment."
         }
         confirmLabel="Delete"
         variant="destructive"
         onConfirm={confirmDeleteNow}
+      />
+
+      <ConfirmDialog
+        open={confirmPromote}
+        onClose={() => setConfirmPromote(false)}
+        title={`Make "${environment.name}" the default for ${environment.repo}?`}
+        description="Every future chat on this repo that doesn't pin a specific environment will be built from this one from now on."
+        confirmLabel="Make default"
+        onConfirm={confirmPromoteNow}
       />
     </div>
   )

--- a/packages/web/components/environments/EnvironmentEditor.tsx
+++ b/packages/web/components/environments/EnvironmentEditor.tsx
@@ -1,0 +1,297 @@
+"use client"
+
+import { useState, useEffect, useRef } from "react"
+import { ArrowLeft, Save, Trash2, Copy, Star, Plus, Loader2 } from "lucide-react"
+import { NetworkModeFields } from "./NetworkModeFields"
+import { recordToEnvVars, envVarsToRecord } from "./helpers"
+import {
+  useUpdateEnvironmentMutation,
+  useDeleteEnvironmentMutation,
+  useCreateEnvironmentMutation,
+  fetchEnvironmentUsage,
+} from "@/lib/query/hooks/useEnvironmentsQuery"
+import { ConfirmDialog } from "@/components/modals/ConfirmDialog"
+import { Input } from "@/components/ui/input"
+import type { EnvVar } from "@/lib/types"
+// Type-only: EnvironmentDTO's module imports @/lib/db/prisma.
+import type { EnvironmentDTO } from "@/lib/environments"
+
+interface EnvironmentEditorProps {
+  environment: EnvironmentDTO
+  onBack: () => void
+  onDeleted: () => void
+  /** Navigate to the duplicated environment once it's created. */
+  onDuplicated: (id: string) => void
+}
+
+function EnvVarRow({
+  envVar,
+  onChange,
+  onDelete,
+  autoFocus,
+}: {
+  envVar: EnvVar
+  onChange: (updated: EnvVar) => void
+  onDelete: () => void
+  autoFocus?: boolean
+}) {
+  const keyRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (autoFocus) {
+      keyRef.current?.focus()
+    }
+  }, [autoFocus])
+
+  return (
+    <div className="flex items-center gap-2 py-1">
+      <Input
+        ref={keyRef}
+        type="text"
+        value={envVar.key}
+        onChange={(e) => onChange({ ...envVar, key: e.target.value })}
+        placeholder="KEY"
+        className="flex-1 font-mono text-sm"
+        autoComplete="off"
+        spellCheck={false}
+      />
+      <span className="text-muted-foreground">=</span>
+      <Input
+        type="password"
+        value={envVar.value}
+        onChange={(e) => onChange({ ...envVar, value: e.target.value })}
+        placeholder="value"
+        className="flex-1 font-mono text-sm"
+        autoComplete="off"
+        spellCheck={false}
+      />
+      <button
+        type="button"
+        onClick={onDelete}
+        className="p-1.5 rounded-md text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors cursor-pointer"
+        aria-label={`Remove ${envVar.key || "variable"}`}
+      >
+        <Trash2 className="h-4 w-4" />
+      </button>
+    </div>
+  )
+}
+
+export function EnvironmentEditor({ environment, onBack, onDeleted, onDuplicated }: EnvironmentEditorProps) {
+  const [name, setName] = useState(environment.name)
+  const [variables, setVariables] = useState<EnvVar[]>(recordToEnvVars(environment.variables))
+  const [newVarId, setNewVarId] = useState<string | null>(null)
+  const [setupScript, setSetupScript] = useState(environment.setupScript ?? "")
+  const [error, setError] = useState<string | null>(null)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const [deleteChatCount, setDeleteChatCount] = useState(0)
+
+  const update = useUpdateEnvironmentMutation()
+  const remove = useDeleteEnvironmentMutation()
+  const create = useCreateEnvironmentMutation()
+
+  // Re-seed local state when a different environment is selected.
+  useEffect(() => {
+    setName(environment.name)
+    setVariables(recordToEnvVars(environment.variables))
+    setNewVarId(null)
+    setSetupScript(environment.setupScript ?? "")
+    setError(null)
+  }, [environment])
+
+  const save = async () => {
+    setError(null)
+    try {
+      await update.mutateAsync({
+        id: environment.id,
+        name,
+        variables: envVarsToRecord(variables),
+        setupScript: setupScript || null,
+      })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save")
+    }
+  }
+
+  const askDelete = async () => {
+    setError(null)
+    const chatCount = await fetchEnvironmentUsage(environment.id).catch(() => 0)
+    setDeleteChatCount(chatCount)
+    setConfirmDelete(true)
+  }
+
+  const confirmDeleteNow = async () => {
+    try {
+      await remove.mutateAsync(environment.id)
+      onDeleted()
+    } catch (err) {
+      // The delete confirmation closes itself immediately (see ConfirmDialog),
+      // so a failure (e.g. "promote another environment to default first")
+      // has to surface on the main editor, not inside the closed dialog.
+      setError(err instanceof Error ? err.message : "Failed to delete")
+    }
+  }
+
+  const duplicate = async () => {
+    setError(null)
+    try {
+      const created = await create.mutateAsync({
+        repo: environment.repo,
+        name: `${environment.name} (copy)`,
+        duplicateOf: environment.id,
+      })
+      onDuplicated(created.id)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to duplicate")
+    }
+  }
+
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      <div className="flex items-center gap-2 px-4 py-3 border-b border-border shrink-0">
+        <button
+          onClick={onBack}
+          aria-label="Back to environments"
+          className="p-1 hover:bg-accent rounded-md transition-colors cursor-pointer"
+        >
+          <ArrowLeft className="w-4 h-4" />
+        </button>
+        <span className="text-sm text-muted-foreground font-mono truncate">{environment.repo}</span>
+        <span className="text-muted-foreground">/</span>
+        <span className="text-sm font-medium truncate">{environment.name}</span>
+        {environment.isDefault && (
+          <span className="text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground shrink-0">Default</span>
+        )}
+        <div className="ml-auto flex items-center gap-2 shrink-0">
+          {!environment.isDefault && (
+            <button
+              onClick={() => update.mutate({ id: environment.id, isDefault: true })}
+              disabled={update.isPending}
+              className="inline-flex items-center gap-1 px-2 py-1 text-sm rounded-md border border-border hover:bg-accent transition-colors cursor-pointer disabled:opacity-50"
+            >
+              <Star className="w-3.5 h-3.5" /> Make default
+            </button>
+          )}
+          <button
+            onClick={duplicate}
+            disabled={create.isPending}
+            className="inline-flex items-center gap-1 px-2 py-1 text-sm rounded-md border border-border hover:bg-accent transition-colors cursor-pointer disabled:opacity-50"
+          >
+            <Copy className="w-3.5 h-3.5" /> Duplicate
+          </button>
+          <button
+            onClick={askDelete}
+            className="inline-flex items-center gap-1 px-2 py-1 text-sm rounded-md border border-border hover:bg-accent text-destructive transition-colors cursor-pointer"
+          >
+            <Trash2 className="w-3.5 h-3.5" /> Delete
+          </button>
+          <button
+            onClick={save}
+            disabled={update.isPending || !name.trim()}
+            className="inline-flex items-center gap-1 px-3 py-1 text-sm rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors cursor-pointer disabled:opacity-50"
+          >
+            {update.isPending ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Save className="w-3.5 h-3.5" />}
+            {update.isPending ? "Saving" : "Save"}
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div role="alert" className="mx-4 mt-3 px-3 py-2 text-sm rounded-md bg-destructive/10 text-destructive shrink-0">
+          {error}
+        </div>
+      )}
+
+      <div className="flex-1 min-h-0 grid grid-cols-1 lg:grid-cols-2 gap-6 p-4 overflow-y-auto">
+        <div className="space-y-6">
+          <section className="space-y-2">
+            <label htmlFor="environment-name" className="text-sm font-medium">
+              Name
+            </label>
+            <Input
+              id="environment-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="max-w-sm"
+            />
+          </section>
+
+          <section className="space-y-2">
+            <h3 className="text-sm font-medium">Network access</h3>
+            <NetworkModeFields
+              networkMode={environment.networkMode}
+              allowedDomains={environment.allowedDomains}
+            />
+            <p className="text-xs text-muted-foreground">
+              Network changes take effect on the next sandbox, not on chats that are already running.
+            </p>
+          </section>
+
+          <section className="space-y-2">
+            <h3 className="text-sm font-medium">Environment variables</h3>
+            <p className="text-xs text-muted-foreground">
+              Available to the agent on every chat that uses this environment.
+            </p>
+            <button
+              type="button"
+              onClick={() => {
+                const newVar: EnvVar = { id: crypto.randomUUID(), key: "", value: "" }
+                setNewVarId(newVar.id)
+                setVariables((prev) => [...prev, newVar])
+              }}
+              className="flex items-center gap-2 w-full py-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+            >
+              <Plus className="h-4 w-4" />
+              Add variable
+            </button>
+            {variables.length > 0 && (
+              <div className="space-y-0.5">
+                {variables.map((envVar) => (
+                  <EnvVarRow
+                    key={envVar.id}
+                    envVar={envVar}
+                    onChange={(updated) =>
+                      setVariables((prev) => prev.map((v) => (v.id === envVar.id ? updated : v)))
+                    }
+                    onDelete={() => setVariables((prev) => prev.filter((v) => v.id !== envVar.id))}
+                    autoFocus={envVar.id === newVarId}
+                  />
+                ))}
+              </div>
+            )}
+          </section>
+        </div>
+
+        <div className="flex flex-col min-h-0">
+          <h3 className="text-sm font-medium mb-2">Setup script</h3>
+          <p className="text-xs text-muted-foreground mb-2">
+            Runs in the repo directory when a sandbox is created (not executed yet in this version
+            of the app). Put secrets in environment variables above, not in this script: the script
+            is stored unencrypted.
+          </p>
+          <textarea
+            value={setupScript}
+            onChange={(e) => setSetupScript(e.target.value)}
+            spellCheck={false}
+            placeholder={"#!/usr/bin/env bash\nset -euo pipefail\n\nnpm install"}
+            className="flex-1 min-h-[300px] w-full px-3 py-2 text-sm font-mono rounded-md border border-border bg-background resize-none focus:outline-none focus:ring-2 focus:ring-ring/40"
+          />
+        </div>
+      </div>
+
+      <ConfirmDialog
+        open={confirmDelete}
+        onClose={() => setConfirmDelete(false)}
+        title={`Delete "${environment.name}"?`}
+        description={
+          deleteChatCount > 0
+            ? `${deleteChatCount} ${deleteChatCount === 1 ? "chat uses" : "chats use"} this environment and will fall back to the repo's default on their next sandbox.`
+            : "No chats use this environment."
+        }
+        confirmLabel="Delete"
+        variant="destructive"
+        onConfirm={confirmDeleteNow}
+      />
+    </div>
+  )
+}

--- a/packages/web/components/environments/EnvironmentEditor.tsx
+++ b/packages/web/components/environments/EnvironmentEditor.tsx
@@ -100,7 +100,9 @@ export function EnvironmentEditor({ environment, onBack, onDeleted, onDuplicated
   // That also means a mutation's query-invalidation refetch (new environment
   // object, same id) never silently overwrites unsaved edits mid-session.
   const [name, setName] = useState(environment.name)
-  const [variables, setVariables] = useState<EnvVar[]>(recordToEnvVars(environment.variables))
+  const [variables, setVariables] = useState<EnvVar[]>(
+    recordToEnvVars(environment.variables ?? {})
+  )
   const [newVarId, setNewVarId] = useState<string | null>(null)
   const [setupScript, setSetupScript] = useState(environment.setupScript ?? "")
   const [error, setError] = useState<string | null>(null)

--- a/packages/web/components/environments/EnvironmentsList.tsx
+++ b/packages/web/components/environments/EnvironmentsList.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Boxes, Globe, Lock, FileCode } from "lucide-react"
+import { Boxes, Globe, Lock, FileCode, Plus, Loader2 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { groupEnvironmentsByRepo } from "./helpers"
 // Type-only: EnvironmentDTO's module imports @/lib/db/prisma.
@@ -9,6 +9,11 @@ import type { EnvironmentDTO } from "@/lib/environments"
 interface EnvironmentsListProps {
   environments: EnvironmentDTO[]
   onSelect: (id: string) => void
+  /** Create a new environment for this repo and navigate to it. */
+  onCreate: (repo: string) => void
+  /** The repo currently being created for, if any, so its button can show a
+   *  spinner and the others stay clickable. */
+  creatingRepo?: string | null
 }
 
 function NetworkModeBadge({ env }: { env: EnvironmentDTO }) {
@@ -27,7 +32,12 @@ function NetworkModeBadge({ env }: { env: EnvironmentDTO }) {
   )
 }
 
-export function EnvironmentsList({ environments, onSelect }: EnvironmentsListProps) {
+export function EnvironmentsList({
+  environments,
+  onSelect,
+  onCreate,
+  creatingRepo = null,
+}: EnvironmentsListProps) {
   if (environments.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center h-full text-center gap-2 text-muted-foreground p-6">
@@ -44,7 +54,22 @@ export function EnvironmentsList({ environments, onSelect }: EnvironmentsListPro
     <div className="p-4 space-y-6">
       {Object.entries(byRepo).map(([repo, envs]) => (
         <section key={repo}>
-          <h2 className="text-xs font-mono text-muted-foreground mb-2">{repo}</h2>
+          <div className="flex items-center justify-between mb-2">
+            <h2 className="text-xs font-mono text-muted-foreground">{repo}</h2>
+            <button
+              type="button"
+              onClick={() => onCreate(repo)}
+              disabled={creatingRepo === repo}
+              className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer disabled:opacity-50"
+            >
+              {creatingRepo === repo ? (
+                <Loader2 className="w-3.5 h-3.5 animate-spin" />
+              ) : (
+                <Plus className="w-3.5 h-3.5" />
+              )}
+              New
+            </button>
+          </div>
 
           {/* Mobile card layout */}
           <div className="space-y-2 md:hidden">
@@ -65,8 +90,8 @@ export function EnvironmentsList({ environments, onSelect }: EnvironmentsListPro
                 <div className="mt-1.5 flex items-center gap-3 text-xs text-muted-foreground">
                   <NetworkModeBadge env={env} />
                   <span>
-                    {Object.keys(env.variables).length}{" "}
-                    {Object.keys(env.variables).length === 1 ? "variable" : "variables"}
+                    {env.variableCount}{" "}
+                    {env.variableCount === 1 ? "variable" : "variables"}
                   </span>
                   {env.hasSetupScript && (
                     <span className="inline-flex items-center gap-1">
@@ -95,8 +120,8 @@ export function EnvironmentsList({ environments, onSelect }: EnvironmentsListPro
                 <span className="ml-auto flex items-center gap-3 text-xs text-muted-foreground">
                   <NetworkModeBadge env={env} />
                   <span>
-                    {Object.keys(env.variables).length}{" "}
-                    {Object.keys(env.variables).length === 1 ? "variable" : "variables"}
+                    {env.variableCount}{" "}
+                    {env.variableCount === 1 ? "variable" : "variables"}
                   </span>
                   {env.hasSetupScript && (
                     <span className="inline-flex items-center gap-1">

--- a/packages/web/components/environments/EnvironmentsList.tsx
+++ b/packages/web/components/environments/EnvironmentsList.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Boxes, Globe, Lock, FileCode, Star } from "lucide-react"
+import { Boxes, Globe, Lock, FileCode } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { groupEnvironmentsByRepo } from "./helpers"
 // Type-only: EnvironmentDTO's module imports @/lib/db/prisma.
@@ -49,15 +49,17 @@ export function EnvironmentsList({ environments, onSelect }: EnvironmentsListPro
           {/* Mobile card layout */}
           <div className="space-y-2 md:hidden">
             {envs.map((env) => (
-              <div
+              <button
                 key={env.id}
                 onClick={() => onSelect(env.id)}
-                className="rounded-lg border border-border bg-white/50 dark:bg-white/5 p-3 cursor-pointer"
+                className="w-full text-left rounded-lg border border-border bg-white/50 dark:bg-white/5 p-3 cursor-pointer"
               >
                 <div className="flex items-center gap-2">
                   <span className="text-sm font-medium truncate">{env.name}</span>
                   {env.isDefault && (
-                    <Star className="w-3 h-3 text-muted-foreground shrink-0" aria-label="Default" />
+                    <span className="text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground shrink-0">
+                      Default
+                    </span>
                   )}
                 </div>
                 <div className="mt-1.5 flex items-center gap-3 text-xs text-muted-foreground">
@@ -72,7 +74,7 @@ export function EnvironmentsList({ environments, onSelect }: EnvironmentsListPro
                     </span>
                   )}
                 </div>
-              </div>
+              </button>
             ))}
           </div>
 

--- a/packages/web/components/environments/EnvironmentsList.tsx
+++ b/packages/web/components/environments/EnvironmentsList.tsx
@@ -1,0 +1,112 @@
+"use client"
+
+import { Boxes, Globe, Lock, FileCode, Star } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { groupEnvironmentsByRepo } from "./helpers"
+// Type-only: EnvironmentDTO's module imports @/lib/db/prisma.
+import type { EnvironmentDTO } from "@/lib/environments"
+
+interface EnvironmentsListProps {
+  environments: EnvironmentDTO[]
+  onSelect: (id: string) => void
+}
+
+function NetworkModeBadge({ env }: { env: EnvironmentDTO }) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      {env.networkMode === "full" ? (
+        <>
+          <Globe className="w-3.5 h-3.5" /> Full access
+        </>
+      ) : (
+        <>
+          <Lock className="w-3.5 h-3.5" /> Restricted
+        </>
+      )}
+    </span>
+  )
+}
+
+export function EnvironmentsList({ environments, onSelect }: EnvironmentsListProps) {
+  if (environments.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full text-center gap-2 text-muted-foreground p-6">
+        <Boxes className="w-8 h-8" />
+        <p className="text-sm">No environments yet.</p>
+        <p className="text-xs">One is created automatically the first time you chat on a repo.</p>
+      </div>
+    )
+  }
+
+  const byRepo = groupEnvironmentsByRepo(environments)
+
+  return (
+    <div className="p-4 space-y-6">
+      {Object.entries(byRepo).map(([repo, envs]) => (
+        <section key={repo}>
+          <h2 className="text-xs font-mono text-muted-foreground mb-2">{repo}</h2>
+
+          {/* Mobile card layout */}
+          <div className="space-y-2 md:hidden">
+            {envs.map((env) => (
+              <div
+                key={env.id}
+                onClick={() => onSelect(env.id)}
+                className="rounded-lg border border-border bg-white/50 dark:bg-white/5 p-3 cursor-pointer"
+              >
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium truncate">{env.name}</span>
+                  {env.isDefault && (
+                    <Star className="w-3 h-3 text-muted-foreground shrink-0" aria-label="Default" />
+                  )}
+                </div>
+                <div className="mt-1.5 flex items-center gap-3 text-xs text-muted-foreground">
+                  <NetworkModeBadge env={env} />
+                  <span>
+                    {Object.keys(env.variables).length}{" "}
+                    {Object.keys(env.variables).length === 1 ? "variable" : "variables"}
+                  </span>
+                  {env.hasSetupScript && (
+                    <span className="inline-flex items-center gap-1">
+                      <FileCode className="w-3.5 h-3.5" /> Setup script
+                    </span>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Desktop list layout */}
+          <div className="hidden md:block space-y-1">
+            {envs.map((env) => (
+              <button
+                key={env.id}
+                onClick={() => onSelect(env.id)}
+                className="w-full flex items-center gap-3 px-3 py-2 rounded-md border border-border hover:bg-accent transition-colors text-left cursor-pointer"
+              >
+                <span className={cn("text-sm font-medium", env.isDefault && "text-foreground")}>
+                  {env.name}
+                </span>
+                {env.isDefault && (
+                  <span className="text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground">Default</span>
+                )}
+                <span className="ml-auto flex items-center gap-3 text-xs text-muted-foreground">
+                  <NetworkModeBadge env={env} />
+                  <span>
+                    {Object.keys(env.variables).length}{" "}
+                    {Object.keys(env.variables).length === 1 ? "variable" : "variables"}
+                  </span>
+                  {env.hasSetupScript && (
+                    <span className="inline-flex items-center gap-1">
+                      <FileCode className="w-3.5 h-3.5" /> Setup script
+                    </span>
+                  )}
+                </span>
+              </button>
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  )
+}

--- a/packages/web/components/environments/EnvironmentsView.tsx
+++ b/packages/web/components/environments/EnvironmentsView.tsx
@@ -47,7 +47,13 @@ export function EnvironmentsView({ urlEnvironmentId, onNavigate }: EnvironmentsV
             </button>
           </div>
         ) : selected ? (
+          // Keyed by id so switching environments mounts a fresh
+          // EnvironmentEditor instance (fresh useState) instead of reusing one
+          // whose local edit state would need reconciling against new props:
+          // that reconciliation effect was also what let a mutation's
+          // query-invalidation refetch silently overwrite unsaved typing.
           <EnvironmentEditor
+            key={selected.id}
             environment={selected}
             onBack={() => onNavigate(null)}
             onDeleted={() => onNavigate(null)}

--- a/packages/web/components/environments/EnvironmentsView.tsx
+++ b/packages/web/components/environments/EnvironmentsView.tsx
@@ -1,8 +1,12 @@
 "use client"
 
+import { useState } from "react"
 import { EnvironmentsList } from "./EnvironmentsList"
 import { EnvironmentEditor } from "./EnvironmentEditor"
-import { useEnvironmentsQuery } from "@/lib/query/hooks/useEnvironmentsQuery"
+import {
+  useEnvironmentsQuery,
+  useCreateEnvironmentMutation,
+} from "@/lib/query/hooks/useEnvironmentsQuery"
 
 interface EnvironmentsViewProps {
   /** Environment id from the URL. Null shows the list. */
@@ -11,8 +15,35 @@ interface EnvironmentsViewProps {
 }
 
 export function EnvironmentsView({ urlEnvironmentId, onNavigate }: EnvironmentsViewProps) {
-  const { data: environments = [], isLoading, error } = useEnvironmentsQuery()
+  // includeVariables: true because this view is also where EnvironmentEditor
+  // reads and writes variables (selected below). EnvironmentsList only shows
+  // names and counts from the same result, so it does not need its own query.
+  const { data: environments = [], isLoading, error } = useEnvironmentsQuery(undefined, true)
   const selected = environments.find((e) => e.id === urlEnvironmentId) ?? null
+
+  const create = useCreateEnvironmentMutation()
+  const [creatingRepo, setCreatingRepo] = useState<string | null>(null)
+  const [createError, setCreateError] = useState<string | null>(null)
+
+  const handleCreate = async (repo: string) => {
+    setCreateError(null)
+    setCreatingRepo(repo)
+    try {
+      // A plain, renamable default: the editor's name field is the place to
+      // actually name it, so this only needs to be unique enough not to
+      // collide with an existing name in the repo.
+      const siblingCount = environments.filter((e) => e.repo === repo).length
+      const created = await create.mutateAsync({
+        repo,
+        name: `New environment ${siblingCount + 1}`,
+      })
+      onNavigate(created.id)
+    } catch (err) {
+      setCreateError(err instanceof Error ? err.message : "Failed to create environment")
+    } finally {
+      setCreatingRepo(null)
+    }
+  }
 
   return (
     <div className="flex-1 flex flex-col min-h-0">
@@ -60,7 +91,24 @@ export function EnvironmentsView({ urlEnvironmentId, onNavigate }: EnvironmentsV
             onDuplicated={(id) => onNavigate(id)}
           />
         ) : (
-          <EnvironmentsList environments={environments} onSelect={(id) => onNavigate(id)} />
+          <div className="flex flex-col min-h-0 h-full">
+            {createError && (
+              <div
+                role="alert"
+                className="mx-4 mt-3 px-3 py-2 text-sm rounded-md bg-destructive/10 text-destructive shrink-0"
+              >
+                {createError}
+              </div>
+            )}
+            <div className="flex-1 min-h-0 overflow-auto">
+              <EnvironmentsList
+                environments={environments}
+                onSelect={(id) => onNavigate(id)}
+                onCreate={handleCreate}
+                creatingRepo={creatingRepo}
+              />
+            </div>
+          </div>
         )}
       </div>
     </div>

--- a/packages/web/components/environments/EnvironmentsView.tsx
+++ b/packages/web/components/environments/EnvironmentsView.tsx
@@ -1,0 +1,62 @@
+"use client"
+
+import { EnvironmentsList } from "./EnvironmentsList"
+import { EnvironmentEditor } from "./EnvironmentEditor"
+import { useEnvironmentsQuery } from "@/lib/query/hooks/useEnvironmentsQuery"
+
+interface EnvironmentsViewProps {
+  /** Environment id from the URL. Null shows the list. */
+  urlEnvironmentId: string | null
+  onNavigate: (id: string | null) => void
+}
+
+export function EnvironmentsView({ urlEnvironmentId, onNavigate }: EnvironmentsViewProps) {
+  const { data: environments = [], isLoading, error } = useEnvironmentsQuery()
+  const selected = environments.find((e) => e.id === urlEnvironmentId) ?? null
+
+  return (
+    <div className="flex-1 flex flex-col min-h-0">
+      {!urlEnvironmentId && (
+        <div
+          className="flex items-center justify-between pt-3 shrink-0"
+          style={{ paddingLeft: "1.625rem", paddingRight: "1.625rem" }}
+        >
+          <div className="flex items-center gap-2">
+            <span className="flex h-7 items-center text-sm font-medium text-foreground px-2 rounded-md hover:bg-accent transition-colors cursor-default">
+              Environments
+            </span>
+          </div>
+        </div>
+      )}
+
+      <div className="flex-1 min-h-0 overflow-auto">
+        {isLoading ? (
+          <div className="p-6 text-sm text-muted-foreground">Loading environments...</div>
+        ) : error ? (
+          <div role="alert" className="m-4 px-3 py-2 text-sm rounded-md bg-destructive/10 text-destructive">
+            {error instanceof Error ? error.message : "Failed to load environments"}
+          </div>
+        ) : urlEnvironmentId && !selected ? (
+          <div className="p-6 space-y-2">
+            <p className="text-sm text-muted-foreground">Environment not found.</p>
+            <button
+              onClick={() => onNavigate(null)}
+              className="text-sm text-primary hover:underline cursor-pointer"
+            >
+              Back to environments
+            </button>
+          </div>
+        ) : selected ? (
+          <EnvironmentEditor
+            environment={selected}
+            onBack={() => onNavigate(null)}
+            onDeleted={() => onNavigate(null)}
+            onDuplicated={(id) => onNavigate(id)}
+          />
+        ) : (
+          <EnvironmentsList environments={environments} onSelect={(id) => onNavigate(id)} />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/packages/web/components/environments/EnvironmentsView.tsx
+++ b/packages/web/components/environments/EnvironmentsView.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react"
 import { EnvironmentsList } from "./EnvironmentsList"
 import { EnvironmentEditor } from "./EnvironmentEditor"
+import { nextEnvironmentName } from "./helpers"
 import {
   useEnvironmentsQuery,
   useCreateEnvironmentMutation,
@@ -30,12 +31,13 @@ export function EnvironmentsView({ urlEnvironmentId, onNavigate }: EnvironmentsV
     setCreatingRepo(repo)
     try {
       // A plain, renamable default: the editor's name field is the place to
-      // actually name it, so this only needs to be unique enough not to
-      // collide with an existing name in the repo.
-      const siblingCount = environments.filter((e) => e.repo === repo).length
+      // actually name it, so this picks the first "New environment N" not
+      // already taken by a sibling in the repo, avoiding a collision with
+      // the API's per-repo name uniqueness check.
+      const siblingNames = environments.filter((e) => e.repo === repo).map((e) => e.name)
       const created = await create.mutateAsync({
         repo,
-        name: `New environment ${siblingCount + 1}`,
+        name: nextEnvironmentName(siblingNames),
       })
       onNavigate(created.id)
     } catch (err) {

--- a/packages/web/components/environments/NetworkModeFields.tsx
+++ b/packages/web/components/environments/NetworkModeFields.tsx
@@ -1,0 +1,118 @@
+"use client"
+
+import { Lock, Globe } from "lucide-react"
+import { BASELINE_DOMAINS } from "@background-agents/common"
+
+interface NetworkModeFieldsProps {
+  networkMode: "full" | "restricted"
+  allowedDomains: string[]
+}
+
+/**
+ * Network access section of the environment editor.
+ *
+ * Restricted mode is NOT selectable right now: the installed
+ * @daytonaio/sdk (0.170.0) has no domain-allowlist field, only
+ * "networkBlockAll" and a CIDR-only "networkAllowList", neither of which can
+ * express an allowed-hostnames list. Sandbox creation throws on restricted
+ * mode (see buildSandboxCreateParams) and the environments API rejects
+ * `networkMode: "restricted"` with a 400, so this component never lets a
+ * user select it and never renders an editable domain list.
+ *
+ * When @daytonaio/sdk is upgraded past 0.170.0 to a version with a real
+ * domain-allowlist field (0.185.0+):
+ *   1. Remove the `disabled` prop and explanatory copy on the "Restricted"
+ *      radio below.
+ *   2. Restore an editable add/remove UI for `allowedDomains` (the baseline
+ *      domains list below is read-only reference copy; it explains what
+ *      restricted mode WILL allow once it's enforced, but was never meant to
+ *      be editable itself).
+ *   3. Delete the matching 400 checks in the environments API routes and the
+ *      throw in buildSandboxCreateParams.
+ */
+export function NetworkModeFields({ networkMode, allowedDomains }: NetworkModeFieldsProps) {
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <label className="flex items-start gap-2">
+          <input
+            type="radio"
+            name="networkMode"
+            checked={networkMode === "full"}
+            readOnly
+            className="mt-1"
+          />
+          <span className="text-sm">
+            <span className="font-medium inline-flex items-center gap-1.5">
+              <Globe className="w-3.5 h-3.5" /> Full access
+            </span>
+            <span className="block text-muted-foreground text-xs">
+              The sandbox can reach any host. This is the only mode available right now.
+            </span>
+          </span>
+        </label>
+
+        <label
+          className="flex items-start gap-2 cursor-not-allowed"
+          aria-disabled="true"
+        >
+          <input
+            type="radio"
+            name="networkMode"
+            checked={networkMode === "restricted"}
+            disabled
+            readOnly
+            className="mt-1"
+          />
+          <span className="text-sm">
+            <span className="font-medium inline-flex items-center gap-1.5 text-muted-foreground">
+              <Lock className="w-3.5 h-3.5" /> Restricted (not available yet)
+            </span>
+            <span className="block text-muted-foreground text-xs">
+              Restricted mode is not enforced by the installed Daytona SDK, so it cannot be
+              selected. The SDK has no domain-allowlist field yet, only a block-all switch and a
+              CIDR-only IP allowlist, neither of which can express an allowed-hostnames list. This
+              will come back once the SDK adds that support.
+            </span>
+          </span>
+        </label>
+      </div>
+
+      <div className="space-y-2 pl-6">
+        <p className="text-xs text-muted-foreground mb-1">
+          When restricted mode ships, these domains will always be allowed so the clone and the
+          agent keep working:
+        </p>
+        <div className="flex flex-wrap gap-1">
+          {BASELINE_DOMAINS.map((domain) => (
+            <span
+              key={domain}
+              className="inline-flex items-center gap-1 text-xs font-mono px-1.5 py-0.5 rounded bg-muted/50 text-muted-foreground"
+            >
+              <Lock className="w-3 h-3" />
+              {domain}
+            </span>
+          ))}
+        </div>
+        {allowedDomains.length > 0 && (
+          <>
+            <p className="text-xs text-muted-foreground mb-1 pt-1">
+              Additional domains saved on this environment (inert until restricted mode is
+              enforced):
+            </p>
+            <div className="flex flex-wrap gap-1">
+              {allowedDomains.map((domain) => (
+                <span
+                  key={domain}
+                  className="inline-flex items-center gap-1 text-xs font-mono px-1.5 py-0.5 rounded bg-muted/50 text-muted-foreground"
+                >
+                  {domain}
+                </span>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/packages/web/components/environments/NetworkModeFields.tsx
+++ b/packages/web/components/environments/NetworkModeFields.tsx
@@ -61,7 +61,6 @@ export function NetworkModeFields({ networkMode, allowedDomains }: NetworkModeFi
             name="networkMode"
             checked={networkMode === "restricted"}
             disabled
-            readOnly
             className="mt-1"
           />
           <span className="text-sm">

--- a/packages/web/components/environments/helpers.test.ts
+++ b/packages/web/components/environments/helpers.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest"
-import { groupEnvironmentsByRepo, recordToEnvVars, envVarsToRecord } from "./helpers"
+import {
+  groupEnvironmentsByRepo,
+  recordToEnvVars,
+  envVarsToRecord,
+  nextEnvironmentName,
+} from "./helpers"
 import type { EnvironmentDTO } from "@/lib/environments"
 
 function makeEnv(overrides: Partial<EnvironmentDTO>): EnvironmentDTO {
@@ -72,5 +77,30 @@ describe("recordToEnvVars / envVarsToRecord round trip", () => {
 
   it("returns an empty object for an empty list", () => {
     expect(envVarsToRecord([])).toEqual({})
+  })
+})
+
+describe("nextEnvironmentName", () => {
+  it("returns 'New environment 1' when there are no existing names", () => {
+    expect(nextEnvironmentName([])).toBe("New environment 1")
+  })
+
+  it("fills a gap left by a deleted or renamed environment", () => {
+    expect(nextEnvironmentName(["New environment 2"])).toBe("New environment 1")
+  })
+
+  it("does not propose a name already taken by a sibling (regression)", () => {
+    const name = nextEnvironmentName(["Default", "New environment 3"])
+    expect(name).not.toBe("New environment 3")
+    expect(name).toBe("New environment 1")
+  })
+
+  it("ignores unrelated names when picking the next number", () => {
+    expect(nextEnvironmentName(["Default", "Staging", "prod"])).toBe("New environment 1")
+  })
+
+  it("treats names as taken when they differ only by surrounding whitespace or case", () => {
+    expect(nextEnvironmentName([" new environment 1 "])).toBe("New environment 2")
+    expect(nextEnvironmentName(["NEW ENVIRONMENT 1"])).toBe("New environment 2")
   })
 })

--- a/packages/web/components/environments/helpers.test.ts
+++ b/packages/web/components/environments/helpers.test.ts
@@ -11,6 +11,7 @@ function makeEnv(overrides: Partial<EnvironmentDTO>): EnvironmentDTO {
     networkMode: "full",
     allowedDomains: [],
     variables: {},
+    variableCount: 0,
     hasSetupScript: false,
     setupScript: null,
     setupScriptUpdatedBy: null,

--- a/packages/web/components/environments/helpers.test.ts
+++ b/packages/web/components/environments/helpers.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest"
+import { groupEnvironmentsByRepo, recordToEnvVars, envVarsToRecord } from "./helpers"
+import type { EnvironmentDTO } from "@/lib/environments"
+
+function makeEnv(overrides: Partial<EnvironmentDTO>): EnvironmentDTO {
+  return {
+    id: "id",
+    repo: "owner/repo",
+    name: "Default",
+    isDefault: true,
+    networkMode: "full",
+    allowedDomains: [],
+    variables: {},
+    hasSetupScript: false,
+    setupScript: null,
+    setupScriptUpdatedBy: null,
+    updatedAt: 0,
+    ...overrides,
+  }
+}
+
+describe("groupEnvironmentsByRepo", () => {
+  it("groups environments under their repo key", () => {
+    const envs = [
+      makeEnv({ id: "1", repo: "a/one", name: "Default" }),
+      makeEnv({ id: "2", repo: "b/two", name: "Default" }),
+      makeEnv({ id: "3", repo: "a/one", name: "Staging", isDefault: false }),
+    ]
+
+    const grouped = groupEnvironmentsByRepo(envs)
+
+    expect(Object.keys(grouped)).toEqual(["a/one", "b/two"])
+    expect(grouped["a/one"].map((e) => e.id)).toEqual(["1", "3"])
+    expect(grouped["b/two"].map((e) => e.id)).toEqual(["2"])
+  })
+
+  it("returns an empty object for an empty list", () => {
+    expect(groupEnvironmentsByRepo([])).toEqual({})
+  })
+})
+
+describe("recordToEnvVars / envVarsToRecord round trip", () => {
+  it("converts a record to rows and back", () => {
+    const record = { API_KEY: "secret", DEBUG: "true" }
+    const rows = recordToEnvVars(record)
+
+    expect(rows).toHaveLength(2)
+    expect(rows.every((r) => typeof r.id === "string" && r.id.length > 0)).toBe(true)
+
+    expect(envVarsToRecord(rows)).toEqual(record)
+  })
+
+  it("drops rows with an empty or whitespace-only key", () => {
+    const rows = [
+      { id: "1", key: "KEY", value: "value" },
+      { id: "2", key: "", value: "ignored" },
+      { id: "3", key: "   ", value: "ignored" },
+    ]
+
+    expect(envVarsToRecord(rows)).toEqual({ KEY: "value" })
+  })
+
+  it("trims keys and lets the last duplicate win", () => {
+    const rows = [
+      { id: "1", key: " KEY ", value: "first" },
+      { id: "2", key: "KEY", value: "second" },
+    ]
+
+    expect(envVarsToRecord(rows)).toEqual({ KEY: "second" })
+  })
+
+  it("returns an empty object for an empty list", () => {
+    expect(envVarsToRecord([])).toEqual({})
+  })
+})

--- a/packages/web/components/environments/helpers.ts
+++ b/packages/web/components/environments/helpers.ts
@@ -38,3 +38,17 @@ export function envVarsToRecord(envVars: EnvVar[]): Record<string, string> {
   }
   return record
 }
+
+/** A plain, renamable default name for a newly created environment: the
+ *  editor's name field is the place to actually name it, so this only needs
+ *  to be the first "New environment N" (starting at 1) not already taken by
+ *  a sibling in that repo. Names are compared trimmed and case-insensitively,
+ *  so "new environment 1" or " New environment 1 " both count as taken. */
+export function nextEnvironmentName(existingNames: string[]): string {
+  const taken = new Set(existingNames.map((name) => name.trim().toLowerCase()))
+  let n = 1
+  while (taken.has(`new environment ${n}`)) {
+    n++
+  }
+  return `New environment ${n}`
+}

--- a/packages/web/components/environments/helpers.ts
+++ b/packages/web/components/environments/helpers.ts
@@ -1,0 +1,40 @@
+import { nanoid } from "nanoid"
+import type { EnvVar } from "@/lib/types"
+import type { EnvironmentDTO } from "@/lib/environments"
+
+/**
+ * Groups environments by repo, preserving the order the API returned them in
+ * (repo asc, default first, name asc: see GET /api/environments). Object key
+ * order in modern JS engines follows insertion order for non-numeric keys, so
+ * this keeps repos in that same order without a separate sort.
+ */
+export function groupEnvironmentsByRepo(
+  environments: EnvironmentDTO[]
+): Record<string, EnvironmentDTO[]> {
+  return environments.reduce<Record<string, EnvironmentDTO[]>>((acc, env) => {
+    ;(acc[env.repo] ??= []).push(env)
+    return acc
+  }, {})
+}
+
+/** Convert a Record<string, string> to EnvVar[] for UI display. Mirrors the
+ *  same conversion in EnvironmentVariablesModal so both editors behave alike. */
+export function recordToEnvVars(record: Record<string, string>): EnvVar[] {
+  return Object.entries(record).map(([key, value]) => ({
+    id: nanoid(),
+    key,
+    value,
+  }))
+}
+
+/** Convert EnvVar[] to Record<string, string> for the API. Empty keys are
+ *  dropped; the last entry for a duplicate key wins. */
+export function envVarsToRecord(envVars: EnvVar[]): Record<string, string> {
+  const record: Record<string, string> = {}
+  for (const { key, value } of envVars) {
+    if (key.trim()) {
+      record[key.trim()] = value
+    }
+  }
+  return record
+}

--- a/packages/web/e2e/environments.spec.ts
+++ b/packages/web/e2e/environments.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * Composer environment picker (Task 8 of the cloud-environments plan).
+ *
+ * This deliberately does not re-test the /environments editor page (create,
+ * duplicate, promote-to-default, delete): that page is Task 7's, already has
+ * route-level coverage in app/api/environments/**\/*.test.ts, and this task
+ * adds nothing to it. It also does not exercise "restricted" network mode:
+ * NetworkModeFields.tsx disables that radio outright (the installed
+ * @daytonaio/sdk has no domain-allowlist field yet; see the comment at the
+ * top of that file), so there is nothing to round-trip.
+ *
+ * What this task actually adds is the environment picker in the chat
+ * composer, and the one thing worth an end-to-end check is that picking a
+ * non-default environment there is what the created chat actually gets.
+ */
+
+import { test, expect } from "@playwright/test"
+import { setupTestAuth, setDefaultAgentEliza } from "./helpers"
+
+test("picking a non-default environment in the composer pins the created chat to it", async ({
+  page,
+  context,
+}) => {
+  await setupTestAuth(page, context)
+  await setDefaultAgentEliza(page)
+
+  // Seed two environments for a repo so the picker has something to choose
+  // between (a repo with a single environment hides the picker: nothing to
+  // pick). The first one created becomes the repo's default.
+  const defaultRes = await page.request.post("/api/environments", {
+    data: { repo: "acme/app", name: "Default" },
+  })
+  expect(defaultRes.ok()).toBeTruthy()
+  const { environment: defaultEnv } = await defaultRes.json()
+  expect(defaultEnv.isDefault).toBe(true)
+
+  const stagingRes = await page.request.post("/api/environments", {
+    data: { repo: "acme/app", name: "Staging" },
+  })
+  expect(stagingRes.ok()).toBeTruthy()
+  const { environment: stagingEnv } = await stagingRes.json()
+  expect(stagingEnv.isDefault).toBe(false)
+
+  // The composer's repo picker calls the real GitHub API, so stub it with a
+  // single fake repo so the test doesn't depend on a real GitHub account or
+  // token (same technique as e2e/repo-picker.spec.ts).
+  await page.route("**/api/github/repos?*", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        repos: [
+          {
+            id: 1,
+            name: "app",
+            full_name: "acme/app",
+            owner: { login: "acme" },
+            default_branch: "main",
+            private: false,
+          },
+        ],
+        page: 1,
+        hasMore: false,
+      }),
+    })
+  })
+
+  await page.goto("/")
+  await expect(page.getByTestId("chat-input")).toBeVisible({ timeout: 10000 })
+  // Wait for the session to hydrate before touching anything chat-state
+  // related (same wait streaming.spec.ts uses).
+  await expect(page.getByText("test@playwright.local")).toBeVisible({ timeout: 10000 })
+
+  await page.getByRole("button", { name: "Repository", exact: true }).click()
+  await page.getByRole("dialog").getByText("acme/app").click()
+
+  // Confirm the repo actually landed before touching the environment
+  // picker: it only renders once chat.repo is a real repo.
+  await expect(page.getByRole("button", { name: "Repository", exact: true })).toHaveCount(0)
+
+  // exact: true matters, since the sidebar nav has an "Environments" button and a
+  // substring match on "Environment" would hit that instead.
+  const environmentButton = page.getByRole("button", { name: "Environment", exact: true })
+  await expect(environmentButton).toBeVisible()
+  await environmentButton.click()
+  await page.getByRole("option", { name: /Staging/ }).click()
+
+  const input = page.getByTestId("chat-input")
+  await input.click()
+  await input.fill("Hello from the environment picker test")
+
+  const [response] = await Promise.all([
+    page.waitForResponse(
+      (res) => res.url().endsWith("/api/chats") && res.request().method() === "POST"
+    ),
+    input.press("Enter"),
+  ])
+  expect(response.ok()).toBeTruthy()
+  const createdChat = await response.json()
+
+  // This is the round trip the task exists to verify: the id picked in the
+  // composer is what actually landed on the chat row, not silently the repo's
+  // default.
+  expect(createdChat.environmentId).toBe(stagingEnv.id)
+  expect(createdChat.environmentId).not.toBe(defaultEnv.id)
+})

--- a/packages/web/e2e/idor.spec.ts
+++ b/packages/web/e2e/idor.spec.ts
@@ -15,6 +15,11 @@
  * This test creates a chat with sandboxId=null, hits the route with a
  * blatantly fake sandboxId, and asserts the route does NOT echo that
  * fake id in its error path — proving it ignored the query param.
+ *
+ * This file also covers the /api/environments IDOR surface: every [id] route
+ * must scope its lookup to userId so another user's environment id returns
+ * 404 rather than leaking existence, is readable, is editable, or is
+ * deletable.
  */
 
 import { test, expect } from "@playwright/test"
@@ -72,4 +77,51 @@ test("IDOR fix: route ignores url-supplied sandboxId and uses chat row", async (
   expect(body).toContain("no active sandbox")
 
   await context.close()
+})
+
+test("another user's environment is not readable, editable, or deletable", async ({ request }) => {
+  // Pure HTTP test (no page render), same convention as chat-mass-assignment.spec.ts:
+  // authenticate by fetching a test session token and sending it as the
+  // next-auth cookie on each request. `?user=b` on the second call picks a
+  // distinct, stable test user so this is a real cross-user check rather than
+  // the same user asserting against itself.
+  const authA = await request.post("/api/test/auth")
+  expect(authA.ok()).toBeTruthy()
+  const { token: tokenA } = await authA.json()
+  const headersA = { Cookie: `next-auth.session-token=${tokenA}` }
+
+  const authB = await request.post("/api/test/auth?user=b")
+  expect(authB.ok()).toBeTruthy()
+  const { token: tokenB } = await authB.json()
+  const headersB = { Cookie: `next-auth.session-token=${tokenB}` }
+
+  // Create an environment as user A, then attempt every verb as user B.
+  const created = await request.post("/api/environments", {
+    headers: headersA,
+    data: { repo: "acme/app", name: "Victim" },
+  })
+  expect(created.status()).toBe(201)
+  const { environment } = await created.json()
+
+  const get = await request.get(`/api/environments/${environment.id}`, { headers: headersB })
+  expect(get.status()).toBe(404)
+
+  const patch = await request.patch(`/api/environments/${environment.id}`, {
+    headers: headersB,
+    data: { name: "Hijacked" },
+  })
+  expect(patch.status()).toBe(404)
+
+  const usage = await request.get(`/api/environments/${environment.id}/usage`, {
+    headers: headersB,
+  })
+  expect(usage.status()).toBe(404)
+
+  const del = await request.delete(`/api/environments/${environment.id}`, { headers: headersB })
+  expect(del.status()).toBe(404)
+
+  // And user A can still reach their own environment: the 404s above are
+  // ownership-scoping, not the row having vanished.
+  const getA = await request.get(`/api/environments/${environment.id}`, { headers: headersA })
+  expect(getA.status()).toBe(200)
 })

--- a/packages/web/lib/contexts/SidebarContext.tsx
+++ b/packages/web/lib/contexts/SidebarContext.tsx
@@ -31,8 +31,8 @@ export interface SidebarContextValue {
   expandChatAndAncestors: (targetId: string, byId: Map<string, { parentChatId?: string | null }>) => void
 
   // Scheduled jobs view
-  viewMode: "chat" | "scheduled-jobs"
-  setViewMode: (mode: "chat" | "scheduled-jobs") => void
+  viewMode: "chat" | "scheduled-jobs" | "environments"
+  setViewMode: (mode: "chat" | "scheduled-jobs" | "environments") => void
   selectedScheduledJob: { id: string; name: string } | null
   setSelectedScheduledJob: (job: { id: string; name: string } | null) => void
 }
@@ -95,7 +95,7 @@ export function SidebarProvider({ children }: SidebarProviderProps) {
   }, [])
 
   // View mode (chat vs scheduled jobs)
-  const [viewMode, setViewMode] = useState<"chat" | "scheduled-jobs">("chat")
+  const [viewMode, setViewMode] = useState<"chat" | "scheduled-jobs" | "environments">("chat")
   const [selectedScheduledJob, setSelectedScheduledJob] = useState<{ id: string; name: string } | null>(null)
 
   const value: SidebarContextValue = {

--- a/packages/web/lib/contexts/SidebarContext.tsx
+++ b/packages/web/lib/contexts/SidebarContext.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { createContext, useContext, useState, useCallback, ReactNode } from "react"
+import { createContext, useContext, useState, useCallback, useMemo, ReactNode } from "react"
 
 // =============================================================================
 // SidebarContext - Provides sidebar UI state to avoid prop drilling
@@ -35,6 +35,11 @@ export interface SidebarContextValue {
   setViewMode: (mode: "chat" | "scheduled-jobs" | "environments") => void
   selectedScheduledJob: { id: string; name: string } | null
   setSelectedScheduledJob: (job: { id: string; name: string } | null) => void
+
+  // Environments view: id from the URL, kept in sync by useUrlSync (initial
+  // load + browser back/forward) and the navigate handlers (in-app clicks).
+  selectedEnvironmentId: string | null
+  setSelectedEnvironmentId: (id: string | null) => void
 }
 
 interface SidebarProviderProps {
@@ -97,26 +102,49 @@ export function SidebarProvider({ children }: SidebarProviderProps) {
   // View mode (chat vs scheduled jobs)
   const [viewMode, setViewMode] = useState<"chat" | "scheduled-jobs" | "environments">("chat")
   const [selectedScheduledJob, setSelectedScheduledJob] = useState<{ id: string; name: string } | null>(null)
+  const [selectedEnvironmentId, setSelectedEnvironmentId] = useState<string | null>(null)
 
-  const value: SidebarContextValue = {
-    collapsed,
-    setCollapsed,
-    toggleCollapse,
-    width,
-    setWidth,
-    mobileSidebarOpen,
-    setMobileSidebarOpen,
-    closeMobileSidebar,
-    repoFilter,
-    setRepoFilter,
-    collapsedChatIds,
-    toggleChatCollapsed,
-    expandChatAndAncestors,
-    viewMode,
-    setViewMode,
-    selectedScheduledJob,
-    setSelectedScheduledJob,
-  }
+  // Memoized so consumers that depend on the whole context object (rather
+  // than a single field) don't re-run on every render this provider takes for
+  // an unrelated reason: an effect keyed on `[sidebar]` would otherwise fire
+  // on every render, not just when a field actually changes.
+  const value: SidebarContextValue = useMemo(
+    () => ({
+      collapsed,
+      setCollapsed,
+      toggleCollapse,
+      width,
+      setWidth,
+      mobileSidebarOpen,
+      setMobileSidebarOpen,
+      closeMobileSidebar,
+      repoFilter,
+      setRepoFilter,
+      collapsedChatIds,
+      toggleChatCollapsed,
+      expandChatAndAncestors,
+      viewMode,
+      setViewMode,
+      selectedScheduledJob,
+      setSelectedScheduledJob,
+      selectedEnvironmentId,
+      setSelectedEnvironmentId,
+    }),
+    [
+      collapsed,
+      toggleCollapse,
+      width,
+      mobileSidebarOpen,
+      closeMobileSidebar,
+      repoFilter,
+      collapsedChatIds,
+      toggleChatCollapsed,
+      expandChatAndAncestors,
+      viewMode,
+      selectedScheduledJob,
+      selectedEnvironmentId,
+    ]
+  )
 
   return <SidebarContext.Provider value={value}>{children}</SidebarContext.Provider>
 }

--- a/packages/web/lib/db/api-helpers.ts
+++ b/packages/web/lib/db/api-helpers.ts
@@ -361,6 +361,7 @@ export async function getChatWithAuth(
   parentChatId: string | null
   needsSync: boolean
   environmentVariables: unknown
+  environmentId: string | null
   createdAt: Date
   updatedAt: Date
   lastActiveAt: Date

--- a/packages/web/lib/environments.test.ts
+++ b/packages/web/lib/environments.test.ts
@@ -182,3 +182,20 @@ describe("getOrCreateDefaultEnvironment", () => {
     })
   })
 })
+
+describe("toResolvedEnvironment", () => {
+  it("narrows an unrecognized networkMode to full rather than trusting the column", async () => {
+    const { toResolvedEnvironment } = await import("./environments")
+    const resolved = toResolvedEnvironment({
+      id: "e",
+      name: "n",
+      repo: "acme/app",
+      isDefault: true,
+      networkMode: "something-else",
+      allowedDomains: [],
+      environmentVariables: null,
+      setupScript: null,
+    })
+    expect(resolved.networkMode).toBe("full")
+  })
+})

--- a/packages/web/lib/environments.test.ts
+++ b/packages/web/lib/environments.test.ts
@@ -294,3 +294,73 @@ describe("getOwnedEnvironment", () => {
     expect(result).toBeNull()
   })
 })
+
+describe("environmentUniqueConstraintMessage / violatedEnvironmentUniqueFields", () => {
+  // Shapes below are copy-pasted from a real P2002 forced against the scratch
+  // DB via @prisma/adapter-pg (Prisma 7.8.0), not guessed:
+  //   node force_conflict.mjs  ->  meta.driverAdapterError.cause.constraint.fields
+  // See task-6-report.md's smoke-test section for the full transcript.
+
+  function p2002(fields: string[]): Prisma.PrismaClientKnownRequestError {
+    return new Prisma.PrismaClientKnownRequestError("Unique constraint failed on the fields", {
+      code: "P2002",
+      clientVersion: "test",
+      meta: {
+        modelName: "Environment",
+        driverAdapterError: {
+          name: "DriverAdapterError",
+          cause: {
+            originalCode: "23505",
+            kind: "UniqueConstraintViolation",
+            constraint: { fields },
+          },
+        },
+      },
+    })
+  }
+
+  it("recognizes the (userId, repo, name) violation from its adapter-reported fields", async () => {
+    const { violatedEnvironmentUniqueFields, environmentUniqueConstraintMessage } = await import(
+      "./environments"
+    )
+    const error = p2002(['"userId"', "repo", "name"])
+
+    expect(violatedEnvironmentUniqueFields(error)).toEqual(["userId", "repo", "name"])
+    expect(environmentUniqueConstraintMessage(error)).toContain(
+      "environment with that name already exists"
+    )
+  })
+
+  it("recognizes the partial default-per-repo index violation, distinct from a name collision", async () => {
+    const { violatedEnvironmentUniqueFields, environmentUniqueConstraintMessage } = await import(
+      "./environments"
+    )
+    const error = p2002(['"userId"', "repo"])
+
+    expect(violatedEnvironmentUniqueFields(error)).toEqual(["userId", "repo"])
+    const message = environmentUniqueConstraintMessage(error)
+    expect(message).not.toContain("name already exists")
+    expect(message.toLowerCase()).toContain("default")
+  })
+
+  it("falls back to the classic meta.target array when no driverAdapterError is present", async () => {
+    const { violatedEnvironmentUniqueFields } = await import("./environments")
+    const error = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+      code: "P2002",
+      clientVersion: "test",
+      meta: { target: ["userId", "repo", "name"] },
+    })
+
+    expect(violatedEnvironmentUniqueFields(error)).toEqual(["userId", "repo", "name"])
+  })
+
+  it("returns an empty field list when meta carries neither shape", async () => {
+    const { violatedEnvironmentUniqueFields } = await import("./environments")
+    const error = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+      code: "P2002",
+      clientVersion: "test",
+    })
+
+    expect(violatedEnvironmentUniqueFields(error)).toEqual([])
+  })
+})

--- a/packages/web/lib/environments.test.ts
+++ b/packages/web/lib/environments.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from "vitest"
+
+// Mock the prisma singleton: lib/db/prisma.ts constructs a PrismaClient at
+// module scope and throws when DATABASE_URL is unset. The functions under
+// test here are pure and never touch this mock.
+vi.mock("@/lib/db/prisma", () => ({ prisma: {} }))
+
+import {
+  decryptEnvironmentVariables,
+  encryptEnvironmentVariables,
+  resolveDomainAllowList,
+  type ResolvedEnvironment,
+} from "./environments"
+import { encrypt } from "./db/encryption"
+import { BASELINE_DOMAINS } from "@background-agents/common"
+
+function env(overrides: Partial<ResolvedEnvironment> = {}): ResolvedEnvironment {
+  return {
+    id: "env_1",
+    name: "Default",
+    repo: "acme/app",
+    isDefault: true,
+    networkMode: "full",
+    allowedDomains: [],
+    variables: {},
+    setupScript: null,
+    ...overrides,
+  }
+}
+
+describe("decryptEnvironmentVariables", () => {
+  it("decrypts every stored value", () => {
+    const stored = { API_KEY: encrypt("secret"), OTHER: encrypt("two") }
+    expect(decryptEnvironmentVariables(stored)).toEqual({ API_KEY: "secret", OTHER: "two" })
+  })
+
+  it("returns an empty object for null, undefined, or a non-object", () => {
+    expect(decryptEnvironmentVariables(null)).toEqual({})
+    expect(decryptEnvironmentVariables(undefined)).toEqual({})
+    expect(decryptEnvironmentVariables("nonsense")).toEqual({})
+  })
+
+  it("skips empty values rather than emitting empty strings", () => {
+    expect(decryptEnvironmentVariables({ A: encrypt("x"), B: "" })).toEqual({ A: "x" })
+  })
+})
+
+describe("encryptEnvironmentVariables", () => {
+  it("round-trips through decrypt", () => {
+    const out = encryptEnvironmentVariables({ TOKEN: "abc" })
+    expect(out.TOKEN).not.toBe("abc")
+    expect(decryptEnvironmentVariables(out)).toEqual({ TOKEN: "abc" })
+  })
+
+  it("trims keys and drops blank ones", () => {
+    const out = encryptEnvironmentVariables({ "  A  ": "1", "": "2", "   ": "3" })
+    expect(Object.keys(out)).toEqual(["A"])
+  })
+})
+
+describe("resolveDomainAllowList", () => {
+  it("returns undefined in full mode so Daytona applies no restriction", () => {
+    expect(resolveDomainAllowList(env({ networkMode: "full" }))).toBeUndefined()
+  })
+
+  it("returns undefined in full mode even when domains are listed", () => {
+    expect(
+      resolveDomainAllowList(env({ networkMode: "full", allowedDomains: ["example.com"] }))
+    ).toBeUndefined()
+  })
+
+  it("joins the baseline with the user's domains in restricted mode", () => {
+    const result = resolveDomainAllowList(
+      env({ networkMode: "restricted", allowedDomains: ["example.com", "*.internal.dev"] })
+    )
+    const parts = result!.split(",")
+    for (const baseline of BASELINE_DOMAINS) expect(parts).toContain(baseline)
+    expect(parts).toContain("example.com")
+    expect(parts).toContain("*.internal.dev")
+  })
+
+  it("deduplicates a user domain that is already in the baseline", () => {
+    const result = resolveDomainAllowList(
+      env({ networkMode: "restricted", allowedDomains: ["github.com"] })
+    )
+    const occurrences = result!.split(",").filter((d) => d === "github.com")
+    expect(occurrences).toHaveLength(1)
+  })
+})

--- a/packages/web/lib/environments.test.ts
+++ b/packages/web/lib/environments.test.ts
@@ -1,18 +1,48 @@
-import { describe, it, expect, vi } from "vitest"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { Prisma } from "@prisma/client"
 
 // Mock the prisma singleton: lib/db/prisma.ts constructs a PrismaClient at
-// module scope and throws when DATABASE_URL is unset. The functions under
-// test here are pure and never touch this mock.
-vi.mock("@/lib/db/prisma", () => ({ prisma: {} }))
+// module scope and throws when DATABASE_URL is unset. Most tests in this file
+// are pure and never touch this mock; getOrCreateDefaultEnvironment's race
+// handling does, so `environment` needs real jest-fn behavior rather than an
+// empty object. `vi.hoisted` lets the factory (which is hoisted above
+// imports) see the mocks.
+const { environment } = vi.hoisted(() => ({
+  environment: {
+    findFirst: vi.fn(),
+    create: vi.fn(),
+    updateMany: vi.fn(),
+    update: vi.fn(),
+  },
+}))
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: { environment, $transaction: vi.fn(async (ops: unknown[]) => ops) },
+}))
 
 import {
   decryptEnvironmentVariables,
   encryptEnvironmentVariables,
   resolveDomainAllowList,
+  getOrCreateDefaultEnvironment,
   type ResolvedEnvironment,
 } from "./environments"
 import { encrypt } from "./db/encryption"
 import { BASELINE_DOMAINS } from "@background-agents/common"
+
+/** A P2002 error the way Prisma actually throws it. */
+function uniqueConstraintError(): Prisma.PrismaClientKnownRequestError {
+  return new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+    code: "P2002",
+    clientVersion: "test",
+  })
+}
+
+beforeEach(() => {
+  environment.findFirst.mockReset()
+  environment.create.mockReset()
+  environment.updateMany.mockReset()
+  environment.update.mockReset()
+})
 
 function env(overrides: Partial<ResolvedEnvironment> = {}): ResolvedEnvironment {
   return {
@@ -85,5 +115,70 @@ describe("resolveDomainAllowList", () => {
     )
     const occurrences = result!.split(",").filter((d) => d === "github.com")
     expect(occurrences).toHaveLength(1)
+  })
+})
+
+describe("getOrCreateDefaultEnvironment", () => {
+  it("propagates a non-P2002 error unchanged instead of masking it as a lost race", async () => {
+    environment.findFirst.mockResolvedValueOnce(null) // no existing default
+    const connectionError = new Error("connection refused")
+    environment.create.mockRejectedValueOnce(connectionError)
+
+    await expect(getOrCreateDefaultEnvironment("u1", "acme/app")).rejects.toBe(connectionError)
+  })
+
+  it("returns the winner on P2002 followed by a successful re-read", async () => {
+    environment.findFirst
+      .mockResolvedValueOnce(null) // no existing default: attempt create
+      .mockResolvedValueOnce({
+        // the re-read after losing the race
+        id: "env_winner",
+        name: "Default",
+        repo: "acme/app",
+        isDefault: true,
+        networkMode: "full",
+        allowedDomains: [],
+        environmentVariables: null,
+        setupScript: null,
+      })
+    environment.create.mockRejectedValueOnce(uniqueConstraintError())
+
+    const result = await getOrCreateDefaultEnvironment("u1", "acme/app")
+
+    expect(result.id).toBe("env_winner")
+    expect(result.isDefault).toBe(true)
+  })
+
+  it("promotes a name-collision row to default when no row is marked default", async () => {
+    environment.findFirst
+      .mockResolvedValueOnce(null) // no existing default: attempt create
+      .mockResolvedValueOnce(null) // re-read for isDefault: true finds nothing
+      .mockResolvedValueOnce({
+        // lookup by name finds the un-promoted collision row
+        id: "env_collided",
+        name: "Default",
+        repo: "acme/app",
+        isDefault: false,
+        networkMode: "full",
+        allowedDomains: [],
+        environmentVariables: null,
+        setupScript: null,
+      })
+    environment.create.mockRejectedValueOnce(uniqueConstraintError())
+    environment.updateMany.mockResolvedValueOnce({ count: 0 })
+    environment.update.mockResolvedValueOnce({})
+
+    const result = await getOrCreateDefaultEnvironment("u1", "acme/app")
+
+    expect(result.id).toBe("env_collided")
+    expect(result.isDefault).toBe(true)
+    expect(environment.updateMany).toHaveBeenCalledWith({
+      where: { userId: "u1", repo: "acme/app", isDefault: true },
+      data: { isDefault: false },
+    })
+    expect(environment.update).toHaveBeenCalledWith({
+      where: { id: "env_collided" },
+      data: { isDefault: true },
+    })
   })
 })

--- a/packages/web/lib/environments.test.ts
+++ b/packages/web/lib/environments.test.ts
@@ -227,11 +227,36 @@ describe("toEnvironmentDTO", () => {
       networkMode: "full",
       allowedDomains: [],
       variables: { FOO: "bar" },
+      variableCount: 1,
       hasSetupScript: true,
       setupScript: "echo hi",
       setupScriptUpdatedBy: "agent",
       updatedAt: now.getTime(),
     })
+  })
+
+  it("omits variables but still reports variableCount when includeVariables is false", async () => {
+    const { toEnvironmentDTO } = await import("./environments")
+    const encrypted = encryptEnvironmentVariables({ FOO: "bar", BAZ: "qux" })
+
+    const dto = toEnvironmentDTO(
+      {
+        id: "env_1",
+        name: "Default",
+        repo: "acme/app",
+        isDefault: true,
+        networkMode: "full",
+        allowedDomains: [],
+        environmentVariables: encrypted,
+        setupScript: null,
+        setupScriptUpdatedBy: null,
+        updatedAt: new Date(),
+      },
+      { includeVariables: false }
+    )
+
+    expect(dto.variables).toBeUndefined()
+    expect(dto.variableCount).toBe(2)
   })
 
   it("reports hasSetupScript false and setupScriptUpdatedBy null for a fresh environment", async () => {
@@ -362,5 +387,17 @@ describe("environmentUniqueConstraintMessage / violatedEnvironmentUniqueFields",
     })
 
     expect(violatedEnvironmentUniqueFields(error)).toEqual([])
+  })
+
+  it("covers both possible causes when the violated fields can't be identified", async () => {
+    const { environmentUniqueConstraintMessage } = await import("./environments")
+    const error = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+      code: "P2002",
+      clientVersion: "test",
+    })
+
+    const message = environmentUniqueConstraintMessage(error)
+    expect(message).toContain("name already exists")
+    expect(message.toLowerCase()).toContain("default")
   })
 })

--- a/packages/web/lib/environments.test.ts
+++ b/packages/web/lib/environments.test.ts
@@ -199,3 +199,98 @@ describe("toResolvedEnvironment", () => {
     expect(resolved.networkMode).toBe("full")
   })
 })
+
+describe("toEnvironmentDTO", () => {
+  it("decrypts variables, derives hasSetupScript, and serializes updatedAt as a number", async () => {
+    const { toEnvironmentDTO } = await import("./environments")
+    const encrypted = encryptEnvironmentVariables({ FOO: "bar" })
+    const now = new Date("2026-01-01T00:00:00.000Z")
+
+    const dto = toEnvironmentDTO({
+      id: "env_1",
+      name: "Default",
+      repo: "acme/app",
+      isDefault: true,
+      networkMode: "full",
+      allowedDomains: [],
+      environmentVariables: encrypted,
+      setupScript: "echo hi",
+      setupScriptUpdatedBy: "agent",
+      updatedAt: now,
+    })
+
+    expect(dto).toEqual({
+      id: "env_1",
+      repo: "acme/app",
+      name: "Default",
+      isDefault: true,
+      networkMode: "full",
+      allowedDomains: [],
+      variables: { FOO: "bar" },
+      hasSetupScript: true,
+      setupScript: "echo hi",
+      setupScriptUpdatedBy: "agent",
+      updatedAt: now.getTime(),
+    })
+  })
+
+  it("reports hasSetupScript false and setupScriptUpdatedBy null for a fresh environment", async () => {
+    const { toEnvironmentDTO } = await import("./environments")
+    const dto = toEnvironmentDTO({
+      id: "env_2",
+      name: "Default",
+      repo: "acme/app",
+      isDefault: true,
+      networkMode: "full",
+      allowedDomains: [],
+      environmentVariables: null,
+      setupScript: null,
+      setupScriptUpdatedBy: null,
+      updatedAt: new Date(),
+    })
+
+    expect(dto.hasSetupScript).toBe(false)
+    expect(dto.setupScriptUpdatedBy).toBeNull()
+  })
+
+  it("narrows an unrecognized setupScriptUpdatedBy value to null", async () => {
+    const { toEnvironmentDTO } = await import("./environments")
+    const dto = toEnvironmentDTO({
+      id: "env_3",
+      name: "Default",
+      repo: "acme/app",
+      isDefault: true,
+      networkMode: "full",
+      allowedDomains: [],
+      environmentVariables: null,
+      setupScript: null,
+      setupScriptUpdatedBy: "garbage",
+      updatedAt: new Date(),
+    })
+
+    expect(dto.setupScriptUpdatedBy).toBeNull()
+  })
+})
+
+describe("getOwnedEnvironment", () => {
+  it("scopes the lookup to the given userId", async () => {
+    const { getOwnedEnvironment } = await import("./environments")
+    environment.findFirst.mockResolvedValueOnce({ id: "env_1", userId: "u1" })
+
+    const result = await getOwnedEnvironment("u1", "env_1")
+
+    expect(environment.findFirst).toHaveBeenCalledWith({
+      where: { id: "env_1", userId: "u1" },
+    })
+    expect(result).toEqual({ id: "env_1", userId: "u1" })
+  })
+
+  it("returns null when the environment belongs to another user or does not exist", async () => {
+    const { getOwnedEnvironment } = await import("./environments")
+    environment.findFirst.mockResolvedValueOnce(null)
+
+    const result = await getOwnedEnvironment("u1", "env_owned_by_someone_else")
+
+    expect(result).toBeNull()
+  })
+})

--- a/packages/web/lib/environments.ts
+++ b/packages/web/lib/environments.ts
@@ -144,6 +144,55 @@ export async function getOwnedEnvironment(userId: string, id: string) {
 }
 
 /**
+ * `Environment` has two unique constraints that both surface as Prisma P2002:
+ * `@@unique([userId, repo, name])` and the hand-written partial index
+ * `Environment_one_default_per_repo` on `(userId, repo) WHERE isDefault`. A
+ * bare "Unique constraint failed" message can't tell them apart, and they
+ * mean very different things to a caller (a name collision they typed vs. a
+ * concurrent request that changed the repo's default out from under them),
+ * so this inspects which fields Prisma actually reports as violated.
+ *
+ * Confirmed against a real violation of each constraint via
+ * `@prisma/adapter-pg` (Prisma 7.8.0, driver-adapter engine): the violated
+ * field list lives at `error.meta.driverAdapterError.cause.constraint.fields`
+ * (e.g. `["\"userId\"", "repo"]` for the partial index, `["\"userId\"",
+ * "repo", "name"]` for the named-uniqueness one), NOT the classic
+ * `error.meta.target` some Prisma engine versions report. That classic shape
+ * is kept as a fallback in case a different adapter or a future engine
+ * reports it that way instead.
+ */
+export function violatedEnvironmentUniqueFields(
+  error: Prisma.PrismaClientKnownRequestError
+): string[] {
+  const meta = error.meta as Record<string, unknown> | undefined
+  const driverAdapterError = meta?.driverAdapterError as { cause?: unknown } | undefined
+  const cause = driverAdapterError?.cause as { constraint?: { fields?: unknown } } | undefined
+  const adapterFields = cause?.constraint?.fields
+  if (Array.isArray(adapterFields)) {
+    return adapterFields.map((field) => String(field).replace(/"/g, ""))
+  }
+
+  const target = meta?.target
+  if (Array.isArray(target)) return target.map(String)
+  if (typeof target === "string") return target.split(",").map((s) => s.trim())
+  return []
+}
+
+/** A user-facing message for a P2002 on the Environment model, above. */
+export function environmentUniqueConstraintMessage(
+  error: Prisma.PrismaClientKnownRequestError
+): string {
+  const fields = violatedEnvironmentUniqueFields(error)
+  if (fields.includes("name")) {
+    return "An environment with that name already exists for this repo"
+  }
+  // No "name" among the violated fields means the partial default-per-repo
+  // index was hit instead: another request created or promoted a default
+  // for this repo at the same time.
+  return "Another request just changed this repo's default environment. Refresh and try again."
+}
+
+/**
  * The repo's default environment, created empty if it doesn't exist yet.
  *
  * The create races with itself when two requests hit a repo that has never had

--- a/packages/web/lib/environments.ts
+++ b/packages/web/lib/environments.ts
@@ -101,8 +101,16 @@ export interface EnvironmentDTO {
   isDefault: boolean
   networkMode: NetworkMode
   allowedDomains: string[]
-  /** Decrypted. */
-  variables: Record<string, string>
+  /**
+   * Decrypted. Only present when the caller asked for it (see
+   * toEnvironmentDTO's includeVariables option): absent, not an empty
+   * object, when it wasn't requested, so "no variables" and "not fetched"
+   * stay distinguishable in the type.
+   */
+  variables?: Record<string, string>
+  /** How many variables this environment has, independent of whether
+   *  `variables` itself was included. Safe to show without decrypting. */
+  variableCount: number
   hasSetupScript: boolean
   setupScript: string | null
   setupScriptUpdatedBy: "user" | "agent" | null
@@ -114,7 +122,24 @@ type EnvironmentDTORow = EnvironmentRow & {
   updatedAt: Date
 }
 
-export function toEnvironmentDTO(row: EnvironmentDTORow): EnvironmentDTO {
+function countEnvironmentVariables(raw: unknown): number {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return 0
+  return Object.keys(raw as Record<string, unknown>).length
+}
+
+/**
+ * `includeVariables` defaults to true so existing single-environment callers
+ * (GET/PATCH /api/environments/[id], POST /api/environments) keep returning
+ * full variables without change. The list endpoint (GET /api/environments)
+ * is the one caller that passes includeVariables: false by default, since
+ * every environment on a repo doesn't need its secrets decrypted just to
+ * render names in a picker or a list.
+ */
+export function toEnvironmentDTO(
+  row: EnvironmentDTORow,
+  options: { includeVariables?: boolean } = {}
+): EnvironmentDTO {
+  const includeVariables = options.includeVariables ?? true
   return {
     id: row.id,
     repo: row.repo,
@@ -122,7 +147,8 @@ export function toEnvironmentDTO(row: EnvironmentDTORow): EnvironmentDTO {
     isDefault: row.isDefault,
     networkMode: toNetworkMode(row.networkMode),
     allowedDomains: row.allowedDomains,
-    variables: decryptEnvironmentVariables(row.environmentVariables),
+    ...(includeVariables && { variables: decryptEnvironmentVariables(row.environmentVariables) }),
+    variableCount: countEnvironmentVariables(row.environmentVariables),
     hasSetupScript: !!row.setupScript,
     setupScript: row.setupScript,
     setupScriptUpdatedBy:
@@ -186,10 +212,16 @@ export function environmentUniqueConstraintMessage(
   if (fields.includes("name")) {
     return "An environment with that name already exists for this repo"
   }
-  // No "name" among the violated fields means the partial default-per-repo
-  // index was hit instead: another request created or promoted a default
-  // for this repo at the same time.
-  return "Another request just changed this repo's default environment. Refresh and try again."
+  if (fields.length > 0) {
+    // No "name" among the violated fields means the partial default-per-repo
+    // index was hit instead: another request created or promoted a default
+    // for this repo at the same time.
+    return "Another request just changed this repo's default environment. Refresh and try again."
+  }
+  // The violated fields couldn't be identified from the error metadata, so
+  // either constraint could be the real cause; don't assert one over the
+  // other.
+  return "Either an environment with that name already exists for this repo, or another request just changed this repo's default environment. Refresh and try again."
 }
 
 /**
@@ -232,7 +264,7 @@ export async function getOrCreateDefaultEnvironment(
     // (userId, repo, name) unique constraint: a row named "Default" already
     // exists for this repo but was never promoted. This shouldn't happen
     // through the app today, but self-heal rather than throwing forever for
-    // this repo — promote that row to default.
+    // this repo: promote that row to default.
     const collided = await prisma.environment.findFirst({
       where: { userId, repo, name: DEFAULT_ENVIRONMENT_NAME },
     })

--- a/packages/web/lib/environments.ts
+++ b/packages/web/lib/environments.ts
@@ -9,6 +9,7 @@
  * empty default if the repo has never had one.
  */
 
+import { Prisma } from "@prisma/client"
 import { BASELINE_DOMAINS } from "@background-agents/common"
 import { prisma } from "@/lib/db/prisma"
 import { encrypt, decrypt } from "@/lib/db/encryption"
@@ -109,14 +110,47 @@ export async function getOrCreateDefaultEnvironment(
       data: { userId, repo, name: DEFAULT_ENVIRONMENT_NAME, isDefault: true },
     })
     return toResolvedEnvironment(created)
-  } catch {
-    // Lost the race (unique index on either (userId, repo, name) or the partial
-    // default index). Whoever won has created it; read theirs.
+  } catch (error) {
+    // Only a unique-constraint violation means "lost a race"; anything else
+    // (connection failure, validation error, ...) is a real error and must
+    // propagate with its original stack intact.
+    if (!(error instanceof Prisma.PrismaClientKnownRequestError) || error.code !== "P2002") {
+      throw error
+    }
+
+    // Lost the race on the partial default index. Whoever won has created it;
+    // read theirs.
     const winner = await prisma.environment.findFirst({
       where: { userId, repo, isDefault: true },
     })
-    if (!winner) throw new Error(`Failed to create default environment for ${repo}`)
-    return toResolvedEnvironment(winner)
+    if (winner) return toResolvedEnvironment(winner)
+
+    // No row is marked default, so the collision was instead on the
+    // (userId, repo, name) unique constraint: a row named "Default" already
+    // exists for this repo but was never promoted. This shouldn't happen
+    // through the app today, but self-heal rather than throwing forever for
+    // this repo — promote that row to default.
+    const collided = await prisma.environment.findFirst({
+      where: { userId, repo, name: DEFAULT_ENVIRONMENT_NAME },
+    })
+    if (collided) {
+      // Two ordered statements in a transaction: Postgres checks the partial
+      // unique index per statement, not deferred, so clearing any existing
+      // default and setting this row's default cannot be a single updateMany.
+      await prisma.$transaction([
+        prisma.environment.updateMany({
+          where: { userId, repo, isDefault: true },
+          data: { isDefault: false },
+        }),
+        prisma.environment.update({
+          where: { id: collided.id },
+          data: { isDefault: true },
+        }),
+      ])
+      return toResolvedEnvironment({ ...collided, isDefault: true })
+    }
+
+    throw new Error(`Failed to create default environment for ${repo}`, { cause: error })
   }
 }
 

--- a/packages/web/lib/environments.ts
+++ b/packages/web/lib/environments.ts
@@ -1,0 +1,147 @@
+/**
+ * Environment resolution.
+ *
+ * Every read of an Environment goes through here. `Chat.environmentId` is
+ * nullable (legacy chats predate the model; NEW_REPOSITORY chats have no repo),
+ * so callers that touched the column directly would each need their own null
+ * branch. resolveEnvironmentForChat collapses that into one place: a chat
+ * without an explicit environment resolves to its repo's default, creating an
+ * empty default if the repo has never had one.
+ */
+
+import { BASELINE_DOMAINS } from "@background-agents/common"
+import { prisma } from "@/lib/db/prisma"
+import { encrypt, decrypt } from "@/lib/db/encryption"
+import { NEW_REPOSITORY } from "@/lib/types"
+
+export const NETWORK_MODES = ["full", "restricted"] as const
+export type NetworkMode = (typeof NETWORK_MODES)[number]
+
+export const DEFAULT_ENVIRONMENT_NAME = "Default"
+
+/** An environment with its variables decrypted. Never persisted in this shape. */
+export interface ResolvedEnvironment {
+  id: string
+  name: string
+  repo: string
+  isDefault: boolean
+  networkMode: NetworkMode
+  allowedDomains: string[]
+  /** Decrypted. Empty object when the environment has none. */
+  variables: Record<string, string>
+  setupScript: string | null
+}
+
+/** Narrow an arbitrary stored string to a NetworkMode, defaulting to "full". */
+function toNetworkMode(value: string): NetworkMode {
+  return (NETWORK_MODES as readonly string[]).includes(value) ? (value as NetworkMode) : "full"
+}
+
+export function decryptEnvironmentVariables(raw: unknown): Record<string, string> {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {}
+  const out: Record<string, string> = {}
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof value === "string" && value) out[key] = decrypt(value)
+  }
+  return out
+}
+
+export function encryptEnvironmentVariables(plain: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const [key, value] of Object.entries(plain)) {
+    const trimmed = key.trim()
+    if (trimmed && typeof value === "string") out[trimmed] = encrypt(value)
+  }
+  return out
+}
+
+/**
+ * The `domainAllowList` string for daytona.create, or undefined in full mode
+ * (Daytona applies no restriction when the field is absent).
+ */
+export function resolveDomainAllowList(env: ResolvedEnvironment): string | undefined {
+  if (env.networkMode !== "restricted") return undefined
+  return Array.from(new Set([...BASELINE_DOMAINS, ...env.allowedDomains])).join(",")
+}
+
+type EnvironmentRow = {
+  id: string
+  name: string
+  repo: string
+  isDefault: boolean
+  networkMode: string
+  allowedDomains: string[]
+  environmentVariables: unknown
+  setupScript: string | null
+}
+
+export function toResolvedEnvironment(row: EnvironmentRow): ResolvedEnvironment {
+  return {
+    id: row.id,
+    name: row.name,
+    repo: row.repo,
+    isDefault: row.isDefault,
+    networkMode: toNetworkMode(row.networkMode),
+    allowedDomains: row.allowedDomains,
+    variables: decryptEnvironmentVariables(row.environmentVariables),
+    setupScript: row.setupScript,
+  }
+}
+
+/**
+ * The repo's default environment, created empty if it doesn't exist yet.
+ *
+ * The create races with itself when two requests hit a repo that has never had
+ * an environment; the partial unique index makes the loser fail, so we catch
+ * and re-read rather than serializing every caller behind a lock.
+ */
+export async function getOrCreateDefaultEnvironment(
+  userId: string,
+  repo: string
+): Promise<ResolvedEnvironment> {
+  const existing = await prisma.environment.findFirst({
+    where: { userId, repo, isDefault: true },
+  })
+  if (existing) return toResolvedEnvironment(existing)
+
+  try {
+    const created = await prisma.environment.create({
+      data: { userId, repo, name: DEFAULT_ENVIRONMENT_NAME, isDefault: true },
+    })
+    return toResolvedEnvironment(created)
+  } catch {
+    // Lost the race (unique index on either (userId, repo, name) or the partial
+    // default index). Whoever won has created it; read theirs.
+    const winner = await prisma.environment.findFirst({
+      where: { userId, repo, isDefault: true },
+    })
+    if (!winner) throw new Error(`Failed to create default environment for ${repo}`)
+    return toResolvedEnvironment(winner)
+  }
+}
+
+/**
+ * The environment a chat's sandbox should be built from.
+ *
+ * Returns null only for NEW_REPOSITORY chats, which have no repo to scope an
+ * environment to. Everything else resolves: the pinned environment when the
+ * chat has one and it still exists, otherwise the repo's default.
+ */
+export async function resolveEnvironmentForChat(chat: {
+  userId: string
+  repo: string
+  environmentId: string | null
+}): Promise<ResolvedEnvironment | null> {
+  if (chat.repo === NEW_REPOSITORY) return null
+
+  if (chat.environmentId) {
+    const pinned = await prisma.environment.findFirst({
+      where: { id: chat.environmentId, userId: chat.userId },
+    })
+    // A deleted environment leaves environmentId null via SetNull, but a chat
+    // read mid-delete can still carry a stale id. Fall through to the default.
+    if (pinned) return toResolvedEnvironment(pinned)
+  }
+
+  return getOrCreateDefaultEnvironment(chat.userId, chat.repo)
+}

--- a/packages/web/lib/environments.ts
+++ b/packages/web/lib/environments.ts
@@ -90,6 +90,60 @@ export function toResolvedEnvironment(row: EnvironmentRow): ResolvedEnvironment 
 }
 
 /**
+ * The wire shape the /environments UI (Task 7) and its API client consume.
+ * Plain serializable data only: no Date, no Decimal, no Prisma JsonValue, so
+ * this stays safe for client components to import with `import type`.
+ */
+export interface EnvironmentDTO {
+  id: string
+  repo: string
+  name: string
+  isDefault: boolean
+  networkMode: NetworkMode
+  allowedDomains: string[]
+  /** Decrypted. */
+  variables: Record<string, string>
+  hasSetupScript: boolean
+  setupScript: string | null
+  setupScriptUpdatedBy: "user" | "agent" | null
+  updatedAt: number
+}
+
+type EnvironmentDTORow = EnvironmentRow & {
+  setupScriptUpdatedBy: string | null
+  updatedAt: Date
+}
+
+export function toEnvironmentDTO(row: EnvironmentDTORow): EnvironmentDTO {
+  return {
+    id: row.id,
+    repo: row.repo,
+    name: row.name,
+    isDefault: row.isDefault,
+    networkMode: toNetworkMode(row.networkMode),
+    allowedDomains: row.allowedDomains,
+    variables: decryptEnvironmentVariables(row.environmentVariables),
+    hasSetupScript: !!row.setupScript,
+    setupScript: row.setupScript,
+    setupScriptUpdatedBy:
+      row.setupScriptUpdatedBy === "user" || row.setupScriptUpdatedBy === "agent"
+        ? row.setupScriptUpdatedBy
+        : null,
+    updatedAt: row.updatedAt.getTime(),
+  }
+}
+
+/**
+ * An environment scoped to its owner. Returns null when it doesn't exist OR
+ * belongs to a different user, so callers can return a single 404 without
+ * distinguishing "not found" from "not yours" (that distinction is exactly
+ * what would let another user's id be probed for existence).
+ */
+export async function getOwnedEnvironment(userId: string, id: string) {
+  return prisma.environment.findFirst({ where: { id, userId } })
+}
+
+/**
  * The repo's default environment, created empty if it doesn't exist yet.
  *
  * The create races with itself when two requests hit a repo that has never had

--- a/packages/web/lib/hooks/useChatNavigation.ts
+++ b/packages/web/lib/hooks/useChatNavigation.ts
@@ -60,6 +60,8 @@ interface UseChatNavigationResult {
   handleRepoFilterChange: (filter: string) => void
   handleOpenScheduledJobs: () => void
   handleNavigateToJob: (jobId: string | null, jobName?: string) => void
+  handleOpenEnvironments: () => void
+  handleNavigateToEnvironment: (environmentId: string | null) => void
   handleNavigateChat: (direction: "up" | "down") => void
   handleRequestMergeChats: (sourceId: string, targetId?: string) => void
   handleRequestRebaseChat: (sourceId: string) => void
@@ -95,6 +97,7 @@ export function useChatNavigation({
       selectChat(chatId)
       sidebar.setViewMode("chat")
       sidebar.setSelectedScheduledJob(null)
+      sidebar.setSelectedEnvironmentId(null)
       // Update URL without triggering Next.js navigation (which causes remount).
       // Using window.history.pushState avoids the component remount router.push causes.
       window.history.pushState(null, "", ROUTES.chat.build(chatId))
@@ -127,6 +130,7 @@ export function useChatNavigation({
     // Switch to chat view
     sidebar.setViewMode("chat")
     sidebar.setSelectedScheduledJob(null) // Clear selected job when switching to chat
+    sidebar.setSelectedEnvironmentId(null)
     // If there's a current chat (real or draft) with a repo selected, inherit its repo and base branch.
     // Sibling chat — no parentChatId, and use baseBranch (not the working branch) so the
     // new chat starts from the same point the current one did.
@@ -157,6 +161,7 @@ export function useChatNavigation({
   const handleOpenScheduledJobs = useCallback(() => {
     sidebar.setViewMode("scheduled-jobs")
     sidebar.setSelectedScheduledJob(null)
+    sidebar.setSelectedEnvironmentId(null)
     selectChat(null)
     window.history.pushState(null, "", ROUTES.jobs.build())
   }, [sidebar, selectChat])
@@ -172,6 +177,34 @@ export function useChatNavigation({
         sidebar.setSelectedScheduledJob(null)
         window.history.pushState(null, "", ROUTES.jobs.build())
       }
+    },
+    [sidebar]
+  )
+
+  // Handler for opening the environments view. Mirrors handleOpenScheduledJobs:
+  // switch the view mode, drop any selected chat/job, and push the URL through
+  // the shared ROUTES table so browser back/forward (and useUrlSync's initial
+  // sync) parse it the same way this push produces it.
+  const handleOpenEnvironments = useCallback(() => {
+    sidebar.setViewMode("environments")
+    sidebar.setSelectedScheduledJob(null)
+    sidebar.setSelectedEnvironmentId(null)
+    selectChat(null)
+    window.history.pushState(null, "", ROUTES.environments.build())
+  }, [sidebar, selectChat])
+
+  // Handler for navigating to a specific environment (updates URL and sidebar
+  // state). Mirrors handleNavigateToJob, but environments has no name-caching
+  // need: EnvironmentsView already has the full environment list loaded (from
+  // useEnvironmentsQuery) to look the row up by id.
+  const handleNavigateToEnvironment = useCallback(
+    (environmentId: string | null) => {
+      sidebar.setSelectedEnvironmentId(environmentId)
+      window.history.pushState(
+        null,
+        "",
+        environmentId ? ROUTES.environment.build(environmentId) : ROUTES.environments.build()
+      )
     },
     [sidebar]
   )
@@ -282,6 +315,8 @@ export function useChatNavigation({
     handleRepoFilterChange,
     handleOpenScheduledJobs,
     handleNavigateToJob,
+    handleOpenEnvironments,
+    handleNavigateToEnvironment,
     handleNavigateChat,
     handleRequestMergeChats,
     handleRequestRebaseChat,

--- a/packages/web/lib/hooks/useChatWithSync.ts
+++ b/packages/web/lib/hooks/useChatWithSync.ts
@@ -166,6 +166,7 @@ export function useChatWithSync() {
         model: config.model,
         status: options?.status ?? "pending",
         planModeEnabled: config.planMode,
+        environmentId: config.environmentId ?? undefined,
       })
 
       // Migrate local state from draft ID to real ID, clear the draft config,

--- a/packages/web/lib/hooks/useDraftChat.ts
+++ b/packages/web/lib/hooks/useDraftChat.ts
@@ -19,6 +19,7 @@ interface DraftChatConfig {
   agent: string | null
   model: string | null
   planMode?: boolean
+  environmentId?: string | null
 }
 
 type DraftChatConfigUpdates = Partial<{
@@ -27,6 +28,7 @@ type DraftChatConfigUpdates = Partial<{
   agent: string | null
   model: string | null
   planMode?: boolean
+  environmentId: string | null
 }>
 
 interface OptimisticDraft {
@@ -178,6 +180,7 @@ export function useDraftChat({
         agent: resolvedAgent,
         model: resolvedModel,
         planModeEnabled: draftChatConfig.planMode ?? false,
+        environmentId: draftChatConfig.environmentId ?? null,
         messages,
         createdAt: Date.now(),
         updatedAt: Date.now(),
@@ -217,6 +220,14 @@ export function useDraftChat({
           if (updates.repo !== undefined) draftUpdates.repo = updates.repo
           if (updates.baseBranch !== undefined) draftUpdates.baseBranch = updates.baseBranch
           if (updates.planModeEnabled !== undefined) draftUpdates.planMode = updates.planModeEnabled
+          if (updates.environmentId !== undefined) {
+            draftUpdates.environmentId = updates.environmentId
+          } else if (updates.repo !== undefined) {
+            // A repo change without an explicit environment invalidates any
+            // environment picked for the old repo: an environment id is only
+            // ever valid for the repo it belongs to.
+            draftUpdates.environmentId = null
+          }
           updateDraftChatConfig(draftUpdates)
         } else {
           // Unauthenticated draft - use local component state

--- a/packages/web/lib/hooks/useUrlNavigation.test.ts
+++ b/packages/web/lib/hooks/useUrlNavigation.test.ts
@@ -24,6 +24,18 @@ describe("matchRoute", () => {
     expect(matchRoute("/chat/abc123")).toEqual({ route: "chat", chatId: "abc123" })
     expect(matchRoute("/jobs")).toEqual({ route: "jobs" })
   })
+
+  it("matches the environments list and a specific environment", () => {
+    expect(matchRoute("/environments")).toEqual({ route: "environments" })
+    expect(matchRoute("/environments/env-123")).toEqual({
+      route: "environment",
+      environmentId: "env-123",
+    })
+  })
+
+  it("does not treat nested environment paths as a single environment route", () => {
+    expect(matchRoute("/environments/env-123/extra")).toBeNull()
+  })
 })
 
 describe("ROUTES.agent", () => {

--- a/packages/web/lib/hooks/useUrlNavigation.ts
+++ b/packages/web/lib/hooks/useUrlNavigation.ts
@@ -58,6 +58,20 @@ export const ROUTES = {
       return m ? { jobId: m[1], runId: m[2] } : null
     },
   },
+  environments: {
+    path: "/environments",
+    build: () => "/environments" as const,
+    match: (path: string): RouteMatch<Record<string, never>> =>
+      path === "/environments" ? {} : null,
+  },
+  environment: {
+    path: "/environments/:environmentId",
+    build: (environmentId: string) => `/environments/${environmentId}` as const,
+    match: (path: string): RouteMatch<{ environmentId: string }> => {
+      const m = path.match(/^\/environments\/([^/]+)$/)
+      return m ? { environmentId: m[1] } : null
+    },
+  },
 } as const
 
 /**
@@ -71,6 +85,8 @@ export function matchRoute(path: string):
   | { route: "jobRun"; jobId: string; runId: string }
   | { route: "job"; jobId: string }
   | { route: "jobs" }
+  | { route: "environment"; environmentId: string }
+  | { route: "environments" }
   | { route: "home" }
   | null {
   // Check in order of specificity (more specific patterns first)
@@ -103,6 +119,17 @@ export function matchRoute(path: string):
 
   if (ROUTES.jobs.match(path)) {
     return { route: "jobs" }
+  }
+
+  // environment must be before environments (since /environments/:id would
+  // match /environments first).
+  const environmentMatch = ROUTES.environment.match(path)
+  if (environmentMatch) {
+    return { route: "environment", environmentId: environmentMatch.environmentId }
+  }
+
+  if (ROUTES.environments.match(path)) {
+    return { route: "environments" }
   }
 
   if (ROUTES.home.match(path)) {

--- a/packages/web/lib/hooks/useUrlSync.ts
+++ b/packages/web/lib/hooks/useUrlSync.ts
@@ -27,6 +27,7 @@ interface UseUrlSyncOptions {
   startAgentDraft: (agent: Agent) => void
   setViewMode: (mode: "chat" | "scheduled-jobs" | "environments") => void
   setSelectedScheduledJob: (job: { id: string; name: string } | null) => void
+  setSelectedEnvironmentId: (id: string | null) => void
 }
 
 export function useUrlSync({
@@ -38,6 +39,7 @@ export function useUrlSync({
   startAgentDraft,
   setViewMode,
   setSelectedScheduledJob,
+  setSelectedEnvironmentId,
 }: UseUrlSyncOptions) {
   // Sync URL to state - used for initial load and browser back/forward
   const syncUrlToState = useCallback(
@@ -67,6 +69,18 @@ export function useUrlSync({
           // Set selected job with ID (name will be updated when job data loads)
           setSelectedScheduledJob({ id: matched.jobId, name: matched.jobId })
           // TODO: Handle run selection when runs view is implemented
+          break
+
+        case "environments":
+          setViewMode("environments")
+          if (!isInitialSync) selectChat(null)
+          setSelectedEnvironmentId(null)
+          break
+
+        case "environment":
+          setViewMode("environments")
+          if (!isInitialSync) selectChat(null)
+          setSelectedEnvironmentId(matched.environmentId)
           break
 
         case "newChat":
@@ -134,7 +148,16 @@ export function useUrlSync({
           break
       }
     },
-    [currentChatId, isDraftChatId, selectChat, startNewChat, startAgentDraft, setViewMode, setSelectedScheduledJob]
+    [
+      currentChatId,
+      isDraftChatId,
+      selectChat,
+      startNewChat,
+      startAgentDraft,
+      setViewMode,
+      setSelectedScheduledJob,
+      setSelectedEnvironmentId,
+    ]
   )
 
   // Track if we've done initial sync

--- a/packages/web/lib/hooks/useUrlSync.ts
+++ b/packages/web/lib/hooks/useUrlSync.ts
@@ -25,7 +25,7 @@ interface UseUrlSyncOptions {
   // Enter a fresh draft chat with the given agent preselected. Used by the
   // /agent/:slug deep link so the agent is baked into the draft at creation.
   startAgentDraft: (agent: Agent) => void
-  setViewMode: (mode: "chat" | "scheduled-jobs") => void
+  setViewMode: (mode: "chat" | "scheduled-jobs" | "environments") => void
   setSelectedScheduledJob: (job: { id: string; name: string } | null) => void
 }
 

--- a/packages/web/lib/query/hooks/index.ts
+++ b/packages/web/lib/query/hooks/index.ts
@@ -41,3 +41,16 @@ export type {
 } from "./useRefreshClaudeCredsMutation"
 export { useCcAuthRunsQuery } from "./useCcAuthRunsQuery"
 export type { CcAuthRun } from "./useCcAuthRunsQuery"
+
+// Environments
+export {
+  useEnvironmentsQuery,
+  useCreateEnvironmentMutation,
+  useUpdateEnvironmentMutation,
+  useDeleteEnvironmentMutation,
+  fetchEnvironmentUsage,
+} from "./useEnvironmentsQuery"
+export type {
+  CreateEnvironmentInput,
+  UpdateEnvironmentInput,
+} from "./useEnvironmentsQuery"

--- a/packages/web/lib/query/hooks/useCreateChatMutation.ts
+++ b/packages/web/lib/query/hooks/useCreateChatMutation.ts
@@ -14,6 +14,7 @@ interface CreateChatParams {
   model?: string | null
   status?: Chat["status"]
   planModeEnabled?: boolean
+  environmentId?: string | null
 }
 
 /**
@@ -33,6 +34,7 @@ export function useCreateChatMutation() {
         model: params.model ?? undefined,
         status: params.status,
         planModeEnabled: params.planModeEnabled,
+        environmentId: params.environmentId ?? undefined,
       })
       return toChatType(serverChat)
     },

--- a/packages/web/lib/query/hooks/useEnvironmentsQuery.ts
+++ b/packages/web/lib/query/hooks/useEnvironmentsQuery.ts
@@ -1,0 +1,97 @@
+"use client"
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { useSession } from "next-auth/react"
+import { queryKeys } from "../keys"
+// Type-only: EnvironmentDTO's module imports @/lib/db/prisma. A plain value
+// import here would pull Prisma into the browser bundle.
+import type { EnvironmentDTO } from "@/lib/environments"
+
+async function json<T>(res: Response): Promise<T> {
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}))
+    throw new Error(body.error ?? body.message ?? `Request failed (${res.status})`)
+  }
+  return res.json() as Promise<T>
+}
+
+/** All environments for the user, or just one repo's when `repo` is given. */
+export function useEnvironmentsQuery(repo?: string) {
+  const { status } = useSession()
+  return useQuery({
+    queryKey: queryKeys.environments.list(repo),
+    queryFn: async () => {
+      const url = repo ? `/api/environments?repo=${encodeURIComponent(repo)}` : "/api/environments"
+      const data = await json<{ environments: EnvironmentDTO[] }>(await fetch(url))
+      return data.environments
+    },
+    enabled: status === "authenticated",
+    staleTime: 30 * 1000,
+  })
+}
+
+export interface CreateEnvironmentInput {
+  repo: string
+  name: string
+  duplicateOf?: string
+}
+
+export function useCreateEnvironmentMutation() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (input: CreateEnvironmentInput) => {
+      const data = await json<{ environment: EnvironmentDTO }>(
+        await fetch("/api/environments", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(input),
+        })
+      )
+      return data.environment
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.environments.all }),
+  })
+}
+
+export interface UpdateEnvironmentInput {
+  id: string
+  name?: string
+  networkMode?: "full" | "restricted"
+  allowedDomains?: string[]
+  variables?: Record<string, string>
+  setupScript?: string | null
+  isDefault?: true
+}
+
+export function useUpdateEnvironmentMutation() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async ({ id, ...patch }: UpdateEnvironmentInput) => {
+      const data = await json<{ environment: EnvironmentDTO }>(
+        await fetch(`/api/environments/${id}`, {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(patch),
+        })
+      )
+      return data.environment
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.environments.all }),
+  })
+}
+
+export function useDeleteEnvironmentMutation() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (id: string) => {
+      await json<{ success: true }>(await fetch(`/api/environments/${id}`, { method: "DELETE" }))
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.environments.all }),
+  })
+}
+
+/** Chat count for the delete confirmation. Fetched on demand, not prefetched. */
+export async function fetchEnvironmentUsage(id: string): Promise<number> {
+  const data = await json<{ chatCount: number }>(await fetch(`/api/environments/${id}/usage`))
+  return data.chatCount
+}

--- a/packages/web/lib/query/hooks/useEnvironmentsQuery.ts
+++ b/packages/web/lib/query/hooks/useEnvironmentsQuery.ts
@@ -15,13 +15,27 @@ async function json<T>(res: Response): Promise<T> {
   return res.json() as Promise<T>
 }
 
-/** All environments for the user, or just one repo's when `repo` is given. */
-export function useEnvironmentsQuery(repo?: string) {
+/**
+ * All environments for the user, or just one repo's when `repo` is given.
+ *
+ * `includeVariables` asks the server to decrypt and return each
+ * environment's `variables` too (see GET /api/environments). Leave it false
+ * (the default) for anything that only displays names/counts, like the
+ * combobox and the list view: without it, decrypted secrets for every
+ * environment on a repo would sit in the SPA's memory on every render that
+ * merely shows a picker. Only the environments editor, which actually reads
+ * and writes variables, should pass true.
+ */
+export function useEnvironmentsQuery(repo?: string, includeVariables = false) {
   const { status } = useSession()
   return useQuery({
-    queryKey: queryKeys.environments.list(repo),
+    queryKey: queryKeys.environments.list(repo, includeVariables),
     queryFn: async () => {
-      const url = repo ? `/api/environments?repo=${encodeURIComponent(repo)}` : "/api/environments"
+      const params = new URLSearchParams()
+      if (repo) params.set("repo", repo)
+      if (includeVariables) params.set("include", "variables")
+      const qs = params.toString()
+      const url = qs ? `/api/environments?${qs}` : "/api/environments"
       const data = await json<{ environments: EnvironmentDTO[] }>(await fetch(url))
       return data.environments
     },

--- a/packages/web/lib/query/hooks/useUpdateChatMutation.ts
+++ b/packages/web/lib/query/hooks/useUpdateChatMutation.ts
@@ -28,6 +28,7 @@ function applyChatUpdate(chat: Chat, data: UpdateChatData): Chat {
   if (data.repo !== undefined) updated.repo = data.repo
   if (data.baseBranch !== undefined) updated.baseBranch = data.baseBranch
   if (data.branch !== undefined) updated.branch = data.branch
+  if (data.environmentId !== undefined) updated.environmentId = data.environmentId
   // sandboxId / sessionId / previewUrlPattern / backgroundSessionId are
   // server-managed (see updateChat type) and never part of `data` here.
   if (data.needsSync !== undefined) updated.needsSync = data.needsSync

--- a/packages/web/lib/query/keys.ts
+++ b/packages/web/lib/query/keys.ts
@@ -19,6 +19,14 @@ export const queryKeys = {
     all: ["settings"] as const,
   },
 
+  // Environments
+  environments: {
+    all: ["environments"] as const,
+    list: (repo?: string) => [...queryKeys.environments.all, "list", repo ?? "*"] as const,
+    detail: (id: string) => [...queryKeys.environments.all, "detail", id] as const,
+    usage: (id: string) => [...queryKeys.environments.all, "usage", id] as const,
+  },
+
   // GitHub
   github: {
     all: ["github"] as const,

--- a/packages/web/lib/query/keys.ts
+++ b/packages/web/lib/query/keys.ts
@@ -22,7 +22,13 @@ export const queryKeys = {
   // Environments
   environments: {
     all: ["environments"] as const,
-    list: (repo?: string) => [...queryKeys.environments.all, "list", repo ?? "*"] as const,
+    list: (repo?: string, includeVariables?: boolean) =>
+      [
+        ...queryKeys.environments.all,
+        "list",
+        repo ?? "*",
+        includeVariables ? "with-variables" : "no-variables",
+      ] as const,
     detail: (id: string) => [...queryKeys.environments.all, "detail", id] as const,
     usage: (id: string) => [...queryKeys.environments.all, "usage", id] as const,
   },

--- a/packages/web/lib/sandbox-create-params.test.ts
+++ b/packages/web/lib/sandbox-create-params.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from "vitest"
+
+// sandbox-create-params.ts imports resolveDomainAllowList from ./environments,
+// which imports the prisma singleton. lib/db/prisma.ts constructs a
+// PrismaClient at module scope and throws without DATABASE_URL, so it must be
+// mocked even though nothing in this test touches it. Same pattern as
+// lib/environments.test.ts.
+vi.mock("@/lib/db/prisma", () => ({ prisma: {} }))
+
+import { buildSandboxCreateParams } from "./sandbox-create-params"
+import { BASELINE_DOMAINS } from "@background-agents/common"
+import type { ResolvedEnvironment } from "./environments"
+
+function env(overrides: Partial<ResolvedEnvironment> = {}): ResolvedEnvironment {
+  return {
+    id: "env_1",
+    name: "Default",
+    repo: "acme/app",
+    isDefault: true,
+    networkMode: "full",
+    allowedDomains: [],
+    variables: {},
+    setupScript: null,
+    ...overrides,
+  }
+}
+
+const base = {
+  name: "backgrounder-abc-123",
+  snapshot: "background-agents-1",
+  repo: "acme/app",
+  branch: "agent/1234",
+}
+
+describe("buildSandboxCreateParams", () => {
+  it("omits domainAllowList in full mode", () => {
+    const params = buildSandboxCreateParams({ ...base, environment: env() })
+    expect(params).not.toHaveProperty("domainAllowList")
+  })
+
+  it("omits domainAllowList when there is no environment at all", () => {
+    const params = buildSandboxCreateParams({ ...base, environment: null })
+    expect(params).not.toHaveProperty("domainAllowList")
+  })
+
+  it("sets domainAllowList to baseline plus user domains in restricted mode", () => {
+    const params = buildSandboxCreateParams({
+      ...base,
+      environment: env({ networkMode: "restricted", allowedDomains: ["example.com"] }),
+    })
+    const domains = String(params.domainAllowList).split(",")
+    expect(domains).toContain("example.com")
+    for (const baseline of BASELINE_DOMAINS) expect(domains).toContain(baseline)
+  })
+
+  it("passes the environment's variables as sandbox envVars", () => {
+    const params = buildSandboxCreateParams({
+      ...base,
+      environment: env({ variables: { NPM_TOKEN: "tok" } }),
+    })
+    expect(params.envVars).toEqual({ NPM_TOKEN: "tok" })
+  })
+
+  it("omits envVars when the environment has none, rather than sending an empty object", () => {
+    const params = buildSandboxCreateParams({ ...base, environment: env() })
+    expect(params).not.toHaveProperty("envVars")
+  })
+
+  it("keeps the existing labels, snapshot, and lifecycle settings", () => {
+    const params = buildSandboxCreateParams({ ...base, environment: env() })
+    expect(params.snapshot).toBe("background-agents-1")
+    expect(params.public).toBe(true)
+    expect(params.autoStopInterval).toBe(5)
+    expect(params.autoDeleteInterval).toBe(5760)
+    expect(params.labels).toMatchObject({ repo: "acme/app", branch: "agent/1234" })
+  })
+})

--- a/packages/web/lib/sandbox-create-params.test.ts
+++ b/packages/web/lib/sandbox-create-params.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest"
 
-// sandbox-create-params.ts imports resolveDomainAllowList from ./environments,
+// sandbox-create-params.ts imports ResolvedEnvironment from ./environments,
 // which imports the prisma singleton. lib/db/prisma.ts constructs a
 // PrismaClient at module scope and throws without DATABASE_URL, so it must be
 // mocked even though nothing in this test touches it. Same pattern as
@@ -8,7 +8,6 @@ import { describe, it, expect, vi } from "vitest"
 vi.mock("@/lib/db/prisma", () => ({ prisma: {} }))
 
 import { buildSandboxCreateParams } from "./sandbox-create-params"
-import { BASELINE_DOMAINS } from "@background-agents/common"
 import type { ResolvedEnvironment } from "./environments"
 
 function env(overrides: Partial<ResolvedEnvironment> = {}): ResolvedEnvironment {
@@ -33,24 +32,33 @@ const base = {
 }
 
 describe("buildSandboxCreateParams", () => {
-  it("omits domainAllowList in full mode", () => {
+  it("emits no network-restriction field in full mode", () => {
     const params = buildSandboxCreateParams({ ...base, environment: env() })
     expect(params).not.toHaveProperty("domainAllowList")
+    expect(params).not.toHaveProperty("networkAllowList")
+    expect(params).not.toHaveProperty("networkBlockAll")
   })
 
-  it("omits domainAllowList when there is no environment at all", () => {
+  it("emits no network-restriction field when there is no environment at all", () => {
     const params = buildSandboxCreateParams({ ...base, environment: null })
     expect(params).not.toHaveProperty("domainAllowList")
+    expect(params).not.toHaveProperty("networkAllowList")
+    expect(params).not.toHaveProperty("networkBlockAll")
   })
 
-  it("sets domainAllowList to baseline plus user domains in restricted mode", () => {
-    const params = buildSandboxCreateParams({
-      ...base,
-      environment: env({ networkMode: "restricted", allowedDomains: ["example.com"] }),
-    })
-    const domains = String(params.domainAllowList).split(",")
-    expect(domains).toContain("example.com")
-    for (const baseline of BASELINE_DOMAINS) expect(domains).toContain(baseline)
+  // The installed @daytonaio/sdk (0.170.0) has no domain-allowlist field,
+  // only networkBlockAll and a CIDR-only networkAllowList, neither of which
+  // can express "allow these hostnames" for CDN-backed services with
+  // rotating IPs. Emitting a field the SDK ignores would silently produce an
+  // unrestricted sandbox despite the "restricted" setting, so restricted mode
+  // is refused outright rather than under-enforced.
+  it("throws for restricted mode, since the installed Daytona SDK cannot enforce a domain allowlist", () => {
+    expect(() =>
+      buildSandboxCreateParams({
+        ...base,
+        environment: env({ networkMode: "restricted", allowedDomains: ["example.com"] }),
+      })
+    ).toThrow(/restricted network/i)
   })
 
   it("passes the environment's variables as sandbox envVars", () => {

--- a/packages/web/lib/sandbox-create-params.ts
+++ b/packages/web/lib/sandbox-create-params.ts
@@ -1,0 +1,40 @@
+/**
+ * Pure construction of the parameter object handed to `daytona.create`.
+ *
+ * Split out of lib/sandbox.ts so the network/env-var wiring is testable
+ * without standing up a Daytona client, a prisma-backed git helper, or a live
+ * snapshot lookup. Both `domainAllowList` and `envVars` are omitted rather
+ * than passed empty: Daytona treats an absent domainAllowList as
+ * "unrestricted", and an empty envVars object is noise in the API call.
+ */
+
+import { SANDBOX_CONFIG } from "@/lib/constants"
+import { resolveDomainAllowList, type ResolvedEnvironment } from "@/lib/environments"
+
+export function buildSandboxCreateParams(args: {
+  name: string
+  snapshot: string
+  repo: string
+  branch: string
+  environment: ResolvedEnvironment | null
+}): Record<string, unknown> {
+  const { name, snapshot, repo, branch, environment } = args
+
+  const domainAllowList = environment ? resolveDomainAllowList(environment) : undefined
+  const envVars = environment?.variables ?? {}
+
+  return {
+    name,
+    snapshot,
+    autoStopInterval: 5,
+    autoDeleteInterval: 5760, // 4 days - auto-delete after being stopped for four days
+    public: true,
+    labels: {
+      [SANDBOX_CONFIG.LABEL_KEY]: "true",
+      repo,
+      branch,
+    },
+    ...(domainAllowList && { domainAllowList }),
+    ...(Object.keys(envVars).length > 0 && { envVars }),
+  }
+}

--- a/packages/web/lib/sandbox-create-params.ts
+++ b/packages/web/lib/sandbox-create-params.ts
@@ -3,13 +3,27 @@
  *
  * Split out of lib/sandbox.ts so the network/env-var wiring is testable
  * without standing up a Daytona client, a prisma-backed git helper, or a live
- * snapshot lookup. Both `domainAllowList` and `envVars` are omitted rather
- * than passed empty: Daytona treats an absent domainAllowList as
- * "unrestricted", and an empty envVars object is noise in the API call.
+ * snapshot lookup.
+ *
+ * `envVars` is omitted rather than passed as `{}` for an environment with no
+ * variables, not because the SDK treats the two differently (it does
+ * `env: params.envVars || {}` internally, so they're wire-identical), but
+ * because omitting is simpler to read at the call site and avoids implying
+ * variables were considered and found empty.
+ *
+ * Network restriction is NOT wired up: the installed `@daytonaio/sdk`
+ * (0.170.0, pinned across the monorepo) has no `domainAllowList` field, only
+ * `networkBlockAll` and a CIDR-only `networkAllowList`, neither of which can
+ * express "allow these hostnames" for CDN-backed services with rotating IPs.
+ * Emitting a field the SDK silently ignores would produce a sandbox that
+ * looks restricted but isn't, so `"restricted"` environments are rejected
+ * outright here until the SDK is upgraded (0.185.0+) and this function is
+ * revisited to emit whatever field replaces `domainAllowList`.
  */
 
+import type { CreateSandboxFromSnapshotParams } from "@daytonaio/sdk"
 import { SANDBOX_CONFIG } from "@/lib/constants"
-import { resolveDomainAllowList, type ResolvedEnvironment } from "@/lib/environments"
+import type { ResolvedEnvironment } from "@/lib/environments"
 
 export function buildSandboxCreateParams(args: {
   name: string
@@ -17,10 +31,21 @@ export function buildSandboxCreateParams(args: {
   repo: string
   branch: string
   environment: ResolvedEnvironment | null
-}): Record<string, unknown> {
+}): CreateSandboxFromSnapshotParams {
   const { name, snapshot, repo, branch, environment } = args
 
-  const domainAllowList = environment ? resolveDomainAllowList(environment) : undefined
+  if (environment?.networkMode === "restricted") {
+    throw new Error(
+      `Environment "${environment.name}" (${environment.id}) is set to restricted network ` +
+        `mode, but the installed @daytonaio/sdk (0.170.0) has no domain-allowlist field to ` +
+        `enforce it with, only "networkBlockAll" and a CIDR-only "networkAllowList", neither ` +
+        `of which can express an allowed-hostnames list. Creating this sandbox would silently ` +
+        `produce an UNRESTRICTED sandbox despite the "restricted" setting, so this is refused ` +
+        `instead. Set the environment's network mode to "full" until the Daytona SDK is ` +
+        `upgraded to a version (0.185.0+) that supports domain allowlisting.`
+    )
+  }
+
   const envVars = environment?.variables ?? {}
 
   return {
@@ -34,7 +59,6 @@ export function buildSandboxCreateParams(args: {
       repo,
       branch,
     },
-    ...(domainAllowList && { domainAllowList }),
     ...(Object.keys(envVars).length > 0 && { envVars }),
   }
 }

--- a/packages/web/lib/sandbox.ts
+++ b/packages/web/lib/sandbox.ts
@@ -15,6 +15,8 @@ import { TOKSCALE_VERSION, getActiveSnapshotName } from "@background-agents/sand
 import { PATHS, SANDBOX_CONFIG } from "@/lib/constants"
 import { NEW_REPOSITORY } from "@/lib/types"
 import { prisma } from "@/lib/db/prisma"
+import type { ResolvedEnvironment } from "@/lib/environments"
+import { buildSandboxCreateParams } from "@/lib/sandbox-create-params"
 
 /**
  * Sandbox ids we've already confirmed have tokscale this process lifetime, so
@@ -141,6 +143,12 @@ export interface CreateSandboxOptions {
    * creating a fresh one. Used when recreating a deleted sandbox.
    */
   restoreExistingBranch?: boolean
+  /**
+   * The resolved environment for this chat: network mode, variables, and (in
+   * Part 2) the setup script. Null for NEW_REPOSITORY chats, which have no repo
+   * to scope an environment to.
+   */
+  environment?: ResolvedEnvironment | null
 }
 
 export interface CreatedSandbox {
@@ -190,18 +198,15 @@ export async function createSandboxForChat(
     }
   }
 
-  const sandbox = await daytona.create({
-    name: generateSandboxName(userId),
-    snapshot: await getActiveSnapshotName(daytona),
-    autoStopInterval: 5,
-    autoDeleteInterval: 5760, // 4 days - auto-delete after being stopped for four days
-    public: true,
-    labels: {
-      [SANDBOX_CONFIG.LABEL_KEY]: "true",
+  const sandbox = await daytona.create(
+    buildSandboxCreateParams({
+      name: generateSandboxName(userId),
+      snapshot: await getActiveSnapshotName(daytona),
       repo: isNewRepo ? NEW_REPOSITORY : `${owner}/${repoApiName}`,
       branch: newBranch,
-    },
-  })
+      environment: options.environment ?? null,
+    }) as Parameters<Daytona["create"]>[0]
+  )
 
   await sandbox.process.executeCommand(`mkdir -p ${PATHS.LOGS_DIR}`)
 

--- a/packages/web/lib/sandbox.ts
+++ b/packages/web/lib/sandbox.ts
@@ -205,7 +205,7 @@ export async function createSandboxForChat(
       repo: isNewRepo ? NEW_REPOSITORY : `${owner}/${repoApiName}`,
       branch: newBranch,
       environment: options.environment ?? null,
-    }) as Parameters<Daytona["create"]>[0]
+    })
   )
 
   await sandbox.process.executeCommand(`mkdir -p ${PATHS.LOGS_DIR}`)

--- a/packages/web/lib/storage.ts
+++ b/packages/web/lib/storage.ts
@@ -31,6 +31,10 @@ export interface DraftChatConfig {
   agent: string | null
   model: string | null
   planMode?: boolean
+  /** Explicit environment pick for the draft, or null once cleared (e.g. by a
+   *  repo change). Undefined means "not yet chosen" (falls back to the repo's
+   *  default at materialization). */
+  environmentId?: string | null
 }
 
 /** Preview state for a chat */

--- a/packages/web/lib/sync/api.ts
+++ b/packages/web/lib/sync/api.ts
@@ -25,6 +25,7 @@ export interface ChatResponse {
   agent: string
   model: string | null
   planModeEnabled: boolean
+  environmentId?: string | null
   displayName: string | null
   shareId?: string | null
   status: string
@@ -150,6 +151,7 @@ export async function createChat(data: {
   model?: string
   status?: string
   planModeEnabled?: boolean
+  environmentId?: string
 }): Promise<ChatResponse> {
   return fetchApi<ChatResponse>("/api/chats", {
     method: "POST",
@@ -175,6 +177,7 @@ export async function updateChat(
     branch: string | null
     needsSync: boolean
     lastActiveAt: number
+    environmentId: string
     // sandboxId / sessionId / previewUrlPattern / backgroundSessionId are
     // server-managed and rejected by PATCH /api/chats/[chatId] — never send them.
   }>
@@ -250,6 +253,7 @@ export function toChatType(serverChat: ChatResponse): Chat {
     agent: serverChat.agent,
     model: serverChat.model || undefined,
     planModeEnabled: serverChat.planModeEnabled,
+    environmentId: serverChat.environmentId ?? null,
     displayName: serverChat.displayName,
     shareId: serverChat.shareId ?? null,
     status: serverChat.status as Chat["status"],

--- a/packages/web/lib/types.ts
+++ b/packages/web/lib/types.ts
@@ -146,6 +146,10 @@ export interface Chat {
   repo: string           // "owner/repo" or NEW_REPOSITORY for local repo
   baseBranch: string     // "main" - what we branched FROM (ignored for NEW_REPOSITORY)
 
+  /** The environment this chat's sandbox is built from. Null for NEW_REPOSITORY
+   *  chats (no repo to scope one to). Fixed once the chat has a sandbox. */
+  environmentId?: string | null
+
   // Created on first message
   branch: string | null         // "swift-lunar-abc1" - the NEW branch we created
   sandboxId: string | null      // Daytona sandbox ID

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -9,6 +9,8 @@
     "clean": "rm -rf .next",
     "start": "next start --port 4000",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:ccauth": "tsx scripts/run-ccauth.ts",

--- a/packages/web/prisma/migrations/20260906012310_add_environment_model/migration.sql
+++ b/packages/web/prisma/migrations/20260906012310_add_environment_model/migration.sql
@@ -33,14 +33,14 @@ ALTER TABLE "Chat" ADD CONSTRAINT "Chat_environmentId_fkey" FOREIGN KEY ("enviro
 ALTER TABLE "Environment" ADD CONSTRAINT "Environment_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- Exactly one default environment per (userId, repo). Prisma can't express a
--- partial unique index, so it goes in by hand — same as the
+-- partial unique index, so it goes in by hand: same as the
 -- McpServerConnection CHECK constraint.
 CREATE UNIQUE INDEX "Environment_one_default_per_repo"
     ON "Environment"("userId", "repo")
     WHERE "isDefault";
 
 -- Backfill: one "Default" environment per repo that already has variables in
--- User.repoEnvironmentVariables. The ciphertext is copied verbatim — no
+-- User.repoEnvironmentVariables. The ciphertext is copied verbatim: no
 -- decrypt/re-encrypt round trip, so values never exist in plaintext here and
 -- the app's decrypt() reads them unchanged.
 INSERT INTO "Environment" (

--- a/packages/web/prisma/migrations/20260906012310_add_environment_model/migration.sql
+++ b/packages/web/prisma/migrations/20260906012310_add_environment_model/migration.sql
@@ -1,0 +1,65 @@
+-- AlterTable
+ALTER TABLE "Chat" ADD COLUMN     "environmentId" TEXT;
+
+-- CreateTable
+CREATE TABLE "Environment" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "repo" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "isDefault" BOOLEAN NOT NULL DEFAULT false,
+    "networkMode" TEXT NOT NULL DEFAULT 'full',
+    "allowedDomains" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "environmentVariables" JSONB,
+    "setupScript" TEXT,
+    "setupScriptPrevious" TEXT,
+    "setupScriptUpdatedBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Environment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Environment_userId_repo_idx" ON "Environment"("userId", "repo");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Environment_userId_repo_name_key" ON "Environment"("userId", "repo", "name");
+
+-- AddForeignKey
+ALTER TABLE "Chat" ADD CONSTRAINT "Chat_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "Environment"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Environment" ADD CONSTRAINT "Environment_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Exactly one default environment per (userId, repo). Prisma can't express a
+-- partial unique index, so it goes in by hand — same as the
+-- McpServerConnection CHECK constraint.
+CREATE UNIQUE INDEX "Environment_one_default_per_repo"
+    ON "Environment"("userId", "repo")
+    WHERE "isDefault";
+
+-- Backfill: one "Default" environment per repo that already has variables in
+-- User.repoEnvironmentVariables. The ciphertext is copied verbatim — no
+-- decrypt/re-encrypt round trip, so values never exist in plaintext here and
+-- the app's decrypt() reads them unchanged.
+INSERT INTO "Environment" (
+    "id", "userId", "repo", "name", "isDefault",
+    "networkMode", "allowedDomains", "environmentVariables",
+    "createdAt", "updatedAt"
+)
+SELECT
+    gen_random_uuid()::text,
+    u."id",
+    repo.key,
+    'Default',
+    true,
+    'full',
+    ARRAY[]::text[],
+    repo.value,
+    NOW(),
+    NOW()
+FROM "User" u,
+     jsonb_each(u."repoEnvironmentVariables"::jsonb) AS repo(key, value)
+WHERE u."repoEnvironmentVariables" IS NOT NULL
+  AND jsonb_typeof(u."repoEnvironmentVariables"::jsonb) = 'object';

--- a/packages/web/prisma/schema.prisma
+++ b/packages/web/prisma/schema.prisma
@@ -84,6 +84,7 @@ model User {
   skills             Skill[]
   tokenUsages        TokenUsage[]
   creditTransactions CreditTransaction[]
+  environments       Environment[]
 }
 
 // =============================================================================
@@ -150,6 +151,12 @@ model Chat {
   model           String?
   planModeEnabled Boolean @default(false)
 
+  // Which environment this chat's sandbox is built from. Null for legacy chats
+  // and NEW_REPOSITORY chats; resolveEnvironmentForChat falls back to the
+  // repo's default. SetNull (not Cascade) so deleting an environment never
+  // destroys chat history.
+  environmentId String?
+
   // Display
   displayName String?
   status      String  @default("pending") // pending, creating, ready, running, error
@@ -185,9 +192,10 @@ model Chat {
   environmentVariables Json?
 
   // Relations
-  user       User                  @relation(fields: [userId], references: [id], onDelete: Cascade)
-  messages   Message[]
-  mcpServers McpServerConnection[]
+  user        User                  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  environment Environment?          @relation(fields: [environmentId], references: [id], onDelete: SetNull)
+  messages    Message[]
+  mcpServers  McpServerConnection[]
 
   // Link back to scheduled run (if this chat belongs to one)
   scheduledJobRun ScheduledJobRun?
@@ -583,5 +591,44 @@ model Skill {
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([userId, repo, fullHandle])
+  @@index([userId, repo])
+}
+
+// =============================================================================
+// Environment - named, per-repo sandbox configuration
+// =============================================================================
+// Supersedes User.repoEnvironmentVariables. Exactly one row per (userId, repo)
+// has isDefault = true; Prisma can't express a partial unique index, so the
+// migration adds it by hand (same approach as McpServerConnection's CHECK).
+
+model Environment {
+  id     String @id @default(cuid())
+  userId String
+  repo   String // "owner/repo"
+
+  name      String
+  isDefault Boolean @default(false)
+
+  // "full" | "restricted". Restricted = BASELINE_DOMAINS + allowedDomains.
+  networkMode    String   @default("full")
+  allowedDomains String[] @default([])
+
+  // Encrypted at rest: { "KEY": "encrypted_value", ... }
+  environmentVariables Json?
+
+  // Stored plaintext, unlike environmentVariables: the sync-back diff in Part 2
+  // needs to compare and display it, and a setup script is normally not secret.
+  // The editor tells users to put secrets in variables instead.
+  setupScript          String? @db.Text
+  setupScriptPrevious  String? @db.Text
+  setupScriptUpdatedBy String? // "user" | "agent"
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  user  User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  chats Chat[]
+
+  @@unique([userId, repo, name])
   @@index([userId, repo])
 }

--- a/packages/web/scripts/verify-environment-backfill.ts
+++ b/packages/web/scripts/verify-environment-backfill.ts
@@ -1,0 +1,86 @@
+/**
+ * Verifies the Environment backfill against the source blob it was built from.
+ *
+ * For every user with repoEnvironmentVariables, checks that each repo key has
+ * exactly one Default environment whose variables decrypt to the same values.
+ * Run after applying the migration locally, and once against a production
+ * clone before the deploy.
+ *
+ *   npx tsx scripts/verify-environment-backfill.ts
+ */
+import path from "node:path"
+
+import { Prisma, PrismaClient } from "@prisma/client"
+import { PrismaPg } from "@prisma/adapter-pg"
+import { config as loadEnv } from "dotenv"
+import pg from "pg"
+
+import { decrypt } from "../lib/db/encryption"
+
+// Same precedence as prisma.config.ts and Next itself: .env.local beats .env,
+// so running this with no arguments hits the same database the app does.
+const exported = process.env.DATABASE_URL
+const packageDir = path.join(__dirname, "..")
+loadEnv({ path: path.join(packageDir, ".env") })
+loadEnv({ path: path.join(packageDir, ".env.local"), override: true })
+if (exported) process.env.DATABASE_URL = exported
+
+const connectionString = process.env.DATABASE_URL ?? process.env.POSTGRES_URL
+if (!connectionString) throw new Error("DATABASE_URL is not set")
+
+// Say out loud which database is about to be read.
+console.log(`Database: ${connectionString.replace(/:\/\/[^@]*@/, "://***@")}`)
+
+const prisma = new PrismaClient({
+  adapter: new PrismaPg(new pg.Pool({ connectionString, max: 5 })),
+})
+
+async function main() {
+  const users = await prisma.user.findMany({
+    where: { NOT: { repoEnvironmentVariables: { equals: Prisma.DbNull } } },
+    select: { id: true, repoEnvironmentVariables: true },
+  })
+
+  let checked = 0
+  const problems: string[] = []
+
+  for (const user of users) {
+    const blob = (user.repoEnvironmentVariables ?? {}) as Record<
+      string,
+      Record<string, string>
+    >
+    for (const [repo, vars] of Object.entries(blob)) {
+      const envs = await prisma.environment.findMany({
+        where: { userId: user.id, repo, isDefault: true },
+      })
+      if (envs.length !== 1) {
+        problems.push(
+          `${user.id} ${repo}: expected 1 default env, found ${envs.length}`
+        )
+        continue
+      }
+      const stored = (envs[0].environmentVariables ?? {}) as Record<
+        string,
+        string
+      >
+      for (const [key, cipher] of Object.entries(vars)) {
+        if (decrypt(stored[key] ?? "") !== decrypt(cipher)) {
+          problems.push(`${user.id} ${repo}: value mismatch for ${key}`)
+        }
+      }
+      checked++
+    }
+  }
+
+  console.log(
+    `Checked ${checked} (user, repo) pairs across ${users.length} users.`
+  )
+  if (problems.length) {
+    console.error(`${problems.length} problems:`)
+    for (const p of problems) console.error(`  - ${p}`)
+    process.exit(1)
+  }
+  console.log("Backfill verified.")
+}
+
+main().finally(() => prisma.$disconnect())


### PR DESCRIPTION
Adds cloud environments. Per repo you can have named environments that hold env vars, a network setting, and a setup script, and a chat gets built from one of them.

This replaces the old `User.repoEnvironmentVariables` blob. The migration backfills a "Default" environment per repo from whatever was in there, copying the ciphertext as is so nothing gets decrypted on the way. Existing chats have no `environmentId` and resolve to that Default, so nothing changes for anyone who doesn't open the new page.

## what's in it

- `Environment` model, migration + backfill, and a partial unique index so there's exactly one default per repo
- `lib/environments.ts` is the only place anything reads an environment from. `resolveEnvironmentForChat` is `chat.environmentId ?? the repo's default`, so there's no null branch scattered around
- env vars go in two places on purpose. sandbox wide at create time (for the setup script and the terminal later), and read fresh every turn in `agent-env.ts` so editing a var takes effect on your next message instead of waiting for a new sandbox. that's how it behaved before and i didn't want to regress it
- CRUD API, `/environments` page (list, editor, duplicate, promote to default, delete), and a picker in the composer next to the repo picker
- `/api/user/repo-env` now reads and writes the repo's default environment. same wire contract, no client changes. without this the old env vars modal would have kept saving into a column nothing reads anymore, which was a silent data loss window
- scheduled job runs resolve the repo's default too, they were getting nothing

## two things that are stored but not live

**setup scripts don't run yet.** you can write and save one and nothing executes it. that's phase 2.

**network restriction isn't enforced.** the installed `@daytonaio/sdk@0.170.0` has no `domainAllowList` field, so passing it does nothing. i had this silently producing a fully unrestricted sandbox at first, which is worse than not shipping it. now the API rejects `restricted` with a 400, sandbox creation throws, and the UI shows the option but won't let you pick it, with the reason. the column and the baseline domain list stay in so the follow up has somewhere to land.

## next phases

**phase 2, setup scripts.** plan is written up already. the script gets written to `/home/daytona/.backgrounder/setup.sh` and started as a detached job with `@background-agents/sandbox-jobs`, so it survives the request dying. the chat sits in a new `setting_up` state streaming the log while the turn waits. if the script fails the turn still runs, the agent just gets told what broke, and since the script is a real file the agent can fix it and we sync it back to the environment with one click revert. that also gives us "set up with agent" basically for free, it's just a normal chat pointed at that file.

**the SDK bump.** `^0.170.0` is pinned across 8 packages, 6 of them published. `domainAllowList` landed somewhere between 0.185 and 0.190. i tried the bump and `npm install` dies on ERESOLVE because package-lock still has a workspace entry for `packages/background-runner-spike`, which isn't on disk anymore. wanted to keep that out of this PR.

**smaller stuff.** `EnvironmentEditor` does `environment.variables ?? {}`, which is fine today because there's one mount site that always fetches with variables, but a second one would silently save an empty set. worth making the editor require a variables-present DTO at some point.

## testing

441 unit tests, typecheck clean, e2e passes. IDOR spec covers the new routes. a few things got verified against a real dev server rather than just mocks, the prisma P2002 metadata shape especially, since it turned out to be `meta.driverAdapterError.cause.constraint.fields` and not `meta.target` like i assumed.

main is merged in, one conflict in the query hooks barrel, both sides kept.
