### PR TITLE
fix(usage): stop a run once its turn has spent the balance

### DIFF
--- a/packages/web/app/api/cron/agent-lifecycle/_lib/constants.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/_lib/constants.ts
@@ -2,3 +2,40 @@
 // the agent and marks the chat/run as errored.
 export const INTERACTIVE_HARD_TIMEOUT = 25 // minutes
 export const SCHEDULED_HARD_TIMEOUT = 20 // minutes
+
+// ── Mid-turn credit guard (see ./credit-guard) ───────────────────────────────
+
+/**
+ * How long a turn must have been running before the guard samples it.
+ *
+ * Measured, not guessed: on Claude Code tokscale reports nothing at all for the
+ * first ~110 seconds of a turn — the session file exists, but no assistant
+ * message carrying a usage record has been written yet, so every earlier sample
+ * reads $0 and tells us nothing. (OpenCode reports from ~15s, but one threshold
+ * for both is simpler than a per-agent table for the sake of one minute.)
+ * Sampling below this only spends a sandbox round-trip to learn nothing.
+ */
+export const CREDIT_GUARD_MIN_RUN_MINUTES = 2
+
+/**
+ * How far ahead the guard has to keep the balance solvent, in minutes.
+ *
+ * Two lags stack up between a token being burnt and this cron being able to act
+ * on it: tokscale's figure only advances when an assistant message completes,
+ * which was observed sitting flat for up to ~2 minutes mid-run before jumping
+ * by the whole accumulated amount; and the cron itself only looks once a
+ * minute. So a balance that merely looks positive right now can already be
+ * spent. Stopping while this much projected spend still fits is what turns
+ * "stop at zero" into "stop before zero".
+ */
+export const CREDIT_GUARD_LOOKAHEAD_MINUTES = 3
+
+// There is deliberately no "balance too high to bother sampling" ceiling. It
+// looks like an obvious saving and cannot be one: to be safe it has to sit
+// above what a single turn can charge (the worst turn on the ledger would have
+// taken $23.78 of credits), and every balance in production is a daily refill
+// target of $0.25 or $0.50 — the largest is $1.77. Any ceiling low enough to
+// exclude somebody is low enough to wave through the runs that do the damage,
+// so it would filter nothing while reading as though it filtered something.
+// If sampling ever does cost too much, the cause will be total concurrency and
+// the fix is to bound it, not to sort runs by their owner's balance.

