### PR TITLE
Rebuild the sandbox snapshot weekly

### DIFF
--- a/.github/workflows/rebuild-snapshot.yml
+++ b/.github/workflows/rebuild-snapshot.yml
@@ -1,0 +1,81 @@
+name: Rebuild sandbox snapshot
+
+# Rebuilds the Daytona sandbox snapshot every week so the agent CLIs baked into
+# it track upstream.
+#
+# Why this exists: packages/sandbox-image installs the agent CLIs UNPINNED
+# (`npm install -g @openai/codex`, etc.), so each CLI is frozen at whatever was
+# latest when the snapshot was last built. The model catalog in
+# packages/common/src/agents.ts, by contrast, ships with every deploy. Without a
+# scheduled rebuild the two drift apart and users get errors like
+# "The 'gpt-5.6-sol' model requires a newer version of Codex" — a model the app
+# offers that the baked CLI is too old to run.
+#
+# The rebuild is zero-downtime (see rebuildSnapshot): it builds a temp snapshot,
+# swaps, rebuilds the canonical one, then drops the temp. Sandboxes already
+# running are unaffected; only newly created ones pick up the new snapshot.
+#
+# Requires a `DAYTONA_API_KEY` repository secret.
+
+on:
+  schedule:
+    # Sundays 09:00 UTC — quiet window, and a week's worth of upstream releases
+    # land together rather than one at a time.
+    - cron: "0 9 * * 0"
+  workflow_dispatch:
+
+# Never let two rebuilds overlap: they create and delete the same two snapshot
+# names, so a second run could delete a snapshot the first is mid-build on.
+# Queue instead of cancelling — cancelling could leave a half-built temp behind
+# (the next run cleans that up, but queueing avoids the state entirely).
+concurrency:
+  group: rebuild-sandbox-snapshot
+  cancel-in-progress: false
+
+jobs:
+  rebuild:
+    runs-on: ubuntu-latest
+    # Two serial image builds. Generous ceiling so a slow upstream pull fails
+    # loudly on its own terms rather than being killed mid-build.
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+
+      - name: Check for the Daytona API key
+        env:
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+        run: |
+          if [ -z "$DAYTONA_API_KEY" ]; then
+            echo "::error::DAYTONA_API_KEY repository secret is not set — nothing to rebuild against."
+            exit 1
+          fi
+
+      - name: Rebuild the snapshot
+        # Call the workspace script directly rather than the root one, which
+        # wraps it in `dotenv -e packages/web/.env -e .env` for local runs.
+        # Those files do not exist in CI; the key comes from the secret instead.
+        run: npm run build:snapshot -w @background-agents/sandbox-image
+        env:
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+
+      - name: Summarize
+        if: always()
+        run: |
+          if [ "${{ job.status }}" = "success" ]; then
+            echo "Sandbox snapshot rebuilt. Agent CLIs are now at their latest published versions." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Snapshot rebuild FAILED. New sandboxes keep launching from the previous snapshot, so nothing is broken right now — but the baked CLIs are getting older. Check the logs above." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/packages/sandbox-image/README.md
+++ b/packages/sandbox-image/README.md
@@ -23,6 +23,32 @@ The image also pre-installs [`tokscale`](https://www.npmjs.com/package/tokscale)
 
 The image is based on `node:22-bookworm` and runs as a non-root `daytona` user (Claude Code refuses to run as root).
 
+## How the agent CLIs stay current
+
+The agent CLIs are installed **unpinned**, so each one is frozen at whatever version was latest when the snapshot was last built. `tokscale` is the exception: it is pinned via `TOKSCALE_VERSION` because the app parses its output.
+
+That freeze matters because the model catalog (`packages/common/src/agents.ts`) ships with every deploy, while the CLI that has to run those models only moves when the snapshot is rebuilt. Let the two drift and users hit errors like:
+
+```
+The 'gpt-5.6-sol' model requires a newer version of Codex.
+Please upgrade to the latest app or CLI and try again.
+```
+
+The app offered a model the baked CLI was too old to run.
+
+So the snapshot is rebuilt **weekly** by `.github/workflows/rebuild-snapshot.yml` (Sundays 09:00 UTC, or on demand via "Run workflow"). It needs a `DAYTONA_API_KEY` repository secret. The rebuild is zero-downtime and safe to run against a live app — see `rebuildSnapshot`.
+
+Two consequences worth knowing:
+
+- **A new CLI release reaches production without anyone approving it.** That is the deliberate trade: upstream breakage is rarer and easier to spot than the silent version drift it replaces. If a release does break things, pin that one package in `AGENT_PACKAGES` the way `TOKSCALE_VERSION` is pinned, and unpin it once upstream is fixed.
+- **A failed run is not an outage.** New sandboxes keep launching from the previous snapshot. It only means the CLIs are ageing, so a red workflow is worth fixing but not paging anyone.
+
+To rebuild by hand:
+
+```bash
+npm run build:snapshot
+```
+
 ## Installation
 
 This is an internal workspace package. It's automatically available to other packages in the monorepo:


### PR DESCRIPTION
fixes the thing behind this error:

```
The 'gpt-5.6-sol' model requires a newer version of Codex.
```

## needs a repo secret before this does anything

**add `DAYTONA_API_KEY` to the repo secrets** (Settings → Secrets and variables → Actions → New repository secret). it isn't there right now, so the first scheduled run will fail without it.

the workflow checks for it up front and fails with a clear message rather than dying somewhere inside the build.

## what was actually wrong

the agent CLIs are installed unpinned in the sandbox image, so each one is frozen at whatever was latest the day the snapshot was last built. the model list in `packages/common/src/agents.ts` ships with every deploy. nothing rebuilt the snapshot on a schedule, so the app kept offering newer models while the baked codex CLI stayed wherever it was months ago.

so it's not really a bug, there just wasn't a policy. now there is one: rebuild weekly, sundays 09:00 UTC, plus a manual "run workflow" button.

## why github actions and not a vercel cron

`rebuildSnapshot` runs two serial image builds. its own docstring already says it isn't bounded by a serverless cron timeout. actions gives it 90 minutes.

runs are queued rather than cancelled if they overlap, since both runs create and delete the same two snapshot names and cancelling mid-build can leave a half-built temp behind.

## the tradeoff, stated out loud

a new CLI release now lands in production without anyone approving it. that's the deal with unpinned installs, and it's better than the silent drift it replaces. if some release breaks things, pin that one package in `AGENT_PACKAGES` like `TOKSCALE_VERSION` already is, and unpin when upstream is fixed. written down in the package README.

also: a failed run isn't an outage. new sandboxes keep using the previous snapshot, it just means the CLIs are getting stale.

## to unblock gpt-5.6-sol today

the weekly job won't help until sunday. run `npm run build:snapshot` now.
