### PR TITLE
Fix/branching bugs

### DIFF
--- a/packages/web/app/api/chats/[chatId]/messages/_lib/history.ts
+++ b/packages/web/app/api/chats/[chatId]/messages/_lib/history.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@/lib/db/prisma"
+import { getInheritedHistory } from "@/lib/db/branch-history"
 import type { ChatRecord, MessagePayload } from "./types"
 
 type AgentHistory = { role: "user" | "assistant"; content: string }[]
@@ -61,25 +62,15 @@ export async function buildAgentHistory(
 
   // When a chat is forked from a parent (via /branch, Option+Enter, etc.),
   // the first message should include the parent's conversation history so
-  // the agent has context about what was previously discussed.
+  // the agent has context about what was previously discussed — frozen at the
+  // branch point, so turns the parent took after the branch never leak in.
   if (!history && chat.parentChatId && !lastAssistant) {
-    const parentMessages = await prisma.message.findMany({
-      where: { chatId: chat.parentChatId },
-      orderBy: { timestamp: "asc" },
-      select: { role: true, content: true },
+    history = await getInheritedHistory({
+      parentChatId: chat.parentChatId,
+      createdAt: chat.createdAt,
     })
-    history = parentMessages
-      .filter(
-        (
-          m
-        ): m is typeof m & { role: "user" | "assistant" } =>
-          (m.role === "user" || m.role === "assistant") &&
-          !!m.content.trim()
-      )
-      .map((m) => ({ role: m.role, content: m.content }))
 
-    if (history.length === 0) history = undefined
-    else
+    if (history)
       console.log(
         `[chats/messages] Chat fork detected: injecting ${history.length} parent messages`
       )

--- a/packages/web/app/api/chats/[chatId]/route.ts
+++ b/packages/web/app/api/chats/[chatId]/route.ts
@@ -9,6 +9,7 @@ import {
   internalError,
 } from "@/lib/db/api-helpers"
 import { logActivityAsync } from "@/lib/db/activity-log"
+import { getInheritedMessages } from "@/lib/db/branch-history"
 
 // =============================================================================
 // Helpers
@@ -147,17 +148,17 @@ export async function GET(
 
     // When this chat was branched from a parent, the parent's conversation is
     // replayed to the agent for context but isn't stored on this chat. Surface
-    // it in the UI too by prepending the parent's user/assistant messages,
-    // flagged `inherited` so the client renders them read-only. Only on a full
-    // fetch (delta sync via afterMessageId is for this chat's own new messages).
+    // it in the UI too by prepending the parent's user/assistant messages *as
+    // they stood at the branch point* (see getInheritedMessages), flagged
+    // `inherited` so the client renders them read-only. Only on a full fetch
+    // (delta sync via afterMessageId is for this chat's own new messages).
     let inheritedMessages: MessageResponse[] = []
     if (chat.parentChatId && !afterMessageId) {
-      const parentMessages = await prisma.message.findMany({
-        where: { chatId: chat.parentChatId, role: { in: ["user", "assistant"] } },
-        orderBy: { timestamp: "asc" },
+      const parentMessages = await getInheritedMessages({
+        parentChatId: chat.parentChatId,
+        createdAt: chat.createdAt,
       })
       inheritedMessages = parentMessages
-        .filter((m) => m.content.trim().length > 0)
         .map((m) => ({
           id: `inherited-${m.id}`,
           role: m.role,

--- a/packages/web/components/sidebar/renderChatTree.tsx
+++ b/packages/web/components/sidebar/renderChatTree.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type React from "react"
-import type { Chat } from "@/lib/types"
+import { isRealRepo, type Chat } from "@/lib/types"
 import { ChatItem } from "./ChatItem"
 
 interface RenderChatTreeArgs {
@@ -17,7 +17,8 @@ interface RenderChatTreeArgs {
   onDeleteChat: (id: string) => void
   /** When provided, rows render a "Pin"/"Unpin" action. */
   onPin?: (id: string, pinned: boolean) => void
-  /** When provided, rows render a "Branch chat" action. */
+  /** When provided, rows render a "Branch chat" action — on chats with a repo
+   *  only, since branching clones one. */
   onBranch?: (id: string) => void
   /** When provided, rows render an "Archive" action (used by the active section). */
   onArchive?: (id: string) => void
@@ -66,7 +67,7 @@ export function renderChatTree(args: RenderChatTreeArgs): React.ReactNode[] {
         onSelect={() => args.onSelectChat(chat.id)}
         onDelete={() => args.onDeleteChat(chat.id)}
         onPin={args.onPin ? (pinned) => args.onPin!(chat.id, pinned) : undefined}
-        onBranch={args.onBranch ? () => args.onBranch!(chat.id) : undefined}
+        onBranch={args.onBranch && isRealRepo(chat.repo) ? () => args.onBranch!(chat.id) : undefined}
         onArchive={args.onArchive ? () => args.onArchive!(chat.id) : undefined}
         onUnarchive={args.onUnarchive ? () => args.onUnarchive!(chat.id) : undefined}
         onRename={(newName) => args.onRenameChat(chat.id, newName)}

--- a/packages/web/components/sidebar/renderMobileChatTree.tsx
+++ b/packages/web/components/sidebar/renderMobileChatTree.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type React from "react"
-import type { Chat } from "@/lib/types"
+import { isRealRepo, type Chat } from "@/lib/types"
 import { MobileChatItem } from "./MobileChatItem"
 
 interface RenderMobileChatTreeArgs {
@@ -16,7 +16,8 @@ interface RenderMobileChatTreeArgs {
   onDeleteChat: (id: string) => void
   /** When provided, rows render a "Pin"/"Unpin" action. */
   onPin?: (id: string, pinned: boolean) => void
-  /** When provided, rows render a "Branch chat" action. */
+  /** When provided, rows render a "Branch chat" action — on chats with a repo
+   *  only, since branching clones one. */
   onBranch?: (id: string) => void
   /** When provided, rows render an "Archive" action (used by the active section). */
   onArchive?: (id: string) => void
@@ -50,7 +51,7 @@ export function renderMobileChatTree(args: RenderMobileChatTreeArgs): React.Reac
         onSelect={() => args.onSelectChat(chat.id)}
         onDelete={() => args.onDeleteChat(chat.id)}
         onPin={args.onPin ? (pinned) => args.onPin!(chat.id, pinned) : undefined}
-        onBranch={args.onBranch ? () => args.onBranch!(chat.id) : undefined}
+        onBranch={args.onBranch && isRealRepo(chat.repo) ? () => args.onBranch!(chat.id) : undefined}
         onArchive={args.onArchive ? () => args.onArchive!(chat.id) : undefined}
         onUnarchive={args.onUnarchive ? () => args.onUnarchive!(chat.id) : undefined}
         onRequestRename={() => args.onRequestRename(chat.id, chat.displayName || "Untitled")}

--- a/packages/web/lib/db/branch-history.test.ts
+++ b/packages/web/lib/db/branch-history.test.ts
@@ -1,0 +1,130 @@
+/**
+ * A branch's inherited history is a snapshot, not a live view.
+ *
+ * The parent keeps being used after a branch is taken; those later turns belong
+ * to the parent alone. They must never show up in the branch's rendered history
+ * or in the context replayed to the branch's agent — which is what happened
+ * before the branch-point cutoff existed: the parent's new messages appeared in
+ * the child on the next full fetch (i.e. after a page refresh).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+interface FakeMessage {
+  id: string
+  chatId: string
+  role: string
+  content: string
+  timestamp: bigint
+  createdAt: Date
+}
+
+let rows: FakeMessage[] = []
+
+/** Minimal stand-in for the subset of `findMany` this module uses. */
+function findMany(args: {
+  where: { chatId: string; role: { in: string[] }; createdAt: { lte: Date } }
+  orderBy: { timestamp: "asc" }
+  select?: Record<string, boolean>
+}) {
+  const { where } = args
+  return Promise.resolve(
+    rows
+      .filter(
+        (m) =>
+          m.chatId === where.chatId &&
+          where.role.in.includes(m.role) &&
+          m.createdAt.getTime() <= where.createdAt.lte.getTime()
+      )
+      .sort((a, b) => Number(a.timestamp - b.timestamp))
+  )
+}
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: { message: { findMany: (args: never) => findMany(args) } },
+}))
+
+import { getInheritedMessages, getInheritedHistory } from "./branch-history"
+
+const BRANCHED_AT = new Date("2026-09-11T12:00:00Z")
+
+function message(overrides: Partial<FakeMessage> & { id: string }): FakeMessage {
+  const createdAt = overrides.createdAt ?? new Date(BRANCHED_AT.getTime() - 1000)
+  return {
+    chatId: "parent",
+    role: "user",
+    content: `content-${overrides.id}`,
+    timestamp: BigInt(createdAt.getTime()),
+    createdAt,
+    ...overrides,
+  }
+}
+
+const branchPoint = { parentChatId: "parent", createdAt: BRANCHED_AT }
+
+beforeEach(() => {
+  rows = []
+})
+
+describe("getInheritedMessages", () => {
+  it("returns the parent's conversation as it stood at the branch point", async () => {
+    rows = [
+      message({ id: "m1", createdAt: new Date(BRANCHED_AT.getTime() - 2000) }),
+      message({ id: "m2", role: "assistant", createdAt: new Date(BRANCHED_AT.getTime() - 1000) }),
+    ]
+
+    const inherited = await getInheritedMessages(branchPoint)
+
+    expect(inherited.map((m) => m.id)).toEqual(["m1", "m2"])
+  })
+
+  it("excludes parent turns that happened after the branch was taken", async () => {
+    rows = [
+      message({ id: "before" }),
+      message({ id: "after", createdAt: new Date(BRANCHED_AT.getTime() + 5000) }),
+      message({
+        id: "after-reply",
+        role: "assistant",
+        createdAt: new Date(BRANCHED_AT.getTime() + 6000),
+      }),
+    ]
+
+    const inherited = await getInheritedMessages(branchPoint)
+
+    expect(inherited.map((m) => m.id)).toEqual(["before"])
+  })
+
+  it("ignores other chats' messages and blank content", async () => {
+    rows = [
+      message({ id: "kept" }),
+      message({ id: "other-chat", chatId: "unrelated" }),
+      message({ id: "blank", content: "   " }),
+    ]
+
+    const inherited = await getInheritedMessages(branchPoint)
+
+    expect(inherited.map((m) => m.id)).toEqual(["kept"])
+  })
+})
+
+describe("getInheritedHistory", () => {
+  it("replays the branch-point conversation to the agent, and nothing later", async () => {
+    rows = [
+      message({ id: "m1", content: "first" }),
+      message({ id: "m2", role: "assistant", content: "reply" }),
+      message({ id: "m3", content: "later", createdAt: new Date(BRANCHED_AT.getTime() + 1000) }),
+    ]
+
+    const history = await getInheritedHistory(branchPoint)
+
+    expect(history).toEqual([
+      { role: "user", content: "first" },
+      { role: "assistant", content: "reply" },
+    ])
+  })
+
+  it("returns undefined when there is nothing to replay", async () => {
+    rows = [message({ id: "blank", content: "" })]
+
+    expect(await getInheritedHistory(branchPoint)).toBeUndefined()
+  })
+})

--- a/packages/web/lib/db/branch-history.ts
+++ b/packages/web/lib/db/branch-history.ts
@@ -1,0 +1,70 @@
+import { prisma } from "@/lib/db/prisma"
+
+// =============================================================================
+// Inherited (branch-point) history
+// =============================================================================
+//
+// A branched chat doesn't copy its parent's messages — it points at the parent
+// (`parentChatId`) and the parent's conversation is read back on demand: shown
+// above the branch's own messages (flagged `inherited`) and replayed to the
+// agent on the branch's first turn.
+//
+// That read MUST be frozen at the moment the branch was taken. The branch row
+// is created right when the user branches, so the branch's own `createdAt` is
+// the branch point: anything the parent said after it belongs to the parent
+// alone. Without the cutoff the inherited block is a *live view* of the parent —
+// keep talking in the parent and its later turns silently appear in the child's
+// history on the next full fetch (and get replayed to the child's agent).
+
+/** A message row as returned by Prisma, narrowed to non-null. */
+type MessageRow = NonNullable<Awaited<ReturnType<typeof prisma.message.findFirst>>>
+
+/** Identifies the branch point: the parent to read, cut off at the branch's creation. */
+export interface BranchPoint {
+  parentChatId: string
+  /** The branched chat's own `createdAt` — see the module comment. */
+  createdAt: Date
+}
+
+function branchPointWhere({ parentChatId, createdAt }: BranchPoint) {
+  return {
+    chatId: parentChatId,
+    role: { in: ["user", "assistant"] },
+    createdAt: { lte: createdAt },
+  }
+}
+
+/** Non-empty user/assistant rows are the only ones worth inheriting. */
+function hasContent(m: { content: string }): boolean {
+  return m.content.trim().length > 0
+}
+
+/**
+ * Full parent message rows as they stood at the branch point, oldest first.
+ * For rendering the inherited block (private chat view and public share view).
+ */
+export async function getInheritedMessages(point: BranchPoint): Promise<MessageRow[]> {
+  const messages = await prisma.message.findMany({
+    where: branchPointWhere(point),
+    orderBy: { timestamp: "asc" },
+  })
+  return messages.filter(hasContent)
+}
+
+/**
+ * The same conversation reduced to what an agent CLI needs for context replay.
+ * Returns undefined when there's nothing to replay.
+ */
+export async function getInheritedHistory(
+  point: BranchPoint
+): Promise<{ role: "user" | "assistant"; content: string }[] | undefined> {
+  const messages = await prisma.message.findMany({
+    where: branchPointWhere(point),
+    orderBy: { timestamp: "asc" },
+    select: { role: true, content: true },
+  })
+  const history = messages
+    .filter(hasContent)
+    .map((m) => ({ role: m.role as "user" | "assistant", content: m.content }))
+  return history.length > 0 ? history : undefined
+}

--- a/packages/web/lib/hooks/useBranching.ts
+++ b/packages/web/lib/hooks/useBranching.ts
@@ -2,8 +2,42 @@
 
 import { useCallback } from "react"
 import { useSession } from "next-auth/react"
+import { useQueryClient } from "@tanstack/react-query"
 import { NEW_REPOSITORY, isRealRepo, type Chat, type ChatStatus } from "@/lib/types"
 import { savePendingMessage } from "@/lib/pending-message"
+import { fetchBranches } from "@/lib/github"
+import { queryKeys } from "@/lib/query/keys"
+import { useToastStore } from "@/lib/stores/toast-store"
+
+/**
+ * A chat with a live sandbox branches off its *working* branch, and the new
+ * chat's sandbox clones that branch from GitHub. Until a commit has been pushed
+ * the branch only exists inside the old sandbox, so there is nothing to clone
+ * and the branch chat would fail on creation.
+ *
+ * Checked on demand rather than tracked, since it's one call on a rare click.
+ * A check that can't complete (offline, GitHub hiccup) doesn't block branching:
+ * this is an early warning, not a gate.
+ */
+async function branchIsOnGitHub(
+  queryClient: ReturnType<typeof useQueryClient>,
+  repo: string,
+  branch: string
+): Promise<boolean> {
+  const [owner, name] = repo.split("/")
+  if (!owner || !name) return true
+  try {
+    const branches = await queryClient.fetchQuery({
+      queryKey: queryKeys.github.branches(owner, name),
+      queryFn: () => fetchBranches(owner, name),
+      // The agent may have pushed seconds ago; a cached list would be wrong.
+      staleTime: 0,
+    })
+    return branches.some((b) => b.name === branch)
+  } catch {
+    return true
+  }
+}
 
 interface UseBranchingOptions {
   currentChat: Chat | null
@@ -83,6 +117,7 @@ export function useBranching({
   openSignInModal,
 }: UseBranchingOptions): UseBranchingResult {
   const { data: session } = useSession()
+  const queryClient = useQueryClient()
 
   // Use the working branch if the sandbox is up; otherwise the base branch the
   // chat was configured with (before any messages were sent).
@@ -116,6 +151,16 @@ export function useBranching({
         openSignInModal(true)
         return false
       }
+      // Nothing has been pushed to the working branch yet — say so instead of
+      // creating a branch chat whose sandbox can't clone it.
+      if (source.branch && !(await branchIsOnGitHub(queryClient, source.repo, source.branch))) {
+        useToastStore.getState().addToast({
+          title: "Nothing committed yet",
+          body: `${source.branch} isn't on GitHub yet, so there's nothing to branch from. Branch again once the agent has committed and pushed.`,
+        })
+        return false
+      }
+
       // When no message is provided, navigate to the new chat
       const navigateToChat = !options?.message
       // Use provided agent/model or inherit from the source chat
@@ -138,7 +183,7 @@ export function useBranching({
       }
       return true
     },
-    [currentChat, startNewChat, sendMessage, session, openSignInModal]
+    [currentChat, startNewChat, sendMessage, session, openSignInModal, queryClient]
   )
 
   const handleBranchChat = useCallback(() => {

--- a/packages/web/lib/server/shared-chat.ts
+++ b/packages/web/lib/server/shared-chat.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@/lib/db/prisma"
+import { getInheritedMessages } from "@/lib/db/branch-history"
 import { NEW_REPOSITORY } from "@/lib/types"
 
 // =============================================================================
@@ -93,7 +94,7 @@ function toSharedMessage(m: NonNullable<MessageRow>, inherited = false): SharedM
 export async function getSharedChat(shareId: string): Promise<SharedChat | null> {
   const chat = await prisma.chat.findUnique({
     where: { shareId },
-    select: { id: true, displayName: true, repo: true, parentChatId: true },
+    select: { id: true, displayName: true, repo: true, parentChatId: true, createdAt: true },
   })
   if (!chat) return null
 
@@ -103,13 +104,11 @@ export async function getSharedChat(shareId: string): Promise<SharedChat | null>
   // it muted with a divider. Same sanitization applies to both.
   let inheritedMessages: SharedMessage[] = []
   if (chat.parentChatId) {
-    const parentMessages = await prisma.message.findMany({
-      where: { chatId: chat.parentChatId, role: { in: ["user", "assistant"] } },
-      orderBy: { timestamp: "asc" },
+    const parentMessages = await getInheritedMessages({
+      parentChatId: chat.parentChatId,
+      createdAt: chat.createdAt,
     })
-    inheritedMessages = parentMessages
-      .filter((m) => m.content.trim().length > 0)
-      .map((m) => toSharedMessage(m, true))
+    inheritedMessages = parentMessages.map((m) => toSharedMessage(m, true))
   }
 
   const messages = await prisma.message.findMany({


### PR DESCRIPTION
# Fix two branching bugs

## 1. A branch's inherited history was live, not a snapshot

A branched chat doesn't copy its parent's messages — it points at the parent and the conversation is read back on demand. That read had no cutoff, so taking a turn in the parent *after* branching made those messages appear in the child on the next full fetch (i.e. after a refresh), and replayed them to the child's agent.

Now cut off at the branch row's own `createdAt`, which is written the moment you branch. One helper (`lib/db/branch-history.ts`) used by the chat view, the public share view and the agent history replay, so the three can't drift. Existing branched chats are corrected with no backfill.

## 2. Branching was offered where it can't work

Branching clones the source chat's branch, so it needs a repo and a branch that's actually on GitHub.

- **No repository:** the sidebar row menu offered "Branch chat" on every chat, and clicking it hit a guard that silently did nothing. Rows now gate on the chat having a repo, matching the palette and composer. The action returns on its own if a repo is later created for the chat.
- **Nothing pushed yet:** the clone failed on a ref that only exists inside the sandbox. Branching now checks GitHub for the branch first and raises a "Nothing committed yet" toast instead of creating a chat that errors. A check that can't complete (offline, GitHub hiccup) doesn't block branching — it's a warning, not a gate.

## Notes

- No schema change and no migration — nothing to apply on deploy.
- 8 files, ~275 added / ~37 removed; most of the added lines are the history helper and its tests.
- `npm run typecheck` clean, 445 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146gxMWW9J1rvbdwpXxRNd4