--- a/packages/web/app/api/cron/agent-lifecycle/_lib/credit-guard.test.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/_lib/credit-guard.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for the mid-turn credit guard's stop decision.
+ *
+ * The metering half is already covered by ./meter-turn.test.ts; what is
+ * asserted here is the arithmetic that decides whether a live agent gets
+ * killed. Both directions matter and they are not symmetric: failing to stop
+ * costs money, but stopping a solvent run destroys a user's work mid-sentence,
+ * so the cases that must NOT trip are as important as the ones that must.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+/** Debit rows the guard will read back for the turn under test. */
+let debits: { amountMicroUsd: bigint }[] = []
+/** Balance getCreditBalance reports after metering. */
+let balance = 0n
+/** When set, the ledger read fails instead of returning `debits`. */
+let ledgerError: Error | undefined
+
+const meterAssistantTurn = vi.fn(async () => 1)
+
+vi.mock("@/lib/server/token-metering", () => ({
+  meterAssistantTurn: () => meterAssistantTurn(),
+}))
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    message: { findFirst: vi.fn(async () => ({ id: "msg_1", metadata: null })) },
+    creditTransaction: {
+      findMany: vi.fn(async () => {
+        if (ledgerError) throw ledgerError
+        return debits
+      }),
+    },
+  },
+}))
+
+vi.mock("@/lib/db/credits", () => ({
+  getCreditBalance: vi.fn(async () => balance),
+}))
+
+import { creditBudgetExhausted } from "./credit-guard"
+
+const daytona = { get: vi.fn(async () => ({})) } as never
+const usd = (n: number) => BigInt(Math.round(n * 1_000_000))
+
+/** A run that has been going ten minutes, on a user with a small balance. */
+function run(overrides: Partial<Parameters<typeof creditBudgetExhausted>[0]> = {}) {
+  return creditBudgetExhausted({
+    userId: "user_1",
+    chatId: "chat_1",
+    agent: "claude-code",
+    sandboxId: "sandbox_1",
+    agentSessionId: "ses_abc",
+    daytona,
+    turnStartedAt: new Date(Date.now() - 10 * 60_000),
+    plan: "pro",
+    runningMinutes: 10,
+    ...overrides,
+  })
+}
+
+beforeEach(() => {
+  debits = []
+  balance = usd(5)
+  ledgerError = undefined
+  meterAssistantTurn.mockClear()
+})
+
+describe("creditBudgetExhausted", () => {
+  it("stops a run whose balance has already gone negative", async () => {
+    debits = [{ amountMicroUsd: usd(-1.4) }]
+    balance = usd(-0.89)
+    expect(await run()).toBe(true)
+  })
+
+  it("stops a run the next few minutes would take under", async () => {
+    // $1.00 over 10 minutes = $0.10/min; three minutes ahead is $0.30, and only
+    // $0.20 is left.
+    debits = [{ amountMicroUsd: usd(-1) }]
+    balance = usd(0.2)
+    expect(await run()).toBe(true)
+  })
+
+  it("lets a run continue while the balance still covers the lookahead", async () => {
+    // Same $0.10/min, but $2.00 left — far more than the $0.30 projected.
+    debits = [{ amountMicroUsd: usd(-1) }]
+    balance = usd(2)
+    expect(await run()).toBe(false)
+  })
+
+  it("leaves a run alone when nothing has been charged to credits", async () => {
+    // No debit rows is how an own-key, free-model or unsubsidised-provider run
+    // presents: chargeTurnToCredits writes none for them. Such a run must not
+    // be stopped even at a zero balance, because it is not spending it.
+    debits = []
+    balance = 0n
+    expect(await run()).toBe(false)
+  })
+
+  it("does not sample a turn inside the blind window", async () => {
+    // Below CREDIT_GUARD_MIN_RUN_MINUTES tokscale has nothing to report, so the
+    // sandbox round-trip is pure cost — the meter must not even be called.
+    expect(await run({ runningMinutes: 1 })).toBe(false)
+    expect(meterAssistantTurn).not.toHaveBeenCalled()
+  })
+
+  it("does not sample an unlimited-plan run", async () => {
+    balance = usd(-100)
+    expect(await run({ plan: "unlimited" })).toBe(false)
+    expect(meterAssistantTurn).not.toHaveBeenCalled()
+  })
+
+  it("lets the run continue when the ledger cannot be read", async () => {
+    // A guard that cannot read the ledger knows nothing, and killing a healthy
+    // agent on missing data is the worse of the two errors.
+    ledgerError = new Error("connection pool exhausted")
+    balance = usd(0.01)
+    expect(await run()).toBe(false)
+  })
+
+  it("still decides on the ledger when metering itself failed", async () => {
+    // meterTurnNow swallows its own failures, so a dead tokscale does not reach
+    // the guard — it just means this tick banked nothing new. The balance and
+    // debits already on record are still real, and a run that is nearly out on
+    // those numbers should stop rather than get a reprieve for an unrelated
+    // fault. Failing to meter under-counts spend, so this errs toward running on.
+    meterAssistantTurn.mockRejectedValueOnce(new Error("tokscale exploded"))
+    debits = [{ amountMicroUsd: usd(-1) }]
+    balance = usd(0.01)
+    expect(await run()).toBe(true)
+  })
+})

