### PR TITLE
Clear the Codex subscription follow-ups

### DIFF
--- a/packages/web/app/api/cron/refresh-codex-creds/route.ts
+++ b/packages/web/app/api/cron/refresh-codex-creds/route.ts
@@ -60,8 +60,17 @@ export async function GET(req: Request): Promise<Response> {
   // Only users who actually have the credential. Uses the `->` accessor
   // rather than the `?` containment operator: `?` is ambiguous with a driver
   // parameter placeholder inside a Prisma tagged template.
+  // `ORDER BY id` is not cosmetic. The sweep is sequential under a 300s
+  // budget, so if it ever has more users than it can finish, an unordered
+  // scan can hand back the same arbitrary order every hour and strand
+  // whichever users land past the cutoff. A stable order makes that failure
+  // deterministic and therefore visible (the same tail is always last), and
+  // it is the ordering a cursor would page over when this needs batching.
+  // Revisit when `scanned` reaches the hundreds.
   const users = await prisma.$queryRaw<{ id: string }[]>`
-    SELECT id FROM "User" WHERE credentials -> 'CODEX_CREDENTIALS' IS NOT NULL
+    SELECT id FROM "User"
+    WHERE credentials -> 'CODEX_CREDENTIALS' IS NOT NULL
+    ORDER BY id
   `
 
   const tally: Tally = {

--- a/packages/web/lib/server/codex-credentials.test.ts
+++ b/packages/web/lib/server/codex-credentials.test.ts
@@ -175,6 +175,10 @@ describe("applyCodexSubscription", () => {
       "sonnet"
     )
     expect(leaks(out)).toBe(false)
+    // Not just "no secret leaked": a rendered auth.json carries only the
+    // placeholder, so the leak check alone passes even with the agent guard
+    // deleted. Assert the key is absent so this test can actually fail.
+    expect(out.CODEX_CREDENTIALS).toBeUndefined()
   })
 
   it("strips the stored blob for a custom codex endpoint", async () => {
@@ -186,6 +190,9 @@ describe("applyCodexSubscription", () => {
       "endpoint:c1"
     )
     expect(leaks(out)).toBe(false)
+    // Same reasoning as the non-codex case: without this the endpoint guard
+    // could be removed and every assertion here would still pass.
+    expect(out.CODEX_CREDENTIALS).toBeUndefined()
   })
 
   it("re-adds a rendered auth.json carrying the placeholder, never the real token", async () => {

--- a/packages/web/lib/server/codex-login.ts
+++ b/packages/web/lib/server/codex-login.ts
@@ -344,14 +344,14 @@ export async function pollCodexDeviceLogin(
   userId: string,
   sessionId: string
 ): Promise<{ status: "pending" | "connected" | "failed"; reason?: string }> {
-  const stored = await readLoginSessionRaw(userId)
+  const loginSession = await readLoginSessionRaw(userId)
   // Compare the client's sessionId against the stored one so a stale client
   // (polling a login that a fresh one has since superseded) can't read
   // another session's result.
-  if (!stored || stored.session.sessionId !== sessionId) {
+  if (!loginSession || loginSession.session.sessionId !== sessionId) {
     return { status: "failed", reason: "unknown_session" }
   }
-  const session = stored.session
+  const session = loginSession.session
 
   const daytona = daytonaClient()
 
@@ -383,7 +383,7 @@ export async function pollCodexDeviceLogin(
   // Claim before spending. A caller that loses the claim has NOT rotated
   // anything and must not tear down the winner's sandbox, so it simply reports
   // pending; the winner's own result reaches the client on its next poll.
-  if (!(await claimLoginSession(userId, stored.raw))) {
+  if (!(await claimLoginSession(userId, loginSession.raw))) {
     return { status: "pending" }
   }
 
@@ -399,9 +399,9 @@ export async function pollCodexDeviceLogin(
     // than at the user's first run.
     const res = await refreshCodexTokens(tokens.refresh_token)
     const cred = credentialFromTokenResponse(res, tokens.account_id, Date.now())
-    const stored = await storeCredentialWithRetry(userId, cred)
+    const persisted = await storeCredentialWithRetry(userId, cred)
     await cleanup()
-    if (!stored) return { status: "failed", reason: "credential_lost" }
+    if (!persisted) return { status: "failed", reason: "credential_lost" }
     return { status: "connected" }
   } catch (err) {
     await cleanup()

--- a/packages/web/lib/server/codex-oauth.ts
+++ b/packages/web/lib/server/codex-oauth.ts
@@ -26,6 +26,20 @@ export class CodexReconnectRequiredError extends Error {
   }
 }
 
+/**
+ * Clamp a server-supplied OAuth `error` code before it reaches a thrown
+ * message or a log line.
+ *
+ * RFC 6749 keeps `error` to a short ASCII token, but nothing here forces the
+ * endpoint to honour that, and this module's whole job is to make sure no
+ * remote-controlled text can carry secrets out through an error string.
+ * Anything that isn't a plausible code is dropped rather than echoed.
+ */
+function sanitizeErrorCode(raw: unknown): string | null {
+  if (typeof raw !== "string") return null
+  return /^[A-Za-z0-9_.-]{1,64}$/.test(raw) ? raw : null
+}
+
 /** OAuth errors that mean the refresh token is permanently unusable. */
 const TERMINAL_ERRORS = new Set([
   "invalid_grant",
@@ -63,7 +77,7 @@ export async function refreshCodexTokens(refreshToken: string): Promise<CodexTok
   if (!res.ok) {
     let code = "unknown_error"
     try {
-      code = (JSON.parse(text) as { error?: string }).error ?? code
+      code = sanitizeErrorCode((JSON.parse(text) as { error?: string }).error) ?? code
     } catch {
       // Non-JSON error body; the status code is all we have.
     }
@@ -81,7 +95,23 @@ export async function refreshCodexTokens(refreshToken: string): Promise<CodexTok
     // the offending input in that message.
     throw new Error("Codex token refresh returned a malformed response body")
   }
-  if (!parsed.access_token || !parsed.refresh_token || !parsed.id_token || !parsed.expires_in) {
+  // Guard the SHAPE, not just truthiness. `parsed` is whatever the endpoint
+  // sent: JSON `null` would make the property reads below throw a raw
+  // TypeError instead of this message, and a stringified `expires_in`
+  // ("864000") would pass a truthiness check and then silently become string
+  // concatenation in `nowSec + expires_in` downstream, producing a nonsense
+  // expiry decades away.
+  if (
+    !parsed ||
+    typeof parsed !== "object" ||
+    typeof parsed.access_token !== "string" ||
+    typeof parsed.refresh_token !== "string" ||
+    typeof parsed.id_token !== "string" ||
+    typeof parsed.expires_in !== "number" ||
+    !Number.isFinite(parsed.expires_in) ||
+    (parsed.earliest_refresh_at !== undefined &&
+      typeof parsed.earliest_refresh_at !== "number")
+  ) {
     throw new Error("Codex token refresh returned an incomplete response")
   }
   return {

--- a/packages/web/prisma/schema.prisma
+++ b/packages/web/prisma/schema.prisma
@@ -282,13 +282,25 @@ model Message {
 }
 
 // =============================================================================
-// CcAuthInfo - kv blobs managed by ccauth + /api/cron/refresh-claude-creds
+// CcAuthInfo - generic server-owned key/value blobs, keyed by a string id
 // =============================================================================
-// Two well-known rows:
-//   id="claude-cookies":     { value: "<claude.ai cookies JSON>" }
-//   id="claude-credentials": { value: '{"claudeAiOauth":{...}}' }
-// Stored as text (not JSONB) — we hand the raw string to the agent's
-// CLAUDE_CODE_CREDENTIALS env var without re-serializing.
+// The name is historical: it started as ccauth's storage and still holds those
+// rows, but it is now the generic kv table for server-owned auth state and is
+// no longer Claude-specific. Read it as "auth info", not "Claude Code auth
+// info", before adding a row.
+//
+// Well-known ids:
+//   claude-cookies       { value: "<claude.ai cookies JSON>" }
+//   claude-credentials   { value: '{"claudeAiOauth":{...}}' }
+//     ^ managed by ccauth + /api/cron/refresh-claude-creds
+//   codex-login:<userId> { value: '{"sandboxId":...,"sessionId":...}' }
+//     ^ one in-flight Codex device login, deleted as soon as it resolves.
+//       Per-user and short-lived (~15 min), which is why it lives here rather
+//       than in its own table: a dedicated model would mean a migration for
+//       state that never outlives a single sign-in.
+//
+// Stored as text (not JSONB) — some values are handed to an agent's env var
+// verbatim (CLAUDE_CODE_CREDENTIALS) and must not be re-serialized.
 
 model CcAuthInfo {
   id        String   @id


### PR DESCRIPTION
the small stuff we parked during review on #422. nothing user facing, no behavior change anyone will notice.

- **codex-oauth**: the `error` code the server sends us was being interpolated into a thrown message unbounded, so a misbehaving auth server could stuff whatever it wanted in there. clamped it. also checks the refresh response's shape instead of truthiness now: a json `null` body threw a raw TypeError past the parse guard, and a stringified `expires_in` would have sailed through and then turned `nowSec + expires_in` into string concatenation, giving an expiry somewhere in the year 29000.

- **tests that couldn't fail**: the non-codex and custom-endpoint cases only asserted "no secret leaked", which is also true of a placeholder auth.json. so both guards could be deleted and everything stayed green. i checked by actually deleting them. now each removal fails exactly one test.

- **sweep ordering**: `ORDER BY id` on the cron query. it's sequential under a 300s budget, so if it ever has more users than it can get through, an unordered scan can strand a different arbitrary tail every hour. ordered means the same tail every time, which is at least visible.

- **naming**: two different values were both called `stored` in the same function in codex-login.

- **schema comment**: `CcAuthInfo` is documented as claude-specific but now also holds the in-flight codex device logins. said so, including why that state lives there (per-user, ~15 min, a dedicated model would mean a migration for something that never outlives one sign-in).

439 tests, typecheck clean.