--- a/packages/web/app/api/cron/agent-lifecycle/_lib/credit-guard.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/_lib/credit-guard.ts
@@ -1,0 +1,105 @@
+import { Daytona } from "@daytonaio/sdk"
+
+import { prisma } from "@/lib/db/prisma"
+import { getCreditBalance } from "@/lib/db/credits"
+import { microToUsd } from "@/lib/server/credits"
+
+import { CREDIT_GUARD_LOOKAHEAD_MINUTES, CREDIT_GUARD_MIN_RUN_MINUTES } from "./constants"
+import { meterTurnNow } from "./meter-turn"
+
+// =============================================================================
+// Mid-turn credit guard
+// =============================================================================
+// checkSharedPoolUsage gates a turn on `credits > 0` at the moment it starts,
+// and a turn's cost is only knowable once it has run — so one turn has always
+// been able to spend whatever it liked. It is not theoretical: a $0.50 balance
+// bought $27.80 of list value in a single 25-minute run that the hard timeout,
+// not the budget, eventually stopped.
+//
+// This closes the gap from the other end. The lifecycle cron already visits
+// every running agent once a minute holding its sandbox, so it can ask tokscale
+// what the turn has spent SO FAR, bank that through the ordinary metering path,
+// and stop the run once the balance can no longer cover what the next few
+// minutes are likely to cost.
+//
+// It bounds the overshoot rather than removing it: nothing is visible during a
+// turn's first ~2 minutes, and tokscale's figure lags behind the spend by up to
+// another ~2 (see the constants). Worst case goes from a full 25-minute run to
+// roughly three minutes of it.
+
+/**
+ * Reason recorded against a run the guard stops. Both call sites render it as
+ * "Agent stopped: …", and the send gate explains what to do about it the next
+ * time the user tries — see formatUsageLimitMessage.
+ */
+export const CREDIT_GUARD_STOP_REASON = "Ran out of credits mid-run"
+
+/**
+ * Meter a running turn and decide whether it has to be stopped.
+ *
+ * Returns true when the caller should tear the run down. Never throws: metering
+ * is best-effort, and a guard that failed to read anything must let the run
+ * continue rather than kill a healthy agent on missing data.
+ */
+export async function creditBudgetExhausted(params: {
+  userId: string
+  chatId: string
+  agent: string
+  sandboxId: string | null
+  /** Agent CLI session id from the snapshot that just observed this turn. */
+  agentSessionId: string | null | undefined
+  /** `Chat.sessionId`, used when the snapshot could not supply one. */
+  fallbackSessionId?: string | null
+  daytona: Daytona
+  /** When the current turn began — the window spend is measured over. */
+  turnStartedAt: Date
+  /** The owner's plan; `unlimited` never touches credits. */
+  plan: string
+  /** How long the turn has been running, for the blind-window gate. */
+  runningMinutes: number
+}): Promise<boolean> {
+  const { userId, chatId, turnStartedAt } = params
+
+  // Cheap gates first — each one avoids a sandbox round-trip. Kept here rather
+  // than at the two call sites so the rule lives in one place.
+  if (params.plan === "unlimited") return false
+  if (params.runningMinutes < CREDIT_GUARD_MIN_RUN_MINUTES) return false
+
+  try {
+    // Bank what has been spent up to now. This is the same call the teardown
+    // paths make, so the delta it writes is charged to credits exactly once and
+    // the final post-turn metering only ever bills the remainder.
+    await meterTurnNow(params)
+
+    // Only debits prove this turn is actually drawing the balance:
+    // chargeTurnToCredits writes them for shared-pool, non-free, budget-pool
+    // rows and nothing else. So a run on the user's own key, on a free model,
+    // or on a provider with no shared pool produces none — and is left alone
+    // here without this having to re-derive any of that. It is also the spend
+    // figure in the unit the balance is kept in, so no discount divisor is
+    // applied a second time.
+    const debits = await prisma.creditTransaction.findMany({
+      where: { userId, chatId, type: "debit", createdAt: { gte: turnStartedAt } },
+      select: { amountMicroUsd: true },
+    })
+    if (debits.length === 0) return false
+
+    const balance = await getCreditBalance(userId)
+    if (balance <= 0n) return true
+
+    // Rate over the whole turn, deliberately not the last two samples. Because
+    // tokscale advances in steps, consecutive samples routinely differ by
+    // nothing at all right in the middle of the heaviest spending — an
+    // instantaneous rate reads $0/min there and would wave the run through. An
+    // average over the turn cannot go blind that way. The floor keeps a turn
+    // metered unusually early from projecting an absurd rate.
+    const spent = debits.reduce((sum, d) => sum + microToUsd(-d.amountMicroUsd), 0)
+    const elapsedMinutes = Math.max((Date.now() - turnStartedAt.getTime()) / 60_000, 1)
+    const projected = (spent / elapsedMinutes) * CREDIT_GUARD_LOOKAHEAD_MINUTES
+
+    return microToUsd(balance) < projected
+  } catch (err) {
+    console.error(`[agent-lifecycle] Credit guard failed for chat ${chatId}:`, err)
+    return false
+  }
+}

--- a/packages/web/app/api/cron/agent-lifecycle/_lib/interactive.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/_lib/interactive.ts
@@ -6,7 +6,7 @@ import { PATHS } from "@/lib/constants"
 import { finalizeTurn, type AgentSnapshot } from "@/lib/agent-session"
 import { meterAssistantTurn } from "@/lib/server/token-metering"
 import { stripNullBytes, stripNullBytesDeep } from "@/lib/db/pg-sanitize"
-import { meterDyingTurn } from "./meter-dying-turn"
+import { meterTurnNow } from "./meter-turn"
 
 import { autoPushChat } from "@/lib/git/auto-push"
 import type { ChatWithMessages } from "./types"
@@ -124,8 +124,8 @@ export async function markChatError(
   // backgroundSessionId. A failed turn is not a free turn: the model produced
   // tokens right up to the moment it errored or was stopped, and once the
   // session id is gone there is no cursor left to diff them against. See
-  // meter-dying-turn.
-  await meterDyingTurn({
+  // meter-turn.
+  await meterTurnNow({
     userId: chat.userId,
     chatId: chat.id,
     agent: chat.agent,

--- a/packages/web/app/api/cron/agent-lifecycle/_lib/meter-turn.test.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/_lib/meter-turn.test.ts
@@ -49,7 +49,7 @@ vi.mock("@/lib/db/prisma", () => ({
   },
 }))
 
-import { meterDyingTurn } from "./meter-dying-turn"
+import { meterTurnNow } from "./meter-turn"
 import { markChatError } from "./interactive"
 
 /** A sandbox handle; the metering call is mocked, so it is never used. */
@@ -78,9 +78,9 @@ beforeEach(() => {
   meterAssistantTurn.mockClear()
 })
 
-describe("meterDyingTurn", () => {
+describe("meterTurnNow", () => {
   it("meters the turn when the sandbox and session are still around", async () => {
-    const rows = await meterDyingTurn({
+    const rows = await meterTurnNow({
       ...dyingChat,
       chatId: "chat_1",
       agentSessionId: AGENT_SESSION_ID,
@@ -95,7 +95,7 @@ describe("meterDyingTurn", () => {
     // match, so passing backgroundSessionId matches nothing and silently bills
     // zero — no error, no row, no clue. Production has never held a usage row
     // whose sessionId was a backgroundSessionId.
-    await meterDyingTurn({
+    await meterTurnNow({
       ...dyingChat,
       chatId: "chat_1",
       agentSessionId: AGENT_SESSION_ID,
@@ -107,7 +107,7 @@ describe("meterDyingTurn", () => {
 
   it("falls back to the chat's resume pointer when the snapshot had no id", async () => {
     // A resumed turn continues Chat.sessionId, so the CLI reports under it.
-    await meterDyingTurn({
+    await meterTurnNow({
       ...dyingChat,
       chatId: "chat_1",
       agentSessionId: undefined,
@@ -118,7 +118,7 @@ describe("meterDyingTurn", () => {
   })
 
   it("prefers the snapshot's id over a stale resume pointer", async () => {
-    await meterDyingTurn({
+    await meterTurnNow({
       ...dyingChat,
       chatId: "chat_1",
       agentSessionId: AGENT_SESSION_ID,
@@ -133,7 +133,7 @@ describe("meterDyingTurn", () => {
     ["no session id at all", { agentSessionId: null, fallbackSessionId: null }],
     ["no daytona client", { daytona: undefined }],
   ])("does nothing and does not throw when there is %s", async (_label, over) => {
-    const rows = await meterDyingTurn({
+    const rows = await meterTurnNow({
       ...dyingChat,
       chatId: "chat_1",
       agentSessionId: AGENT_SESSION_ID,
@@ -147,7 +147,7 @@ describe("meterDyingTurn", () => {
   it("swallows a metering failure — a bad turn must not get worse", async () => {
     meterAssistantTurn.mockRejectedValueOnce(new Error("tokscale exploded"))
     await expect(
-      meterDyingTurn({
+      meterTurnNow({
         ...dyingChat,
         chatId: "chat_1",
         agentSessionId: AGENT_SESSION_ID,

--- a/packages/web/app/api/cron/agent-lifecycle/_lib/meter-turn.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/_lib/meter-turn.ts
@@ -4,7 +4,7 @@ import { prisma } from "@/lib/db/prisma"
 import { meterAssistantTurn } from "@/lib/server/token-metering"
 
 // =============================================================================
-// Metering a turn that is about to be torn down
+// Metering a turn where it stands
 // =============================================================================
 // The happy paths (finalizeInteractiveChat, finalizeScheduledRun) meter before
 // they release the chat, and so does the SSE stream route — which meters an
@@ -19,7 +19,14 @@ import { meterAssistantTurn } from "@/lib/server/token-metering"
 // rate-limited or timed-out turn had already spent were never billed and could
 // never be recovered afterwards.
 //
-// This is the missing counterpart. Call it before the teardown, never after.
+// This is the missing counterpart: on a teardown path, call it BEFORE the
+// teardown, never after.
+//
+// It is also safe on a turn that is still running, which is what ./credit-guard
+// uses it for. Nothing here assumes the turn has ended — meterAssistantTurn
+// diffs tokscale's cumulative against the session's own cursor under an
+// advisory lock, so metering the same session twice charges the second caller
+// only what was spent in between.
 //
 // The id it needs is the AGENT CLI's session id — what tokscale files usage
 // under, and what every other metering call site passes as `snapshot.sessionId`.
@@ -34,11 +41,11 @@ import { meterAssistantTurn } from "@/lib/server/token-metering"
 // logged and swallowed.
 
 /**
- * Meter whatever a dying turn already spent, while the sandbox and session id
+ * Meter whatever this turn has spent so far, while the sandbox and session id
  * are still around to be asked. Returns the number of usage rows written (0
  * when there was nothing to meter, or when anything at all went wrong).
  */
-export async function meterDyingTurn(params: {
+export async function meterTurnNow(params: {
   userId: string
   chatId: string
   agent: string
@@ -86,7 +93,7 @@ export async function meterDyingTurn(params: {
     })
   } catch (err) {
     console.error(
-      `[agent-lifecycle] Failed to meter the dying turn for chat ${chatId}:`,
+      `[agent-lifecycle] Failed to meter the turn for chat ${chatId}:`,
       err
     )
     return 0

--- a/packages/web/app/api/cron/agent-lifecycle/_lib/monitor.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/_lib/monitor.ts
@@ -15,6 +15,11 @@ import {
  * Snapshot a running background agent and dispatch to the appropriate handler
  * when it reaches a terminal state. Keeps the sandbox alive via refreshActivity.
  * Swallows errors (logged) so a single failing sandbox doesn't break the cron.
+ *
+ * Returns the snapshot it took, so a caller that wants to act on a run that is
+ * still going — the credit guard does — can reuse it instead of paying for a
+ * second read. Undefined when the session could not be read at all, and for a
+ * transient read failure, both of which mean "no usable state this tick".
  */
 export async function monitorAgent(
   sandboxId: string,
@@ -34,7 +39,7 @@ export async function monitorAgent(
       snapshot: AgentSnapshot
     ) => Promise<void>
   }
-) {
+): Promise<AgentSnapshot | undefined> {
   try {
     const sandbox = await daytona.get(sandboxId)
     await sandbox.refreshActivity() // Keep alive
@@ -48,7 +53,7 @@ export async function monitorAgent(
       // race) — this is not evidence the agent errored, just that we
       // couldn't read its state this tick. Don't cancel a possibly-healthy
       // agent or record a spurious failure; just check again next cycle.
-      return
+      return undefined
     }
 
     if (snapshot.status === "completed") {
@@ -68,8 +73,10 @@ export async function monitorAgent(
       )
     }
     // else still running, check again next cycle
+    return snapshot
   } catch (err) {
     console.error(`[agent-lifecycle] Monitor error:`, err)
+    return undefined
   }
 }
 

--- a/packages/web/app/api/cron/agent-lifecycle/_lib/scheduled.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/_lib/scheduled.ts
@@ -13,7 +13,7 @@ import { checkSharedPoolUsage, UsageLimitError } from "@/lib/db/usage-limit"
 import { getClaudeCredentials } from "@/lib/claude-credentials"
 import { applyCodexSubscription } from "@/lib/server/codex-credentials"
 import { meterAssistantTurn } from "@/lib/server/token-metering"
-import { meterDyingTurn } from "./meter-dying-turn"
+import { meterTurnNow } from "./meter-turn"
 import { buildUsageMeta } from "@/lib/server/shared-pool"
 import { PATHS } from "@/lib/constants"
 import { NEW_REPOSITORY } from "@/lib/types"
@@ -599,16 +599,16 @@ export async function failScheduledRun(
    */
   { countFailure = true }: { countFailure?: boolean } = {},
   /** Agent CLI session id from the snapshot that saw the failure — see
-   * _lib/meter-dying-turn for why backgroundSessionId will not do. */
+   * _lib/meter-turn for why backgroundSessionId will not do. */
   agentSessionId?: string
 ) {
   // Bill what the run already spent, before the chat update below clears
   // backgroundSessionId and — worse — before the sandbox is deleted at the end
   // of this function. Once that sandbox is gone there is no tokscale left to
   // ask, so a failed run's tokens are unrecoverable rather than merely late.
-  // See _lib/meter-dying-turn.
+  // See _lib/meter-turn.
   if (run.chatId) {
-    await meterDyingTurn({
+    await meterTurnNow({
       userId: run.job.userId,
       chatId: run.chatId,
       agent: run.job.agent,

--- a/packages/web/app/api/cron/agent-lifecycle/route.ts
+++ b/packages/web/app/api/cron/agent-lifecycle/route.ts
@@ -6,6 +6,7 @@ import { logLlmProviderError } from "@/lib/db/activity-log"
 import { UsageLimitError } from "@/lib/db/usage-limit"
 
 import { INTERACTIVE_HARD_TIMEOUT, SCHEDULED_HARD_TIMEOUT } from "./_lib/constants"
+import { creditBudgetExhausted, CREDIT_GUARD_STOP_REASON } from "./_lib/credit-guard"
 import { monitorAgent, stopAgent } from "./_lib/monitor"
 import { startJobExecution, finalizeScheduledRun, failScheduledRun } from "./_lib/scheduled"
 import { finalizeInteractiveChat, markChatError } from "./_lib/interactive"
@@ -48,6 +49,7 @@ export async function GET(req: Request) {
     timedOutInteractive: 0,
     timedOutScheduled: 0,
     skippedOverLimit: 0,
+    stoppedOutOfCredits: 0,
     errors: [] as string[],
   }
 
@@ -136,6 +138,8 @@ export async function GET(req: Request) {
           orderBy: { timestamp: "desc" },
           take: 1,
         },
+        // For the mid-turn credit guard: `unlimited` plans never draw credits.
+        user: { select: { plan: true } },
       },
     })
 
@@ -168,24 +172,55 @@ export async function GET(req: Request) {
         }
 
         // Monitor and check completion
-        await monitorAgent(chat.sandboxId!, chat.backgroundSessionId!, daytona, {
-          onComplete: async (snapshot) => {
-            await finalizeInteractiveChat(chat, snapshot, daytona)
-            results.completedInteractive++
-          },
-          onError: async (error, errorKind, snapshot) => {
-            logLlmProviderError({
-              userId: chat.userId,
-              agent: chat.agent,
-              model: chat.model,
-              chatId: chat.id,
-              source: "cron-interactive",
-              error,
-              errorKind,
-            })
-            await markChatError(chat, error, daytona, snapshot.sessionId)
-          },
-        })
+        const snapshot = await monitorAgent(
+          chat.sandboxId!,
+          chat.backgroundSessionId!,
+          daytona,
+          {
+            onComplete: async (snapshot) => {
+              await finalizeInteractiveChat(chat, snapshot, daytona)
+              results.completedInteractive++
+            },
+            onError: async (error, errorKind, snapshot) => {
+              logLlmProviderError({
+                userId: chat.userId,
+                agent: chat.agent,
+                model: chat.model,
+                chatId: chat.id,
+                source: "cron-interactive",
+                error,
+                errorKind,
+              })
+              await markChatError(chat, error, daytona, snapshot.sessionId)
+            },
+          }
+        )
+
+        // Still running: bill what it has spent so far and stop it if the
+        // balance can no longer cover the next few minutes. Reuses the snapshot
+        // above for the agent session id — without that id there is nothing to
+        // meter against.
+        if (
+          snapshot?.status === "running" &&
+          (await creditBudgetExhausted({
+            userId: chat.userId,
+            chatId: chat.id,
+            agent: chat.agent,
+            sandboxId: chat.sandboxId,
+            agentSessionId: snapshot.sessionId,
+            fallbackSessionId: chat.sessionId,
+            daytona,
+            turnStartedAt: runStartedAt,
+            plan: chat.user.plan,
+            runningMinutes: totalMinutes,
+          }))
+        ) {
+          await stopAgent(chat.sandboxId!, chat.backgroundSessionId!, daytona)
+          // markChatError meters once more on the way out, which catches
+          // whatever the run spent between the guard's reading and the stop.
+          await markChatError(chat, CREDIT_GUARD_STOP_REASON, daytona, snapshot.sessionId)
+          results.stoppedOutOfCredits++
+        }
       } catch (err) {
         results.errors.push(`Failed to monitor chat ${chat.id}: ${err}`)
       }
@@ -196,7 +231,9 @@ export async function GET(req: Request) {
     // =========================================
     const runningJobs = await prisma.scheduledJobRun.findMany({
       where: { status: "running" },
-      include: { job: true },
+      include: {
+        job: { include: { user: { select: { plan: true } } } },
+      },
     })
 
     for (const run of runningJobs) {
@@ -227,24 +264,58 @@ export async function GET(req: Request) {
         }
 
         if (run.sandboxId && run.backgroundSessionId) {
-          await monitorAgent(run.sandboxId, run.backgroundSessionId, daytona, {
-            onComplete: async (snapshot) => {
-              await finalizeScheduledRun(run, snapshot, daytona)
-              results.completedScheduled++
-            },
-            onError: async (error, errorKind, snapshot) => {
-              logLlmProviderError({
-                userId: run.job.userId,
-                agent: run.job.agent,
-                model: run.job.model,
-                jobRunId: run.id,
-                source: "cron-scheduled",
-                error,
-                errorKind,
-              })
-              await failScheduledRun(run, error, daytona, {}, snapshot.sessionId)
-            },
-          })
+          const snapshot = await monitorAgent(
+            run.sandboxId,
+            run.backgroundSessionId,
+            daytona,
+            {
+              onComplete: async (snapshot) => {
+                await finalizeScheduledRun(run, snapshot, daytona)
+                results.completedScheduled++
+              },
+              onError: async (error, errorKind, snapshot) => {
+                logLlmProviderError({
+                  userId: run.job.userId,
+                  agent: run.job.agent,
+                  model: run.job.model,
+                  jobRunId: run.id,
+                  source: "cron-scheduled",
+                  error,
+                  errorKind,
+                })
+                await failScheduledRun(run, error, daytona, {}, snapshot.sessionId)
+              },
+            }
+          )
+
+          if (
+            snapshot?.status === "running" &&
+            run.chatId &&
+            (await creditBudgetExhausted({
+              userId: run.job.userId,
+              chatId: run.chatId,
+              agent: run.job.agent,
+              sandboxId: run.sandboxId,
+              agentSessionId: snapshot.sessionId,
+              daytona,
+              turnStartedAt: run.startedAt,
+              plan: run.job.user.plan,
+              runningMinutes,
+            }))
+          ) {
+            await stopAgent(run.sandboxId, run.backgroundSessionId, daytona)
+            // countFailure: false — a spent balance says nothing about the job
+            // itself, so it must not count toward the 3-strike auto-disable.
+            // Same treatment the pre-flight UsageLimitError gets above.
+            await failScheduledRun(
+              run,
+              CREDIT_GUARD_STOP_REASON,
+              daytona,
+              { countFailure: false },
+              snapshot.sessionId
+            )
+            results.stoppedOutOfCredits++
+          }
         }
       } catch (err) {
         results.errors.push(`Failed to monitor run ${run.id}: ${err}`)


### PR DESCRIPTION
 ## Problem

  A turn's cost is only knowable once it has run,  so `checkSharedPoolUsage` gates on `credits >
  0` at turn start and nothing bounds what that  turn then spends.

  In production a **$0.50 balance bought $27.80
  of list value** in one 25-minute run — stopped
  by the hard timeout, not the budget, leaving
  the account $0.89 in deficit. 12 users
  currently sit on negative balances.

  ## Change

  The lifecycle cron already visits every running  agent once a minute holding its sandbox. It
  now asks tokscale what the turn has spent *so
  far*, banks it through the ordinary metering
  path, and stops the run when the balance can't
  cover the next few minutes.

  **Sampled** when: status is `running` · plan is  not `unlimited` · running ≥ 2 minutes.

  **Stopped** when the turn has produced credit
  debits since it started, **and** either the
  balance is `≤ 0` or `balance < (spentThisTurn /  minutesElapsed) × 3`.

  Gating on debits is what decides *which* runs
  are eligible: `chargeTurnToCredits` writes them  only for shared-pool, non-free,
  budget-provider rows, so own-key runs, free
  models and unsubsidised providers produce none
  and are never stopped — without this
  re-deriving any pool rules. Those rows are
  already denominated in credits, so the discount  divisor can't be applied twice.

  Any failure reading the ledger leaves the run
  alone.

  ## Measured first

  The whole idea rests on tokscale reporting
  mid-turn. It does, for Claude Code and OpenCode  alike, but two behaviours shape the design:

  - **~110s blind window** on Claude — nothing is  reported until the first round-trip closes.
  Hence the 2-minute wait.
  - **Advances in steps**, sitting flat up to ~2
  minutes then jumping by the whole accumulated
  amount. Hence projecting from the turn's
  average rate, not the last two samples — an
  instantaneous rate reads $0/min mid-plateau,
  exactly when spending is heaviest.

  ## Scope

  Bounds the overshoot, doesn't remove it: worst
  case falls from a full 25-minute run to roughly  **3 minutes** of one (~8×). Existing negative
  balances are unaffected.

  **Gemini is untested** — it can produce debits,  so it can be stopped, but only Claude and
  OpenCode were spiked. If tokscale doesn't
  report it mid-turn the guard simply never fires  there (fail-open).

  ## Out Of Credit
  
<img width="1113" height="464" alt="image" src="https://github.com/user-attachments/assets/9386ef40-289e-4561-9aba-cdf6eed85ab4" />


  
  ## Testing

  Typecheck clean; 25 tests pass. New
  `credit-guard.test.ts` covers both directions —  stopping on a spent balance and on projection,
  plus the cases that must **not** trip (no
  debits, blind window, unlimited plan, ledger
  read failure), since killing a solvent run
  destroys a user's work mid-sentence.
